### PR TITLE
Update Web API login documentation

### DIFF
--- a/source/developer/web-service.md
+++ b/source/developer/web-service.md
@@ -20,7 +20,7 @@ The majority of the Mattermost API involves interacting with teams. Therefore, m
 Make an HTTP POST to `yourdomain.com/api/v3/users/login` with a JSON body indicating the `name` of the team, the user's `email` and `password`.
 
 ```
-curl -i -d '{"name":"exampleteam","email":"someone@nowhere.com","password":"thisisabadpassword"}' http://localhost:8065/api/v3/users/login
+curl -i -d '{"name":"exampleteam","user_id":"someone@nowhere.com","password":"thisisabadpassword"}' http://localhost:8065/api/v3/users/login
 ```
 
 If successful, the response will contain a `Token` header and a User object in the body.

--- a/source/developer/web-service.md
+++ b/source/developer/web-service.md
@@ -20,7 +20,7 @@ The majority of the Mattermost API involves interacting with teams. Therefore, m
 Make an HTTP POST to `yourdomain.com/api/v3/users/login` with a JSON body indicating the `name` of the team, the user's `email` and `password`.
 
 ```
-curl -i -d '{"name":"exampleteam","user_id":"someone@nowhere.com","password":"thisisabadpassword"}' http://localhost:8065/api/v3/users/login
+curl -i -d '{"name":"exampleteam","login_id":"someone@nowhere.com","password":"thisisabadpassword"}' http://localhost:8065/api/v3/users/login
 ```
 
 If successful, the response will contain a `Token` header and a User object in the body.


### PR DESCRIPTION
While running a test of the new 3.0.2 release (RHEL), I was unable to programmatically login with the documented api call. 
```
curl -i -d '{"name":"exampleteam","email":"someone@nowhere.com","password":"thisisabadpassword"}' http://localhost:8065/api/v3/users/login
```
After looking through the source code, I found that "login_id" was used in place of "email". The call works with "login_id". Proposing that docs update to reflect this, or add some clarification on how we can use "email" as a key in the POST.

Commands I ran:
```
curl -i -d '{"name":"myteam","login_id":"michael@analyticsmd.com","password":"foo"}' http://localhost:8065/api/v3/users/login
HTTP/1.1 200 OK
Content-Type: application/json
Set-Cookie: MMAUTHTOKEN=g3wmyjaqgpya8msgpy137q3eue; Path=/; Expires=Fri, 24 Jun 2016 23:46:26 GMT; Max-Age=2592000; HttpOnly
Token: g3wmyjaqgpya8msgpy137q3eue
X-Ratelimit-Limit: 10
X-Ratelimit-Remaining: 9
X-Ratelimit-Reset: 1
X-Request-Id: pp3dtc9wcf8d8jxmmwt61zmx9c
X-Version-Id: 3.0.0.1464218248
Date: Wed, 25 May 2016 23:46:26 GMT
Content-Length: 549

{"id":"hq9yu7z8ztdrbboa5f34qwpnrw","create_at":1463381700127,"update_at":1463381700127,"delete_at":0,"username":"michael","auth_data":"","auth_service":"","email":"michael@analyticsmd.com","nickname":"","first_name":"","last_name":"","roles":"system_admin","last_activity_at":1464219476736,"last_ping_at":1464219954023,"allow_marketing":true,"notify_props":{"all":"true","channel":"true","desktop":"all","desktop_sound":"true","email":"true","first_name":"false","mention_keys":"michael,@michael"},"last_password_update":1463381700127,"locale":"en"}

curl -i -d '{"name":"myteam","email":"michael@analyticsmd.com","password":"foo"}' http://localhost:8065/api/v3/users/login
HTTP/1.1 400 Bad Request
Content-Type: application/json
X-Ratelimit-Limit: 10
X-Ratelimit-Remaining: 9
X-Ratelimit-Reset: 1
X-Request-Id: ob55y57bspy8dcx8woab71pyny
X-Version-Id: 3.0.0.1464218248
Date: Wed, 25 May 2016 23:46:43 GMT
Content-Length: 281

{"id":"store.sql_user.get_for_login.app_error","message":"We couldn't find an existing account matching your credentials. This team may require an invite from the team owner to join.","detailed_error":"","request_id":"ob55y57bspy8dcx8woab71pyny","status_code":400,"is_oauth":false}
```