### PR TITLE
Corrected minor requirements, reformatted

### DIFF
--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -97,12 +97,12 @@ For enterprise deployments of 10,000-20,000 registered users with moderate usage
 **Proxy Server** 
 
 - One server with 4-8 vCPUs/cores, 16-32 GB RAM, minimum 4 GB SSD storage
-- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality). Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline.
+- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality. Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline.
 
 **Mattermost Server** (1 to 2 depending on level of redundancy and high availability required) 
 
 - One server with 4-8 vCPUs/cores, 16-32 GB RAM, minimum 4 GB SSD storage
-- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality). Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline. Note: The high availability option is available only by `contacting the Enterprise Edition team <https://about.mattermost.com/contact/>`_.
+- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality. Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline. Note: The high availability option is available only by `contacting the Enterprise Edition team <https://about.mattermost.com/contact/>`_.
 
 **Network Attached Storage** 
 

--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -86,7 +86,6 @@ Notes:
 2. Storage recommendation is based on storing 3 years of archives with moderate file sharing.
 3. Solid state drives (SSD) can be used in place of disk storage for higher concurrency.
 4. Team deployments assume registered users are divided into teams of 10-100.
->>>>>>> Corrected minor requirements, reformatted
 
 Hardware Sizing for Enterprise Deployments (Multi-Server)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -8,9 +8,7 @@ Software & Hardware Requirements
 Deployment Overview
 -------------------
 
-Please see `Mattermost Deployment
-Overview <http://docs.mattermost.com/deployment/deployment.html>`__ for
-a summary of components listed here.
+Please see `Mattermost Deployment Overview <http://docs.mattermost.com/deployment/deployment.html>`__ for a summary of components listed here.
 
 .. figure:: ../images/network.PNG
    :alt: image
@@ -46,11 +44,9 @@ Mobile Web Experience
 Email Client
 ^^^^^^^^^^^^
 
--  *Desktop clients:* Outlook 2010+, Apple Mail version 7+, Thunderbird
-   38.2+
+-  *Desktop clients:* Outlook 2010+, Apple Mail version 7+, Thunderbird 38.2+
 -  *Web based clients:* Office 365, Outlook, Gmail, Yahoo, AOL
--  *Mobile clients:* iOS Mail App (iOS 7+), Gmail Mobile App (Android,
-   iOS)
+-  *Mobile clients:* iOS Mail App (iOS 7+), Gmail Mobile App (Android, iOS)
 
 Server Software
 ~~~~~~~~~~~~~~~
@@ -58,12 +54,9 @@ Server Software
 Mattermost Server Operating System
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  Ubuntu 14.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat
-   Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux
-   6.6+, Oracle Linux 7.1+
+-  Ubuntu 14.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux 6.6+, Oracle Linux 7.1+
 
-The Mattermost roadmap does not currently include production support for
-Fedora, FreeBSD or Arch Linux.
+The Mattermost roadmap does not currently include production support for Fedora, FreeBSD or Arch Linux.
 
 Database Software
 ^^^^^^^^^^^^^^^^^
@@ -71,75 +64,54 @@ Database Software
 -  MySQL 5.6+
 -  PostgreSQL 9.4+
 
-Deployments requiring searching in Chinese, Japanese and Korean
-languages require MySQL 5.7.6+ and the configuration of `ngram Full-Text
-parser <https://dev.mysql.com/doc/refman/5.7/en/fulltext-search-ngram.html>`__.
-See `CJK
-discussion <https://github.com/mattermost/platform/issues/2033#issuecomment-183872616>`__
-for details.
+Deployments requiring searching in Chinese, Japanese and Korean languages require MySQL 5.7.6+ and the configuration of `ngram Full-Text parser <https://dev.mysql.com/doc/refman/5.7/en/fulltext-search-ngram.html>`__. See `CJK discussion <https://github.com/mattermost/platform/issues/2033#issuecomment-183872616>`__ for details.
 
 Hardware Requirements
 ---------------------
 
