### PR TITLE
#84: Enable collapse/expand of headings in left sidebar.

### DIFF
--- a/source/myscript.js
+++ b/source/myscript.js
@@ -9,6 +9,13 @@ $(document).ready(function(){
 		$('.wy-side-scroll').scrollTop(sidebarScrollPosition-120);
 	}
 
+	$('.wy-menu-vertical .caption').on('click', function(){
+		if(!$(this).next().is(":visible")) {
+			$(".wy-menu-vertical > ul:visible").slideToggle();
+			$(this).next().slideToggle();
+		}
+	});
+
 	var centerScroll = function(position){
 		setTimeout(function(){
 			var centerScrollPosition = $('.wy-nav-content-wrap').scrollTop();

--- a/source/theme.css
+++ b/source/theme.css
@@ -35,6 +35,14 @@ footer {
 	max-width: 1000px;
 }
 
+.wy-menu-vertical > ul {
+	display: none;
+}
+
+.wy-menu-vertical > ul.current {
+	display: block;
+}
+
 .wy-menu-vertical li.toctree-l2.current li.toctree-l3>a {
 	border: none;
 	background: #D0D0D0;
@@ -56,6 +64,7 @@ footer {
 	margin: 4px 0;
 	height: 33px;
 	background: #CACACA;
+	cursor:pointer;
 }
 
 .wy-menu-vertical p.caption:first-child {


### PR DESCRIPTION
Hid all menu sections except for the _active_ section of the table ofcontents, upon load. Added a handler on-click of the headers to toggle the visibility of visible sections, and ensure the section below the selected header is visible. Included a special check to ensure that if you click the header of a section that is already visible, nothing will happen. Ensured the mouse pointer is styled to a pointer when hoving the section header since they are now selectable. mattermost/docs#84