### PR TITLE
Re-add Ulimit to Install Guides

### DIFF
--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -6,7 +6,7 @@ Production Enterprise Install on RHEL 6.6
 Install Mattermost Enterprise Edition in production mode on one, two or three machines, using the following steps: 
 
 - `Install Red Hat Enterprise Linux (x64) 6.6 <#install-red-hat-enterprise-linux-x64-66>`_
-- `Set up Database Serverre <#set-up-database-server>`_
+- `Set up Database Server <#set-up-database-server>`_
 - `Set up Mattermost Server <#set-up-mattermost-server>`_
 - `Set up NGINX Server <#set-up-nginx-server>`_
 - `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_

--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -6,7 +6,7 @@ Production Enterprise Install on RHEL 6.6
 Install Mattermost Enterprise Edition in production mode on one, two or three machines, using the following steps: 
 
 - `Install Red Hat Enterprise Linux (x64) 6.6 <#install-red-hat-enterprise-linux-x64-66>`_
-- `Set up Database Server <#set-up-database-server>`_
+- `Set up Database Serverre <#set-up-database-server>`_
 - `Set up Mattermost Server <#set-up-mattermost-server>`_
 - `Set up NGINX Server <#set-up-nginx-server>`_
 - `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_
@@ -165,6 +165,7 @@ Set up Mattermost Server
           start on runlevel [2345]
           stop on runlevel [016]
           respawn
+          limit nofile 50000 50000
           chdir /opt/mattermost
           exec bin/platform
 

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -175,6 +175,7 @@ Set up Mattermost Server
           User=mattermost
           ExecStart=/opt/mattermost/bin/platform
           PIDFile=/var/spool/mattermost/pid/master.pid
+          LimitNOFILE=49152
 
           [Install]
           WantedBy=multi-user.target

--- a/source/install/ee-prod-ubuntu.rst
+++ b/source/install/ee-prod-ubuntu.rst
@@ -153,6 +153,7 @@ Set up Mattermost Server
           start on runlevel [2345]
           stop on runlevel [016]
           respawn
+          limit nofile 50000 50000
           chdir /home/ubuntu/mattermost
           setuid ubuntu
           exec bin/platform

--- a/source/install/prod-rhel-6.rst
+++ b/source/install/prod-rhel-6.rst
@@ -165,6 +165,7 @@ Set up Mattermost Server
           start on runlevel [2345]
           stop on runlevel [016]
           respawn
+          limit nofile 50000 50000
           chdir /opt/mattermost
           exec bin/platform
 

--- a/source/install/prod-rhel-7.rst
+++ b/source/install/prod-rhel-7.rst
@@ -175,6 +175,7 @@ Set up Mattermost Server
           User=mattermost
           ExecStart=/opt/mattermost/bin/platform
           PIDFile=/var/spool/mattermost/pid/master.pid
+          LimitNOFILE=49152
 
           [Install]
           WantedBy=multi-user.target

--- a/source/install/prod-ubuntu.rst
+++ b/source/install/prod-ubuntu.rst
@@ -153,6 +153,7 @@ Set up Mattermost Server
           start on runlevel [2345]
           stop on runlevel [016]
           respawn
+          limit nofile 50000 50000
           chdir /home/ubuntu/mattermost
           setuid ubuntu
           exec bin/platform


### PR DESCRIPTION
Somehow these got paved over since they were merged in June. Not sure how that happened, but adding them back in in this PR. Debian install guide still has it in there.

Original PR: https://github.com/mattermost/docs/pull/211/files