-Usage of CPU, RAM and storage space can vary significantly based on user
-behavior. For deployments larger than 500 users, it's highly recommended
-usage patterns in a small pilot deployment representative of your large
-organization is observed before rolling out the full scale service.
+Usage of CPU, RAM and storage space can vary significantly based on user behavior. For deployments larger than 500 users, it's highly recommended usage patterns in a small pilot deployment representative of your large organization is observed before rolling out the full scale service.
 
 Hardware Sizing for Team Deployments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Most small to medium Mattermost team deployments can be supported on a
-single server with the following specifications based on registered
-users:
+Most small to medium Mattermost team deployments can be supported on a single server with the following specifications based on registered users:
 
--  250-500 users - 2 CPUs (2GHz or higher), 4GB
-   RAM, and 45-90GB HDD storage
--  500-1,000 users - 4 CPUs (2.8GHz or higher), 8GB
-   RAM, and 90-180GB HDD storage
--  1,000-2,000 users - 4-8 CPUs (2.8GHz or higher),
-   16-32GB RAM, and 180-360GB HDD storage
+-  250-500 users - 2 vCPUs/cores, 4 GB RAM, and 45-90 GB storage
+-  500-1,000 users - 4 vCPUs/cores, 8 GB RAM, and 90-180 GB storage
+-  1,000-2,000 users - 4-8 vCPUs/cores, 16-32 GB RAM, and 180-360 GB storage
 
 Notes:
 
-1. Larger deployments should estimate utilization based on pilots
-   representative of full scale usage.
-2. Storage recommendation is based on storing 3 years of archives with
-   moderate file sharing.
-3. Solid-state storage drives (SSD) can be used in place of disk storage
-   for higher concurrency.
-4. Team deployments assume registered users are divided into teams of
-   10-100.
+1. Larger deployments should estimate utilization based on pilots representative of full scale usage.
+2. Storage recommendation is based on storing 3 years of archives with moderate file sharing.
+3. Solid state drives (SSD) can be used in place of disk storage for higher concurrency.
+4. Team deployments assume registered users are divided into teams of 10-100.
+>>>>>>> Corrected minor requirements, reformatted
 
 Hardware Sizing for Enterprise Deployments (Multi-Server)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost can also be configured with a redundant, highly available,
-highly scalable mode to support large organizations. The following is an
-example that can be scaled up or down in size:
+Mattermost can also be configured with a redundant, highly available, highly scalable mode to support large organizations. The following is an example that can be scaled up or down in size:
 
-For enterprise deployments of 10,000-20,000 registered users with
-moderate usage and a peak of 2,000-4,000 concurrent users, the following
-hardware deployment configurations are recommended:
+For enterprise deployments of 10,000-20,000 registered users with moderate usage and a peak of 2,000-4,000 concurrent users, the following hardware deployment configurations are recommended:
 
 **Proxy Server** 
 
-- One server with 4-8 CPU cores supporting Hyper-Threading, 16-32 GB, SSD drive with at least 4GB of storage 
-- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality. Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline. Note: The high availability option is available only by `contacting the Enterprise Edition team <https://about.mattermost.com/contact/>`_.
+- One server with 4-8 vCPUs/cores, 16-32 GB RAM, minimum 4 GB SSD storage
+- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality). Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline.
 
-**Mattermost Server** (1 to 2 depending on the level of redundancy and high
-availability required) 
+**Mattermost Server** (1 to 2 depending on level of redundancy and high availability required) 
 
-- One server with 4-8 CPU cores supporting Hyper-Threading, 16-32GB memory, SSD drive with at least 4GB storage. 
-- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality. Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline. Note: The high availability option is available only by `contacting the Enterprise Edition team <https://about.mattermost.com/contact/>`_.
+- One server with 4-8 vCPUs/cores, 16-32 GB RAM, minimum 4 GB SSD storage
+- (Optional) Add one additional identical server for high availability mode, where one Mattermost server can be disabled or upgraded without interrupting service quality). Second server should be sized to carry the full load of the first server so performance does not degrade when the first server is taken offline. Note: The high availability option is available only by `contacting the Enterprise Edition team <https://about.mattermost.com/contact/>`_.
 
 **Network Attached Storage** 
 
