### PR TITLE
Fix broken links by configuring AutoStructify

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -16,6 +16,14 @@ import sys
 import os
 import shlex
 from recommonmark.parser import CommonMarkParser
+from recommonmark.transform import AutoStructify
+
+def setup(app):
+    app.add_config_value('recommonmark_config', {
+        'enable_auto_doc_ref': True,
+        'enable_auto_toc_tree': False,
+    }, True)
+    app.add_transform(AutoStructify)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/source/developer/webhooks-incoming.md
+++ b/source/developer/webhooks-incoming.md
@@ -5,7 +5,7 @@ Incoming webhooks allow external applications, written in the programming langua
 A couple key points:
 
 - **Mattermost incoming webhooks are Slack-compatible.** If you've used Slack's incoming webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../../usage/Markdown.md) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
+- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../../usage/markdown.md) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
 
 _Example:_
 
@@ -74,7 +74,7 @@ Additional Notes:
 
 2. With **Enable Overriding of Icon from Webhooks** turned on, you can similarly change the icon the message posts with by providing a link to an image in the `icon_url` parameter of your payload. For example, ```payload={"icon_url": "http://somewebsite.com/somecoolimage.jpg", "text": "Hello, this is some text."}``` will post using whatever image is located at `http://somewebsite.com/somecoolimage.jpg` as the icon for the post
 
-3. Also, as mentioned previously, [markdown](../../usage/Markdown.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return and bold text for "the"
+3. Also, as mentioned previously, [markdown](../../usage/markdown.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return and bold text for "the"
 
 4. Just like regular posts, the text will be limited to 4000 characters at maximum
 

--- a/source/developer/webhooks-incoming.md
+++ b/source/developer/webhooks-incoming.md
@@ -5,7 +5,7 @@ Incoming webhooks allow external applications, written in the programming langua
 A couple key points:
 
 - **Mattermost incoming webhooks are Slack-compatible.** If you've used Slack's incoming webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../../usage/markdown.md) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
+- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../help/messaging/formatting-text.md) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
 
 _Example:_
 
@@ -74,7 +74,7 @@ Additional Notes:
 
 2. With **Enable Overriding of Icon from Webhooks** turned on, you can similarly change the icon the message posts with by providing a link to an image in the `icon_url` parameter of your payload. For example, ```payload={"icon_url": "http://somewebsite.com/somecoolimage.jpg", "text": "Hello, this is some text."}``` will post using whatever image is located at `http://somewebsite.com/somecoolimage.jpg` as the icon for the post
 
