### PR TITLE
Reorganization into Guides (+landing page UX)

### DIFF
--- a/source/administration/upgrade-guide.rst
+++ b/source/administration/upgrade-guide.rst
@@ -1,1 +1,1 @@
-Please see http://docs.mattermost.com/administration/upgrade.html
+Please see :doc:`upgrade`.

--- a/source/conf.py
+++ b/source/conf.py
@@ -187,7 +187,9 @@ html_static_path = ['theme.css', 'myscript.js']
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+html_additional_pages = {
+    'index': 'index.html'
+}
 
 # If false, no module index is generated.
 #html_domain_indices = True

--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -1,0 +1,53 @@
+Mattermost Administrator's Guide
+--------------------------------
+
+Install Guides
+==============
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /install/requirements*
+   /install/docker-local*
+   /install/docker-ebs*
+   /install/ee-install*
+   /install/prod-ubuntu*
+   /install/prod-rhel*
+   /install/prod*
+   /install/smtp*
+   /install/troubleshooting*
+   /install/i18n*
+
+Deployment
+==========
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /deployment/on-boarding*
+   /deployment/push*
+   /deployment/sso-ldap*
+   /deployment/auth*
+   /deployment/sso-saml.md
+   /deployment/scaling*
+   /deployment/cluster*
+   /deployment/sso-gitlab*
+   /deployment/sso-google*
+   /deployment/sso-office*
+
+Administration
+==============
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /administration/command*
+   /administration/config*
+   /administration/team-settings.md
+   /administration/statistics.md
+   /administration/upgrade.md
+   /administration/migrating.md
+   /administration/[!_upgrade-guide]*

