### PR TITLE
Updated systemd init daemon to wait for postgresql

### DIFF
--- a/source/install/prod-rhel-7.md
+++ b/source/install/prod-rhel-7.md
@@ -83,7 +83,7 @@
     ```
     [Unit]
     Description=Mattermost
-    After=syslog.target network.target
+    After=syslog.target network.target postgresql-9.4.service
 
     [Service]
     Type=simple


### PR DESCRIPTION
If postgresql is not up and ready, mattermost fails to start during boot with :  Failed to ping db err:pq: the database system is starting up.