### PR TITLE
Fix broken formatting in upgrade.md

### DIFF
--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -7,10 +7,10 @@ This guide explains how to upgrade your Mattermost deployment across versions an
 1. Download the **appropriate next upgrade** of your server and note any compatibility procedures 
       1. Run `platform -version` to check the current version of your Mattermost server
       2. Determine the appropriate next upgrade for your server: 
-        - Mattermost `v1.3.x`, `v1.4.x` and `v2.0.x` can upgrade directly to Mattermost `v2.1.x`.
-        - Mattermost `v1.2.x` must upgrade to Mattermost `v1.3.x` before further upgrades.
-        - Mattermost `v1.1.x` must upgrade to Mattermost `v1.2.x` before further upgrades.
-        - Mattermost `v1.0.x` must upgrade to Mattermost `v1.1.x` before further upgrades.
+          - Mattermost `v1.3.x`, `v1.4.x` and `v2.0.x` can upgrade directly to Mattermost `v2.1.x`.
+          - Mattermost `v1.2.x` must upgrade to Mattermost `v1.3.x` before further upgrades.
+          - Mattermost `v1.1.x` must upgrade to Mattermost `v1.2.x` before further upgrades.
+          - Mattermost `v1.0.x` must upgrade to Mattermost `v1.1.x` before further upgrades.
       3. Use the [Version Archive table](http://docs.mattermost.com/administration/upgrade.html#version-archive) to find the `[RELEASE URL]` for your desired version and enter `wget [RELEASE URL]` to download. For example, to download `vX.X.X`, use `wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz`
       4. Review **Compatibility** section in [CHANGELOG](http://docs.mattermost.com/administration/changelog.html) for the version downloaded and make sure to follow any instructions
 2. Stop the Mattermost Server


### PR DESCRIPTION
@it33, just FYI docs.mattermost.com needs minimum 4 spaces to nest a bulleted or numbered list or else it doesn't format properly on the site. It's fixed in this PR.