--- a/source/guides/core.rst
+++ b/source/guides/core.rst
@@ -1,0 +1,10 @@
+Core Team Handbook
+------------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /process/overview*
+   /process/release-process*
+   /process/*

--- a/source/guides/developer.rst
+++ b/source/guides/developer.rst
@@ -1,0 +1,13 @@
+Mattermost Developer's Guide
+----------------------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /developer/contribution*
+   /developer/developer-setup*
+   /developer/running-mattermost*
+   /developer/style*
+   /developer/fx*
+   /developer/localization-process.rst

--- a/source/guides/integration.rst
+++ b/source/guides/integration.rst
@@ -1,0 +1,16 @@
+Mattermost Integration Guide
+----------------------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /developer/api*
+   /developer/webhooks*
+   /developer/slash*
+   /developer/message-attachments*
+   /developer/web-service*
+   /developer/web-service-reference*
+   /developer/oauth*
+   /integrations/zapier*
+   /developer/integration*

--- a/source/guides/user.rst
+++ b/source/guides/user.rst
@@ -1,0 +1,46 @@
+Mattermost User's Guide
+-----------------------
+
+Getting Started
+===============
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /help/getting-started/signing-in.md
+   /help/getting-started/messaging-basics.md
+   /help/getting-started/configuring-notifications.md
+   /help/getting-started/organizing-conversations.md
+   /help/getting-started/searching.md
+   /help/getting-started/creating-teams.md
+   /help/getting-started/managing-members.md
+
+Messaging
+=========
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   /help/messaging/sending-messages.md
+   /help/messaging/reading-messages.md
+   /help/messaging/mentioning-teammates.md
+   /help/messaging/formatting-text.md
+   /help/messaging/attaching-files.md
+   /help/messaging/executing-commands.md
+   /help/messaging/*
+
+Settings
+========
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :glob:
+
+   /help/settings/account-settings.md
+   /help/settings/theme-colors.md
+   /help/settings/channel-settings.md
+   /help/settings/team-settings.md
+   /help/settings/*

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,146 +1,24 @@
-.. Mattermost documentation master file, created by
-   sphinx-quickstart on Thu Nov 19 13:21:53 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. Top-Level documentation file is used to start the toctree; 
+   however, this file is overriden in the rendering process
+   by an alternative index.html that provides a visually-pleasing 
+   landing page.  Updates to this top-level item must also
+   be transposed in the 'templates/index.html' file.
 
 Mattermost Documentation 
--------------------
-
------
+------------------------
 
 .. _`mattermost.org/download`: http://www.mattermost.org/download/
 .. _contacting Mattermost, Inc.: https://about.mattermost.com/contact/
 .. _download and try it today.: https://docs.mattermost.com/install/ee-install.html
 
-
 .. toctree::
    :maxdepth: 1
-   :caption: Overview
    :glob:
 
-   overview/product*
-   overview/security*
-   deployment/deployment*
-   overview/integrations*
-   overview/auth*
+   Overview <overview/index>
+   User's Guide <guides/user>
+   Administrator's Guide <guides/administrator>
+   Integration Guide <guides/integration>
+   Developer's Guide <guides/developer>
+   Core Team Handbook <guides/core>
    
-.. toctree::
-   :maxdepth: 1
-   :caption: Install Guides
-   :glob:
-
-   install/requirements*
-   install/docker-local*
-   install/docker-ebs*
-   install/ee-install*
-   install/prod-ubuntu*
-   install/prod-rhel*
-   install/prod*
-   install/smtp*
-   install/troubleshooting*
-   install/i18n*
-
-   
-.. toctree::
-   :maxdepth: 1
-   :caption: Deployment
-   :glob:
-
-   deployment/on-boarding*
-   deployment/push*
-   deployment/sso-ldap*
-   deployment/auth*
-   deployment/sso-saml.md
-   deployment/scaling*
-   deployment/cluster*
-   deployment/sso-gitlab*
-   deployment/sso-google*
-   deployment/sso-office*
-
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Administration
-   :glob:
-
-   administration/command*
-   administration/config*
-   administration/team-settings.md
-   administration/statistics.md
-   administration/upgrade.md
-   administration/migrating.md
-   administration/*
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Integrations
-   :glob:
-
-   developer/api*
-   developer/webhooks*
-   developer/slash*
-   developer/message-attachments*
-   developer/web-service*
-   developer/web-service-reference*
-   developer/oauth*
-   integrations/zapier*
-   developer/integration*
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Help: Getting Started
-   :glob:
-
-   help/getting-started/signing-in.md
-   help/getting-started/messaging-basics.md
-   help/getting-started/configuring-notifications.md
-   help/getting-started/organizing-conversations.md
-   help/getting-started/searching.md
-   help/getting-started/creating-teams.md
-   help/getting-started/managing-members.md
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Help: Messaging
-   :glob:
-
-   help/messaging/sending-messages.md
-   help/messaging/reading-messages.md
-   help/messaging/mentioning-teammates.md
-   help/messaging/formatting-text.md
-   help/messaging/attaching-files.md
-   help/messaging/executing-commands.md
-   help/messaging/*
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Help: Settings
-   :glob:
-
-   help/settings/account-settings.md
-   help/settings/theme-colors.md
-   help/settings/channel-settings.md
-   help/settings/team-settings.md
-   help/settings/*
-
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Contributor's Guide
-   :glob:
-
-   developer/contribution*
-   developer/developer-setup*
-   developer/running-mattermost*
-   developer/style*
-   developer/fx*
-   developer/localization-process.rst
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Team Handbook
-   :glob:
-
-   process/overview*
-   process/release-process*
-   process/*

--- a/source/overview/index.rst
+++ b/source/overview/index.rst
@@ -1,0 +1,12 @@
+Mattermost Overview
+-------------------
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   /overview/product*
+   /overview/security*
+   /deployment/deployment*
+   /overview/integrations*
+   /overview/auth*

--- a/source/overview/integrations.rst
+++ b/source/overview/integrations.rst
@@ -1,6 +1,6 @@
-===========================
-Integrations Guide 
-===========================
+=====================
+Integrations Overview 
+=====================
 
 Mattermost offers a host of options for connecting to systems on your private network as well as services hosted on hybrid and public clouds. 
 

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -1,0 +1,18 @@
+<header>
+	<div class="header__container">
+		<a href="http://docs.mattermost.com/" class="header__logo">
+			<img width="176" src="https://about.mattermost.com/wp-content/uploads/2016/01/logo.png">
+		</a>
+		<div class="links__icon">
+			<i class="fa fa-bars"></i>
+		</div>
+		<ul class="header__links">
+			<li><a href="https://about.mattermost.com/solutions/">Solutions</a></li>
+			<li><a href="https://about.mattermost.com/features/">Features</a></li>
+			<li><a class="active" href="http://docs.mattermost.com/">Documentation</a></li>
+			<li><a href="https://about.mattermost.com/pricing/">Pricing</a></li>
+			<li><a href="https://about.mattermost.com/contact/">Contact</a></li>
+			<li><a href="https://www.mattermost.org/download/">Download</a></li>
+		</ul>
+	</div>
+</header>

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -1,0 +1,178 @@
+{# Overrides the output of converting index.rst to enable a custom landing page for the docs #}
+{# Ensure that all links found within the index.rst are transposed here as well. #}
+
+{%- extends "layout-notoc.html" %}
+{% set title = _('Mattermost Documentation') %}
+
+{% block body %}
+
+    <style type="text/css">
+
+        .landing {
+            width: 100%;
+            max-width: 700px; /* Force to a maximum of 3 tiles wide */
+            margin: 0 auto;
+            text-align: center;
+        }
+
+        .landing .landing-title {
+            text-align:center;
+            font-size: 2em;
+            margin: .67em 0
+        }
+
+        .tiles-flex {
+            display: -webkit-box;
+            display: -ms-flexbox;
+            display: flex;
+            -ms-flex-wrap: wrap;
+            flex-wrap: wrap;
+            -webkit-box-pack: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            -ms-flex-line-pack: center;
+            align-content: center;
+            max-width: 700px; /* purely to stop the max width of tiles at 3 */
+        }
+
+        .tile {
+            /* looks */
+            border-top: 8px solid #343537;
+            background-color: #fff;
+            box-shadow: .5px 2px 4px 0 #bdbdbd;
+            /* sizing/boxing */
+            width: 200px;
+            height: 220px;
+            margin: 10px;
+            padding: 10px;
+            /* animation */
+            -webkit-transition: 250ms;
+            transition: 250ms;
+            -webkit-transform: translate3d(0,0,0);
+            transform: translate3d(0,0,0);
+            will-change: transform;
+            /* layout */
+            display: -webkit-box;
+            display: -ms-flexbox;
+            display: flex;
+            -webkit-box-orient: horizontal;
+            -webkit-box-direction: normal;
+            -ms-flex-direction: row;
+            flex-direction: row;
+            -ms-flex-wrap: wrap;
+            flex-wrap: wrap;
+            -webkit-box-pack: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            -ms-flex-line-pack: stretch;
+            align-content: stretch;
+            -webkit-box-align: stretch;
+            -ms-flex-align: stretch;
+            align-items: stretch;
+        }
+
+        .tile:hover {
+            -webkit-transform: translate3d(0,-6px,0);
+            transform: translate3d(0,-6px,0)
+        }
+
+        .tile .tile-title {
+            /* looks */
+            font-size: 20px;
+            letter-spacing: .4px;
+            color: #676363;
+            /* sizing/boxing */
+            height: 89px;
+            width: 100%;
+            margin: 0px;
+            padding: 0px 20px;
+            /* layout */
+            display:-webkit-box;
+            display:-ms-flexbox;
+            display:flex;
+            -ms-flex-item-align: auto;
+            align-self: auto;
+            -webkit-box-orient:vertical;
+            -webkit-box-direction:normal;
+            -ms-flex-direction:column;
+            flex-direction:column;
+            -ms-flex-pack:distribute;
+            justify-content:space-around;
+        }
+
+        .tile .tile-divider {
+            height:2px;
+            width: 100%;
+            margin: 0 5px;
+            border: .5px solid #343537;
+            background-color: #343537;
+            -ms-flex-item-align: auto;
+            align-self: auto;
+        }
+
+        .tile .tile-description {
+            /* looks */
+            font-size: 14px;
+            letter-spacing: .2px;
+            line-height: 1.25;
+            color: #757575;
+            /* sizing/boxing */
+            height: 89px;
+            width: 100%;
+            margin: 0px;
+            /* layout */            
+            display:-webkit-box;
+            display:-ms-flexbox;
+            display:flex;
+            -ms-flex-item-align: auto;
+            align-self: auto;
+            -webkit-box-orient:vertical;
+            -webkit-box-direction:normal;
+            -ms-flex-direction:column;
+            flex-direction:column;
+            -ms-flex-pack:distribute;
+            justify-content:space-around;
+        }
+
+    </style>
+
+    <div class="landing">
+        <h1 class="landing-title">Mattermost Documentation</h1>
+        <div class="tiles-flex">
+            <a class="tile" href="overview/index.html">
+                <h2 class="tile-title">Overview</h2>
+                <div class="tile-divider"></div>
+                <p class="tile-description">Solution benefits, features, security, deployment and integrations.</p>
+            </a>
+            <a class="tile" href="guides/user.html">
+                <h2 class="tile-title">User's Guide</h2>
+                <div class="tile-divider"></div>
+                <p class="tile-description">End user help and documentation</p>
+            </a>
+            <a class="tile" href="guides/administrator.html">
+                <h2 class="tile-title">Administrator's Guide</h2>
+                <div class="tile-divider"></div>
+                <p class="tile-description"> Installation, deployment and administration guides</p>
+            </a>
+            <a class="tile" href="guides/integration.html">
+                <h2 class="tile-title">Integration Guide</h2>
+                <div class="tile-divider"></div>
+                <p class="tile-description">Integrating other systems into messaging solution</p>
+            </a>
+            <a class="tile" href="guides/developer.html">
+                <h2 class="tile-title">Developer's Guide</h2>
+                <div class="tile-divider"></div>
+                <p class="tile-description">Contributing to the Mattermost open source project</p>
+            </a>
+            <a class="tile" href="guides/core.html">
+                <h2 class="tile-title">Core Team Handbook</h2>
+                <div class="tile-divider"></div>
+                <p class="tile-description">Joining the Mattermost core team</p>
+            </a>
+        </div>
+    </div>
+
+{% endblock %}

