### PR TITLE
Update v3.3 changelog

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -20,10 +20,10 @@ Expected release date: 2016-08-16
 - Added status indicators to the Direct Message and Channel member lists.
 - Added `@here` to mention users who are online.
 
-#### Google SSO ([Enterprise E10, E20](https://about.mattermost.com/pricing/))
+#### Google SSO ([Enterprise E20](https://about.mattermost.com/pricing/))
 - Users can sign in to Mattermost with their Google credentials and new Mattermost user accounts are automatically created on first login.
 
-#### Office 365 SSO (Beta) ([Enterprise E10, E20](https://about.mattermost.com/pricing/))
+#### Office 365 SSO (Beta) ([Enterprise E20](https://about.mattermost.com/pricing/))
 - Users can sign in to Mattermost with their Office 365 credentials and new Mattermost user accounts are automatically created on first login.
 
 #### High Availability Mode (Beta) ([Enterprise E20](https://about.mattermost.com/pricing/))

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -20,12 +20,11 @@ Expected release date: 2016-08-16
 - Added status indicators to the Direct Message and Channel member lists.
 - Added `@here` to mention users who are online.
 
-#### OAuth 2.0 Service Provider
-- Added support for OAuth 2.0 service provider, allowing external applications to authenticate API requests to Mattermost.
-- Added an option to enable automatic authorization of trusted OAuth 2.0 applications by the Mattermost server.
+#### Google SSO ([Enterprise E10, E20](https://about.mattermost.com/pricing/))
+- Users can sign in to Mattermost with their Google credentials and new Mattermost user accounts are automatically created on first login.
 
-#### Google and Office 365 SSO ([Enterprise E10, E20](https://about.mattermost.com/pricing/))
-- Added support for Google and Office 365 single-sign-on.
+#### Office 365 SSO (Beta) ([Enterprise E10, E20](https://about.mattermost.com/pricing/))
+- Users can sign in to Mattermost with their Office 365 credentials and new Mattermost user accounts are automatically created on first login.
 
 #### High Availability Mode (Beta) ([Enterprise E20](https://about.mattermost.com/pricing/))
 - Support for highly available application servers configurable in the System Console and configuration files. See [documentation](http://docs.mattermost.com/deployment/cluster.html) for more details.

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -202,6 +202,7 @@ The following config settings will only work on servers with an Enterprise Licen
 - Office 365 login sometimes causes a bad token error.
 - Messages sometimes don't appear deleted until the page is refreshed.
 - When joining a channel from a public link, the page sometimes loads for a long time and requires a refresh.
+- After leaving a team, joining or creating a team sometimes causes an error.
 
 ### Contributors
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -199,6 +199,9 @@ The following config settings will only work on servers with an Enterprise Licen
 - Sometimes only the last character typed in the channel switcher appears.
 - Webhook attachments don’t show up in search results.
 - Count of unread mentions are sometimes mixed when switching between multiple teams.
+- Office 365 login sometimes causes a bad token error.
+- Messages sometimes don't appear deleted until the page is refreshed.
+- When joining a channel from a public link, the page sometimes loads for a long time and requires a refresh.
 
 ### Contributors
 


### PR DESCRIPTION
- Add more known issues
- Remove OAuth service provider from changelog (we'll consider promoting it with the upcoming Mattermost Zapier app)
- Label Office 365 support as Beta