### PR TITLE
Enable smooth-scrolling on (some) touch-enabled devices

### DIFF
--- a/source/theme.css
+++ b/source/theme.css
@@ -158,6 +158,10 @@ h1, h2, .rst-content .toctree-wrapper p.caption, h3, h4, h5, h6, legend {
 	width: 100%;
 	height: 100%;
 	background: transparent;
+	
+	/* May seem out of place, but it enables smooth/momentum/elastic scrolling on mobile devices */
+	overflow-y: scroll; /* has to be scroll, not auto */
+    -webkit-overflow-scrolling: touch;
 }
 
 .wy-side-nav-search input[type=text] {

--- a/source/theme.css
+++ b/source/theme.css
@@ -158,10 +158,6 @@ h1, h2, .rst-content .toctree-wrapper p.caption, h3, h4, h5, h6, legend {
 	width: 100%;
 	height: 100%;
 	background: transparent;
-	
-	/* May seem out of place, but it enables smooth/momentum/elastic scrolling on mobile devices */
-	overflow-y: scroll; /* has to be scroll, not auto */
-    -webkit-overflow-scrolling: touch;
 }
 
 .wy-side-nav-search input[type=text] {
@@ -262,6 +258,10 @@ header .header__links li a {
 	}
 	.wy-menu-vertical {
 		top: 0;
+	}
+	.wy-nav-content-wrap {
+		overflow-y: scroll;
+		-webkit-overflow-scrolling: touch;
 	}
 	header .header__logo img {
 		width: 176px;


### PR DESCRIPTION
Added the required css attributes to the body of the page to enable a smooth (aka elastic/momentum) scrolling on mobile devices, as requested by mattermost/docs#368.  Note that this is a feature that is only supported by certain touch-enabled devices/browsers!