### PR TITLE
Renaming FX guidelines to UX guidelines in text

### DIFF
--- a/source/developer/fx-guidelines.rst
+++ b/source/developer/fx-guidelines.rst
@@ -1,7 +1,7 @@
-FX Guidelines
+UX Guidelines
 ========================
 
-The purpose of the Mattermost Fan eXperience Guidelines ("FX Guidelines") is to deliver a level of usability and consistency that turns users of Mattermost software into fans of the Mattermost experience.
+The purpose of the Mattermost User Experience Guidelines ("UX Guidelines") is to deliver a level of usability and consistency that turns users of Mattermost software into fans of the Mattermost experience.
 
 
 ---------------------------


### PR DESCRIPTION
- Not breaking links