### PR TITLE
godep is not required for the latest master

### DIFF
--- a/source/developer/developer-setup.md
+++ b/source/developer/developer-setup.md
@@ -33,20 +33,17 @@ Developer Machine Setup
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
 
-5. If you are running Mattermost version 3.0 or older, install godep with `go get github.com/tools/godep`
-6. Run unit tests on Mattermost using `make test` to make sure the installation was successful
-7. If the tests passed, you can run Mattermost using `make run`
-8. You need to create a team and admin account. You can choose a team name, email and password:
+5. Run unit tests on Mattermost using `make test` to make sure the installation was successful
+6. If the tests passed, you can run Mattermost using `make run`
+7. You need to create a team and admin account. You can choose a team name, email and password:
 	- Note: Make sure your team name does not contain any spaces
-    - Note: If you are running Mattermost version 3.0 or older, prepend all commands with `godep `.
-	  E.g. `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
 	- `go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-9. Now you can log into Mattermost as the user you created in step 8
-10. You can stop Mattermost using `make stop`
-11. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
+8. Now you can log into Mattermost as the user you created in step 7
+9. You can stop Mattermost using `make stop`
+10. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
     - `env GOOS=windows GOARCH=amd64 go install std`
     - `env GOOS=darwin GOARCH=amd64 go install std`
@@ -83,20 +80,17 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 	3. `cd src/github.com/mattermost`  
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
-8. If you are running Mattermost version 3.0 or older, install godep with `go get github.com/tools/godep`
-9. Run unit tests on Mattermost using `make test` to make sure the installation was successful
-10. If the tests passed, you can run Mattermost using `make run`
-11. You need to create a team and admin account. You can choose a team name, email and password:
+8. Run unit tests on Mattermost using `make test` to make sure the installation was successful
+9. If the tests passed, you can run Mattermost using `make run`
+10. You need to create a team and admin account. You can choose a team name, email and password:
 	- Note: Make sure your team name does not contain any spaces
-    - Note: If you are running Mattermost version 3.0 or older, prepend all commands with `godep `.
-	  E.g. `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
 	- `go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-12. Now you can log into Mattermost as the user you created in step 11
-13. You can stop Mattermost using `make stop`
-14. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
+11. Now you can log into Mattermost as the user you created in step 10
+12. You can stop Mattermost using `make stop`
+13. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
     - `env GOOS=windows GOARCH=amd64 go install std`
     - `env GOOS=darwin GOARCH=amd64 go install std`
@@ -143,20 +137,17 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 	3. `cd src/github.com/mattermost`  
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
-7. If you are running Mattermost version 3.0 or older, install godep with `go get github.com/tools/godep`
-8. Run unit tests on Mattermost using `make test` to make sure the installation was successful
-9. If the tests passed, you can run Mattermost using `make run`
-10. You need to create a team and admin account. You can choose a team name, email and password:
+7. Run unit tests on Mattermost using `make test` to make sure the installation was successful
+8. If the tests passed, you can run Mattermost using `make run`
+9. You need to create a team and admin account. You can choose a team name, email and password:
 	- Note: Make sure your team name does not contain any spaces
-    - Note: If you are running Mattermost version 3.0 or older, prepend all commands with `godep `.
-	  E.g. `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
 	- `go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-11. Now you can log into Mattermost as the user you created in step 10
-12. You can stop Mattermost using `make stop`
-13. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
+10. Now you can log into Mattermost as the user you created in step 9
+11. You can stop Mattermost using `make stop`
+12. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
     - `env GOOS=windows GOARCH=amd64 go install std`
     - `env GOOS=darwin GOARCH=amd64 go install std`

--- a/source/developer/developer-setup.md
+++ b/source/developer/developer-setup.md
@@ -37,11 +37,12 @@ Developer Machine Setup
 6. Run unit tests on Mattermost using `make test` to make sure the installation was successful
 7. If the tests passed, you need to create a team and an admin account. You can choose a team name, email and password:
 	- Note: Make sure your team name does not contain any spaces.
