### PR TITLE
Fix a typo, and fix title underline lengths.

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -69,7 +69,7 @@ Changes from v3.3 to v3.4:
 
 (Only affects servers with public links enabled) After upgrading to v3.4, existing public links will no longer be valid. This is because in past versions, when the Public Link Salt was regenerated existing public links were not invalidated. Now, when the salt is regenerated, existing links are made invalid.
 
-**config.json**    
+#### config.json   
 
 Multiple setting options were added to `config.json`. Below is a list of the additions and their default values on install. The settings can be modified in `config.json` or the System Console. 
 


### PR DESCRIPTION
The build throws warnings when the title underline in an .rst file is too short. The title underline should be at least as long as the title text.