### PR TITLE
PLT-2865: Bug: Theme is lost on search results page

### DIFF
--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -1,6 +1,6 @@
 {# layout.html #}
 {# Import the theme's layout. #}
-{% extends "!page.html" %}
+{% extends "!layout.html" %}
 
 {% set css_files = css_files + ['_static/theme.css'] %}
 {% set script_files = script_files + ['_static/myscript.js'] %}


### PR DESCRIPTION
The template used for the search results is not the same template used for a page.  The mattermost docs only had the `page.html` template overridden to add the custom css and custom header, so I renamed the template to instead extend the `layout.html` page, so that it will have an impact on both the `page.html` template and `search.html` template rendering.

[**Note** I read the contribution guidelines for mattermost. While this issue didnt explicitly state that it was open for APR, it seemed trivial enough to resolve, so I'm submitting the PR request anyhow.  Hope that's ok!]