--- a/source/templates/layout-notoc.html
+++ b/source/templates/layout-notoc.html
@@ -1,0 +1,160 @@
+{# TEMPLATE VAR SETTINGS #}
+{%- set url_root = pathto('', 1) %}
+{%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
+{%- if not embedded and docstitle %}
+  {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
+{%- else %}
+  {%- set titlesuffix = "" %}
+{%- endif %}
+
+<!DOCTYPE html>
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  {{ metatags }}
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% block htmltitle %}
+  <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+  {% endblock %}
+
+  {# FAVICON #}
+  {% if favicon %}
+    <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
+  {% endif %}
+
+  {# CSS #}
+
+  {% set css_files = css_files + ['_static/theme.css'] %}
+  {% set script_files = script_files + ['_static/myscript.js'] %}
+
+  {# RTD hosts this file, so just load on non RTD builds #}
+  {% if not READTHEDOCS %}
+    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  {% endif %}
+
+  {% for cssfile in css_files %}
+    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+  {% endfor %}
+
+  {% for cssfile in extra_css_files %}
+    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+  {% endfor %}
+
+  {%- block linktags %}
+    {%- if hasdoc('about') %}
+        <link rel="author" title="{{ _('About these documents') }}"
+              href="{{ pathto('about') }}"/>
+    {%- endif %}
+    {%- if hasdoc('genindex') %}
+        <link rel="index" title="{{ _('Index') }}"
+              href="{{ pathto('genindex') }}"/>
+    {%- endif %}
+    {%- if hasdoc('search') %}
+        <link rel="search" title="{{ _('Search') }}" href="{{ pathto('search') }}"/>
+    {%- endif %}
+    {%- if hasdoc('copyright') %}
+        <link rel="copyright" title="{{ _('Copyright') }}" href="{{ pathto('copyright') }}"/>
+    {%- endif %}
+    <link rel="top" title="{{ docstitle|e }}" href="{{ pathto('index') }}"/>
+    {%- if parents %}
+        <link rel="up" title="{{ parents[-1].title|striptags|e }}" href="{{ parents[-1].link|e }}"/>
+    {%- endif %}
+    {%- if next %}
+        <link rel="next" title="{{ next.title|striptags|e }}" href="{{ next.link|e }}"/>
+    {%- endif %}
+    {%- if prev %}
+        <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}"/>
+    {%- endif %}
+  {%- endblock %}
+  {%- block extrahead %} {% endblock %}
+
+  {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
+  <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
+
+  <style type="text/css">
+
+    .wy-nav-content {
+        max-width: none;
+    }
+
+    .wy-nav-content .document {
+        max-width: none;
+    }
+
+    .wy-nav-content-wrap {
+        margin-left: 0px;
+    }
+
+  </style>
+
+</head>
+
+<body class="wy-body-for-nav" role="document">
+  
+  {% block menu %} {% endblock %}
+  {% block extrabody %} {% endblock %}
+
+  <div class="wy-grid-for-nav">
+
+    <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
+
+      {# MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
+      <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
+        {% block mobile_nav %}
+          <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
+          <a href="{{ pathto(master_doc) }}">{{ project }}</a>
+        {% endblock %}
+      </nav>
+
+      {# PAGE CONTENT #}
+      <div class="wy-nav-content">
+        <div class="rst-content">
+          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+           <div itemprop="articleBody">
+            {% block body %}{% endblock %}
+           </div>
+          </div>
+          {% include "footer.html" %}
+        </div>
+      </div>
+
+    </section>
+
+  </div>
+
+  {% if not embedded %}
+    <script type="text/javascript">
+        var DOCUMENTATION_OPTIONS = {
+            URL_ROOT:'{{ url_root }}',
+            VERSION:'{{ release|e }}',
+            COLLAPSE_INDEX:false,
+            FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
+            HAS_SOURCE:  {{ has_source|lower }}
+        };
+    </script>
+    {%- for scriptfile in script_files %}
+      <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+    {%- endfor %}
+  {% endif %}
+
+  {# RTD hosts this file, so just load on non RTD builds #}
+  {% if not READTHEDOCS %}
+    <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
+  {% endif %}
+
+  {# STICKY NAVIGATION #}
+  {% if theme_sticky_navigation %}
+  <script type="text/javascript">
+      jQuery(function () {
+          SphinxRtdTheme.StickyNav.enable();
+      });
+  </script>
+  {% endif %}
+
+  {% block footer %}
+    {% include "header.html" %}
+  {% endblock %}
+
+</body>
+</html>

--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -1,4 +1,3 @@
-{# layout.html #}
 {# Import the theme's layout. #}
 {% extends "!layout.html" %}
 
@@ -6,22 +5,5 @@
 {% set script_files = script_files + ['_static/myscript.js'] %}
 
 {% block footer %}
-<header>
-	<div class="header__container">
-		<a href="http://docs.mattermost.com/" class="header__logo">
-			<img width="176" src="https://about.mattermost.com/wp-content/uploads/2016/01/logo.png">
-		</a>
-		<div class="links__icon">
-			<i class="fa fa-bars"></i>
-		</div>
-		<ul class="header__links">
-			<li><a href="https://about.mattermost.com/solutions/">Solutions</a></li>
-			<li><a href="https://about.mattermost.com/features/">Features</a></li>
-			<li><a class="active" href="http://docs.mattermost.com/">Documentation</a></li>
-			<li><a href="https://about.mattermost.com/pricing/">Pricing</a></li>
-			<li><a href="https://about.mattermost.com/contact/">Contact</a></li>
-			<li><a href="https://www.mattermost.org/download/">Download</a></li>
-		</ul>
-	</div>
-</header>
+	{% include "header.html" %}
 {% endblock %}

--- a/source/theme.css
+++ b/source/theme.css
@@ -50,8 +50,12 @@ footer {
 	font-size: 105%;
 }
 
+.wy-grid-for-nav {
+	padding-top: 70px;
+}
+
 .wy-nav-content {
-	padding-top: 6em;
+	padding-top: 26px;
 }
 
 .wy-table td, .rst-content table.docutils td, .rst-content table.field-list td {
@@ -60,10 +64,6 @@ footer {
 
 .wy-nav-content .document {
 	max-width: 1000px;
-}
-
-.wy-menu-vertical > ul {
-	display: none;
 }
 
 .wy-menu-vertical > ul.current {
@@ -79,6 +79,10 @@ footer {
 	background: #E0E0E0;
 	border-color: #ddd;
 	border-top: none;
+}
+
+.wy-menu-vertical li a {
+	white-space: nowrap;
 }
 
 .wy-menu-vertical li.on a, .wy-menu-vertical li.current>a {
@@ -263,6 +267,9 @@ header .header__links li a {
 		overflow-y: scroll;
 		-webkit-overflow-scrolling: touch;
 	}
+	.wy-nav-content-wrap.shift {
+		top: 70px;
+	}
 	header .header__logo img {
 		width: 176px;
 	}
@@ -285,7 +292,10 @@ header .header__links li a {
 		max-width: 100%;
 		width: auto;
 	}
-	.wy-nav-top {
-		margin-top: 70px;
+}
+
+@media screen and (min-width: 1400px) {
+	.wy-nav-content-wrap {
+    	background: #fcfcfc; /* gets rid of the wony gray bottom of the page when viewed on a wide screen */
 	}
 }


### PR DESCRIPTION
- Reorganized the TOC into "Guides" based on feedback/guidance from @it33.  _NOTE: The TOC reflects all changes committed to the TOC as of this morning.  Subsequent changes to 'index.rst' will need to be manually merged into this branch before/after the merge is pulled._
- Added markup to override the root index to display a custom homepage that uses tiles similar to mongodb docs.
- Added a temporary duplicate of the underlying theme's layout template in order to add the custom markup for the new homepage.  This will be cleaned up once the theme's code is condensed and integrated into the project for easier modification as needed.  Transitioned the header's content into it's own template for reuse in both layout templates.
- [#369] Added in a small fix to the display of the site to ensure that content does not scroll underneath of the header.  Included tests/fixes to resolve this in mobile view as well.  Can remove this an make it a separate pull-request if necessary.
- Updated the administrator's guide TOC to specifically exclude 'upgrade-guide' from it's wildcard inclusion to reduce a terrible amount of warnings that are generated otherwise.

**Screenshot 1**: Home Page
![image](https://cloud.githubusercontent.com/assets/600643/18609765/47f49cda-7cd8-11e6-8bbc-a2849a26b649.png)

**Screenshot 2**: Example of TOC. Page shows what is seen after selecting "User's Guide" from the homepage.  Note the top-boundary of the scrollbar for the page's content ends at the bottom of the header.  Compare this to the current site... Because of the removal of this overlay, #369 should be resolved.
![image](https://cloud.githubusercontent.com/assets/600643/18609773/6fc3a4cc-7cd8-11e6-827b-1380f1efebd8.png)