-3. Also, as mentioned previously, [markdown](../../usage/markdown.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return and bold text for "the"
+3. Also, as mentioned previously, [markdown](../help/messaging/formatting-text.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return and bold text for "the"
 
 4. Just like regular posts, the text will be limited to 4000 characters at maximum
 

--- a/source/developer/webhooks-outgoing.md
+++ b/source/developer/webhooks-outgoing.md
@@ -5,7 +5,7 @@ Outgoing webhooks allow external applications, written in the programming langua
 A couple key points:
 
 - **Mattermost outgoing webhooks are Slack-compatible.** If you've used Slack's outgoing webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost outgoing webhooks support full markdown.** When an integration responds with a message to post, it will have access to a rich range of formatting unavailable in Slack that is made possible through [markdown support](../../usage/Markdown.md) in Mattermost. This includes headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
+- **Mattermost outgoing webhooks support full markdown.** When an integration responds with a message to post, it will have access to a rich range of formatting unavailable in Slack that is made possible through [markdown support](../../usage/markdown.md) in Mattermost. This includes headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
 
 _Example:_
 
@@ -97,7 +97,7 @@ Additional Notes:
 
 2. With **Enable Overriding of Icon from Webhooks** turned on, you can similarly change the icon the message posts with by providing a link to an image in the `icon_url` parameter of your JSON response. For example, ```{"icon_url": "http://somewebsite.com/somecoolimage.jpg", "text": "Hello, this is some text."}``` will post using whatever image is located at `http://somewebsite.com/somecoolimage.jpg` as the icon for the post
 
-3. Also, as mentioned previously, [markdown](../../usage/Markdown.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return, italicized text for "text" and bold text for "the"
+3. Also, as mentioned previously, [markdown](../../usage/markdown.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return, italicized text for "text" and bold text for "the"
 
 4. Just like regular posts, the text will be limited to 4000 characters at maximum
 

--- a/source/developer/webhooks-outgoing.md
+++ b/source/developer/webhooks-outgoing.md
@@ -5,7 +5,7 @@ Outgoing webhooks allow external applications, written in the programming langua
 A couple key points:
 
 - **Mattermost outgoing webhooks are Slack-compatible.** If you've used Slack's outgoing webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost outgoing webhooks support full markdown.** When an integration responds with a message to post, it will have access to a rich range of formatting unavailable in Slack that is made possible through [markdown support](../../usage/markdown.md) in Mattermost. This includes headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
+- **Mattermost outgoing webhooks support full markdown.** When an integration responds with a message to post, it will have access to a rich range of formatting unavailable in Slack that is made possible through [markdown support](../help/messaging/formatting-text.md) in Mattermost. This includes headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
 
 _Example:_
 
@@ -97,7 +97,7 @@ Additional Notes:
 
 2. With **Enable Overriding of Icon from Webhooks** turned on, you can similarly change the icon the message posts with by providing a link to an image in the `icon_url` parameter of your JSON response. For example, ```{"icon_url": "http://somewebsite.com/somecoolimage.jpg", "text": "Hello, this is some text."}``` will post using whatever image is located at `http://somewebsite.com/somecoolimage.jpg` as the icon for the post
 
-3. Also, as mentioned previously, [markdown](../../usage/markdown.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return, italicized text for "text" and bold text for "the"
+3. Also, as mentioned previously, [markdown](../help/messaging/formatting-text.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return, italicized text for "text" and bold text for "the"
 
 4. Just like regular posts, the text will be limited to 4000 characters at maximum
 

--- a/source/help/settings/team-settings.md
+++ b/source/help/settings/team-settings.md
@@ -63,7 +63,7 @@ The Slack Import feature in Mattermost is in "Beta" and focus is on supporting m
 
 6. Once logged in, the Mattermost users will have access to previous Slack messages in the public channels imported from Slack.
 
-**It is highly recommended that you test Slack import before applying it to an instance intended for production.** If you use Docker, you can spin up a test instance in one line (`docker run --name mattermost-dev -d --publish 8065:80 mattermost/platform`). If you don't use Docker, there are [step-by-step instructions](../install/Docker-Single-Container.md) to install Mattermost in preview mode in less than 5 minutes.
+**It is highly recommended that you test Slack import before applying it to an instance intended for production.** If you use Docker, you can spin up a test instance in one line (`docker run --name mattermost-dev -d --publish 8065:80 mattermost/platform`). If you don't use Docker, there are [step-by-step instructions](../install/docker-single-container.md) to install Mattermost in preview mode in less than 5 minutes.
 
 #### Limitations 
 

--- a/source/help/settings/team-settings.md
+++ b/source/help/settings/team-settings.md
@@ -63,7 +63,7 @@ The Slack Import feature in Mattermost is in "Beta" and focus is on supporting m
 
 6. Once logged in, the Mattermost users will have access to previous Slack messages in the public channels imported from Slack.
 
-**It is highly recommended that you test Slack import before applying it to an instance intended for production.** If you use Docker, you can spin up a test instance in one line (`docker run --name mattermost-dev -d --publish 8065:80 mattermost/platform`). If you don't use Docker, there are [step-by-step instructions](../install/docker-single-container.md) to install Mattermost in preview mode in less than 5 minutes.
+**It is highly recommended that you test Slack import before applying it to an instance intended for production.** If you use Docker, you can spin up a test instance in one line (`docker run --name mattermost-dev -d --publish 8065:80 mattermost/platform`). If you don't use Docker, there are [step-by-step instructions](../../install/docker-ebs.md) to install Mattermost in preview mode in less than 5 minutes.
 
 #### Limitations 
 

--- a/source/install/docker-ebs.md
+++ b/source/install/docker-ebs.md
@@ -27,4 +27,4 @@ The following instructions use Docker to install Mattermost in _Preview Mode_ fo
 See [Configuration Settings](../administration/config-settings.md) documentation to customize your deployment. 
 
 #### (Recommended) Enable Email 
-The default single-container Docker instance for Mattermost is designed for product evaluation, and sets `SendEmailNotifications=false` so the product can function without enabling email. To see the product's full functionality, [enabling SMTP email is recommended](SMTP-Email-Setup.md).
+The default single-container Docker instance for Mattermost is designed for product evaluation, and sets `SendEmailNotifications=false` so the product can function without enabling email. To see the product's full functionality, [enabling SMTP email is recommended](smtp-email-setup.md).

--- a/source/install/docker-local-machine.md
+++ b/source/install/docker-local-machine.md
@@ -88,7 +88,7 @@ See [Configuration Settings](../administration/config-settings.md) documentation
 
 The default single-container Docker instance for Mattermost is designed for product evaluation, and sets `ByPassEmail=true` so the product can run without enabling email, when doing so maybe difficult. 
 	
-To see the product's full functionality, [enabling SMTP email is recommended](SMTP-Email-Setup.md).
+To see the product's full functionality, [enabling SMTP email is recommended](smtp-email-setup.md).
 
 ## Upgrading Mattermost 
 


### PR DESCRIPTION
Fix the problem that some markdown links are not translated to correct html links.
There are 2 problems.

First `[foo](foo.md)` is translated to wrong link `<a href="foo.md">foo</a>` (see [docs.mattermost.com/README.html](http://docs.mattermost.com/README.html)). 
To solve the problem, configure [AutoStructify](http://recommonmark.readthedocs.org/en/latest/auto_structify.html) in conf.py. Note that disable [Auto Toc Tree](http://recommonmark.readthedocs.org/en/latest/auto_structify.html#auto-toc-tree) because it changes html files significantly.

Second, some links are incorrect capitalized. `[foo](Foo.md)` is wrong, because all markdown files except `README.md` and `CONTRIBUTION.md` in this repository have lowercase letters only filenames. [Aut Doc Ref in AutoStructify](http://recommonmark.readthedocs.org/en/latest/auto_structify.html#auto-doc-ref) is case-sensitive. Therefore, convert `[foo](Foo.md)` to `[foo](foo.md)`, by running the following command:

```
find . -name '*.md' | \
  xargs -n1 \
    ruby -i -p -e \
      '$_.gsub!(/](?!.*(README|CONTRIBUTING)\.md)\(([^:]*\.md)\)/) { "](#{$2.downcase})" }'
```