### PR TITLE
Minor Changes to Attaching Files Documentation

### DIFF
--- a/source/help/messaging/attaching-files.md
+++ b/source/help/messaging/attaching-files.md
@@ -15,7 +15,7 @@ Mattermost has a built in file previewer that is used to view media, download fi
 
 
 #### Sharing Public Links
-Public links allow you to share file attachments with people outside your Mattermost team. Open the file previewer by clicking on the thumbnail of an attachment, then click **Get Public Link**. This opens a dialog box with a link to copy. When the link is shared and opened by another user, the file will be automatically downloaded. 
+Public links allow you to share file attachments with people outside your Mattermost team. Open the file previewer by clicking on the thumbnail of an attachment, then click **Get Public Link**. This opens a dialog box with a link to copy. When the link is shared and opened by another user, the file will automatically download.
 
 If **Get Public Link** is not visible in the file previewer, then it has been disabled through the System Console. Please contact your system administrator to have it enabled if necessary.
 

--- a/source/help/messaging/attaching-files.md
+++ b/source/help/messaging/attaching-files.md
@@ -15,9 +15,9 @@ Mattermost has a built in file previewer that is used to view media, download fi
 
 
 #### Sharing Public Links
-Public links allow you to share file attachments with people outside your Mattermost team. Open the file previewer by clicking on the thumbnail of an attachment, then click **Get Public Link**. This opens a dialog box with a link to copy. When the link is shared and opened by another user, the file will automatically download. 
+Public links allow you to share file attachments with people outside your Mattermost team. Open the file previewer by clicking on the thumbnail of an attachment, then click **Get Public Link**. This opens a dialog box with a link to copy. When the link is shared and opened by another user, the file will be automatically downloaded. 
 
-If **Get Public Link** is not visible in the file previewer then contact your system administrator to enable public file links in the System Console file settings.
+If **Get Public Link** is not visible in the file previewer, then it has been disabled through the System Console. Please contact your system administrator to have it enabled.
 
 
 #### Downloading Files

--- a/source/help/messaging/attaching-files.md
+++ b/source/help/messaging/attaching-files.md
@@ -17,7 +17,7 @@ Mattermost has a built in file previewer that is used to view media, download fi
 #### Sharing Public Links
 Public links allow you to share file attachments with people outside your Mattermost team. Open the file previewer by clicking on the thumbnail of an attachment, then click **Get Public Link**. This opens a dialog box with a link to copy. When the link is shared and opened by another user, the file will be automatically downloaded. 
 
-If **Get Public Link** is not visible in the file previewer, then it has been disabled through the System Console. Please contact your system administrator to have it enabled.
+If **Get Public Link** is not visible in the file previewer, then it has been disabled through the System Console. Please contact your system administrator to have it enabled if necessary.
 
 
 #### Downloading Files


### PR DESCRIPTION
Changed wording to sound more natural.
Changed the description of "Get Public Link not visible" to not contact the system administrator, as it is usually disabled for a reason.