+    - Note: The latest version of mattermast does not rely on `godep` anymore. If you have the latest version, run the commands by omitting the `godep` at the beginning (e.g. `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`)
 	- `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `godep go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
 	- `godep go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-8. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 6
+8. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 7.
 9. You can stop Mattermost using `make stop`
 10. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
@@ -84,11 +85,12 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 9. Run unit tests on Mattermost using `make test` to make sure the installation was successful
 10. If the tests passed, you need to create a team and an admin account. You can choose a team name, email and password:
 	- Note: Make sure your team name does not contain any spaces.
+    - Note: The latest version of mattermast does not rely on `godep` anymore. If you have the latest version, run the commands by omitting the `godep` at the beginning (e.g. `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`)
 	- `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `godep go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
 	- `godep go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-11. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 10
+11. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 10.
 12. You can stop Mattermost using `make stop`
 13. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
@@ -141,11 +143,12 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 8. Run unit tests on Mattermost using `make test` to make sure the installation was successful
 9. If the tests passed, you need to create a team an admin account. You can choose a team name, email and password:
 	- Note: Make sure your team name does not contain any spaces.
+    - Note: The latest version of mattermast does not rely on `godep` anymore. If you have the latest version, run the commands by omitting the `godep` at the beginning (e.g. `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`)
 	- `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
 	- `godep go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
 	- `godep go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-10. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 8
+10. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 9.
 11. You can stop Mattermost using `make stop`
 12. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.

--- a/source/developer/developer-setup.md
+++ b/source/developer/developer-setup.md
@@ -33,18 +33,20 @@ Developer Machine Setup
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
 
-5. Install godep with `go get github.com/tools/godep`
+5. If you are using version 3.0 or older, install godep with `go get github.com/tools/godep`
 6. Run unit tests on Mattermost using `make test` to make sure the installation was successful
-7. If the tests passed, you need to create a team and an admin account. You can choose a team name, email and password:
-	- Note: Make sure your team name does not contain any spaces.
-    - Note: The latest version of mattermast does not rely on `godep` anymore. If you have the latest version, run the commands by omitting the `godep` at the beginning (e.g. `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`)
-	- `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
-	- `godep go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
-	- `godep go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
+7. If the tests passed, you can run Mattermost using `make run`
+8. You need to create a team and admin account. You can choose a team name, email and password:
+	- Note: Make sure your team name does not contain any spaces
+    - Note: If you are running Mattermost version 3.0 or older, prepend all commands with `godep `.
+	  E.g. `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
+	- `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
+	- `go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
+	- `go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-8. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 7.
-9. You can stop Mattermost using `make stop`
-10. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
+9. Now you can log into Mattermost as the user you created in step 8
+10. You can stop Mattermost using `make stop`
+11. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
     - `env GOOS=windows GOARCH=amd64 go install std`
     - `env GOOS=darwin GOARCH=amd64 go install std`