-- One NAS server with 3.6-7.2TB of storage (based on moderate storage of 10MB per user per month times 20,000 users times 3 years of history, times 2x safety factor) or sized appropriately for your desired usage requirements. For high availability it is recommended you select a NAS server offering redundancy.
+- One NAS server with 4-8 TB of storage (based on moderate storage of 10 MB per user per month times 20,000 users times 3 years of history, times 2x safety factor) or sized appropriately for your desired usage requirements. For high availability it is recommended you select a NAS server offering redundancy.
 
 **Database Server** (2 recommended for redundancy) 
 
-- One database server with 8-16 CPU cores supporting Hyper-Threading, 16-32GB memory, SSD drive with at least 100GB of storage.
+- One database server with 8-16 vCPUs/cores, 16-32 GB memory, minimum 100 GB SSD storage
 - (Recommended) Add one identical database server to setup a Master-Slave configuration where the master can failover to slave with minimal disruption to service.
 
 **Notes:**
@@ -149,20 +121,15 @@ availability required)
 Alternate Storage Calculations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As an alternative to recommended storage sizing above, you can forecast
-your own storage usuage. Begin with a Mattermost server approximately
-600 MB to 800 MB in size including operating system and database, then
-add the multiplied product of:
+As an alternative to recommended storage sizing above, you can forecast your own storage usuage. Begin with a Mattermost server approximately 600 MB to 800 MB in size including operating system and database, then add the multiplied product of:
 
--  Estimated storage per user per month (see below), multipled by 12
-   months in a year
+-  Estimated storage per user per month (see below), multipled by 12 months in a year
 -  Estimated mean average number of users in a year
 -  A 1-2x safety factor
 
 **Estimated storage per user per month**
 
-File usage per user varies significantly across industries. The below
-benchmarks are recommended:
+File usage per user varies significantly across industries. The below benchmarks are recommended:
 
 -  **Low usage teams** (1-5 MB/user/month) 
 	- Primarily use text-messages and links to communicate. Examples would include software development teams that heavily use web-based document creation and management tools, and therefore rarely upload files to the server.
@@ -173,10 +140,6 @@ benchmarks are recommended:
 -  **High usage teams** - (25-100 MB/user/month) 
 	- Heaviest utlization comes from teams uploading a high number of large files into Mattermost on a regular basis. Examples include creative teams who share and store artwork and media with tags and commentary in a pipeline production process.
 
-*Example:* A 30-person team with medium usage (5-25 MB/user/month) with
-a safety factor of 2x would require between 300 MB (30 users \* 5 MB \*
-2x safety factor) and 1500 MB (30 users \* 25 MB \* 2x safety factor) of
-free space in the next year.
+*Example:* A 30-person team with medium usage (5-25 MB/user/month) with a safety factor of 2x would require between 300 MB (30 users \* 5 MB \* 2x safety factor) and 1500 MB (30 users \* 25 MB \* 2x safety factor) of free space in the next year.
 
-It's recommended to review storage utilization at least quarterly to
-ensure adequate free space is available.
+It's recommended to review storage utilization at least quarterly to ensure adequate free space is available.


### PR DESCRIPTION
Server side CPU speed is mostly meaningless, number of CPUs should be the deciding factors (I might be wrong, I do not have much experience with server-side computing) 1/5

Removed HT support, HT gives up to 30% on a single CPU server, and 15% on a dual CPU server. In most cases, HT does not give enough of a performance increase to justify requiring it. 2/5

Changed "CPUs" to "vCPUs/cores" to reflect typical deployment on a cloud instance or a dedicated server. 0/5

Reformatted multi-line paragraphs, spacing (300GB => 300 GB), spelling, etc. 0/5
@coreyhulen give it a quick review?