@@ -63,7 +65,7 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 4. Download Go 1.5.1 from [http://golang.org/dl/](http://golang.org/dl/)
 5. Set up your Go workspace and add Go to the PATH
 	1. `mkdir ~/go`
-	2. Add the following to your `~/.bashrc`	
+	2. Add the following to your `~/.bashrc`
 		- `export GOPATH=$HOME/go`  
 		- `export PATH=$PATH:$GOPATH/bin`  
 		- `ulimit -n 8096`  
@@ -81,18 +83,20 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 	3. `cd src/github.com/mattermost`  
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
-8. Install godep with `go get github.com/tools/godep`
+8. If you are using version 3.0 or older, install godep with `go get github.com/tools/godep`
 9. Run unit tests on Mattermost using `make test` to make sure the installation was successful
-10. If the tests passed, you need to create a team and an admin account. You can choose a team name, email and password:
-	- Note: Make sure your team name does not contain any spaces.
-    - Note: The latest version of mattermast does not rely on `godep` anymore. If you have the latest version, run the commands by omitting the `godep` at the beginning (e.g. `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`)
-	- `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
-	- `godep go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
-	- `godep go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
+10. If the tests passed, you can run Mattermost using `make run`
+11. You need to create a team and admin account. You can choose a team name, email and password:
+	- Note: Make sure your team name does not contain any spaces
+    - Note: If you are running Mattermost version 3.0 or older, prepend all commands with `godep `.
+	  E.g. `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
+	- `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
+	- `go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
+	- `go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-11. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 10.
-12. You can stop Mattermost using `make stop`
-13. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
+12. Now you can log into Mattermost as the user you created in step 11
+13. You can stop Mattermost using `make stop`
+14. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
     - `env GOOS=windows GOARCH=amd64 go install std`
     - `env GOOS=darwin GOARCH=amd64 go install std`
@@ -139,18 +143,20 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 	3. `cd src/github.com/mattermost`  
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
-7. Install godep with `go get github.com/tools/godep`
+7. If you are using version 3.0 or older, install godep with `go get github.com/tools/godep`
 8. Run unit tests on Mattermost using `make test` to make sure the installation was successful
-9. If the tests passed, you need to create a team an admin account. You can choose a team name, email and password:
-	- Note: Make sure your team name does not contain any spaces.
-    - Note: The latest version of mattermast does not rely on `godep` anymore. If you have the latest version, run the commands by omitting the `godep` at the beginning (e.g. `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`)
-	- `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
-	- `godep go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
-	- `godep go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
+9. If the tests passed, you can run Mattermost using `make run`
+10. You need to create a team and admin account. You can choose a team name, email and password:
+	- Note: Make sure your team name does not contain any spaces
+    - Note: If you are running Mattermost version 3.0 or older, prepend all commands with `godep `.
+	  E.g. `godep go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
+	- `go run mattermost.go  -create_team -team_name="name" -email="user@example.com"`
+	- `go run mattermost.go  -create_user -team_name="name" -email="user@example.com" -password="mypassword"`
+	- `go run mattermost.go  -assign_role -team_name="name" -email="user@example.com" -role="system_admin"`
 
-10. Now you can run Mattermost using `make run`. Log-in as the admin account you created in step 9.
-11. You can stop Mattermost using `make stop`
-12. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
+11. Now you can log into Mattermost as the user you created in step 10
+12. You can stop Mattermost using `make stop`
+13. If you want to setup for cross compilation (required for the `make package` and dependant targets) run:
     - Note: You can skip the platform you are on because you have that target installed by default.
     - `env GOOS=windows GOARCH=amd64 go install std`
     - `env GOOS=darwin GOARCH=amd64 go install std`

--- a/source/developer/developer-setup.md
+++ b/source/developer/developer-setup.md
@@ -33,7 +33,7 @@ Developer Machine Setup
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
 
-5. If you are using version 3.0 or older, install godep with `go get github.com/tools/godep`
+5. If you are running Mattermost version 3.0 or older, install godep with `go get github.com/tools/godep`
 6. Run unit tests on Mattermost using `make test` to make sure the installation was successful
 7. If the tests passed, you can run Mattermost using `make run`
 8. You need to create a team and admin account. You can choose a team name, email and password:
@@ -83,7 +83,7 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 	3. `cd src/github.com/mattermost`  
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
-8. If you are using version 3.0 or older, install godep with `go get github.com/tools/godep`
+8. If you are running Mattermost version 3.0 or older, install godep with `go get github.com/tools/godep`
 9. Run unit tests on Mattermost using `make test` to make sure the installation was successful
 10. If the tests passed, you can run Mattermost using `make run`
 11. You need to create a team and admin account. You can choose a team name, email and password:
@@ -143,7 +143,7 @@ Any issues? Please let us know on our forums at: http://forum.mattermost.org
 	3. `cd src/github.com/mattermost`  
 	4. `git clone https://github.com/<username>/platform.git`  
 	5. `cd platform`
-7. If you are using version 3.0 or older, install godep with `go get github.com/tools/godep`
+7. If you are running Mattermost version 3.0 or older, install godep with `go get github.com/tools/godep`
 8. Run unit tests on Mattermost using `make test` to make sure the installation was successful
 9. If the tests passed, you can run Mattermost using `make run`
 10. You need to create a team and admin account. You can choose a team name, email and password:


### PR DESCRIPTION
When running the commands with `godep` on the latest master, godep will
print the error `godep: No Godeps found (or in any parent directory)`.

This change explais that the same commands work if the developer omits
`godep` at the beginning of the command.