### PR TITLE
Desktop App Docs v1

### DIFF
--- a/source/help/apps/desktop-changelog.md
+++ b/source/help/apps/desktop-changelog.md
@@ -16,7 +16,6 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
  - Added an option to configure whether a red badge is shown on taskbar icon for unread messages
  - Added new shortcuts:
      - `CTRL + S`: sets focus on the Mattermost search box
-     - `CTRL + SHIFT + S`: sets focus on the Mattermost search box and adds `in:[channel_url]` to search in current channel
      - `ALT + Left Arrow`: go to previous page in history
      - `ALT + Right Arrow`: go to next page in history
  - Upgraded the Settings page user interface
@@ -31,7 +30,6 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
  - Added an option to configure whether a red badge is shown on taskbar icon for unread messages
  - Added new shortcuts:
      - `CMD + S`: sets focus on the Mattermost search box
-     - `CMD + SHIFT + S`: sets focus on the Mattermost search box and adds `in:[channel_url]` to search in current channel
      - `CMD + [`: go to previous page in history
      - `CMD + ]`: go to next page in history
  - Upgraded the Settings page user interface
@@ -46,7 +44,6 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
  - Added a script to create `Mattermost.desktop` desktop entry to help [integrate the application into a desktop environment](https://wiki.archlinux.org/index.php/Desktop_entries) more easily
  - Added new shortcuts:
      - `CTRL + S`: sets focus on the Mattermost search box
-     - `CTRL + SHIFT + S`: sets focus on the Mattermost search box and adds `in:[channel_url]` to search in current channel
      - `ALT + Left Arrow`: go to previous page in history
      - `ALT + Right Arrow`: go to next page in history
  - Upgraded the Settings page user interface
@@ -67,7 +64,7 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
  - Fixed the Mattermost icon for desktop notifications in Windows 10
  - Fixed an issue where the maximized state of the app window was lost in some cases
  - Fixed an issue where shortcuts didn't work when switching applications or tabs in some cases
- - Fixed a pixelated application icon in top left of the window
+ - Fixed an issue where application icon at the top left of the window was pixelated
  - Fixed an issue where the application kept focus after closing the app window
 
 #### OS X

--- a/source/help/apps/desktop-changelog.md
+++ b/source/help/apps/desktop-changelog.md
@@ -2,9 +2,11 @@
 
 ## Release v3.4.0
 
-Expected release date: September 2016
+Expected release date: End of September 2016
 
-This release contains a security update and it is highly recommended that users upgrade to this version. 
+This release contains a security update and it is highly recommended that users upgrade to this version.
+
+Version number updated to 3.4 to make numbering consistent with Mattermost server and mobile app releases. This change will not imply monthly releases.
 
 ### Improvements
 
@@ -188,42 +190,54 @@ Many thanks to all our contributors. In alphabetical order:
 
 ## Release v1.2.1 (Beta)
 
-### Fixes
-- Fixed issue to remove "Electron" from appearing in the title bar on startup.
-
-### Improvements
-- Added a dialog to confirm use of non-http(s) protocols prior to opening links. For example, clicking on a link to `file://test` will open a dialog to confirm the user intended to open a file.
-
-#### Windows and OS X
-- Added a right-click menu option for tray icon to open the Desktop application on Windows and OS X.
-
-### Known issues
-- The shortcuts can't switch teams twice in a row.
-- The team pages are not correctly rendered until the window is resized when the zoom level is changed.
-
-## Release v1.2.0 (Beta)
-
-- **Released:** 2016-05-17
+Release date: 2016-05-24
 
 This release contains a security update and it is highly recommended that users upgrade to this version.
 
-### Fixes
+ - v1.2.1, released 2016-05-24
+     - Fixed an issue where "Electron" appeared in the title bar on startup.
+     - Added a dialog to confirm use of non-http(s) protocols prior to opening links. For example, clicking on a link to `file://test` will open a dialog to confirm the user intended to open a file.
+     - (Windows and OS X) Added a right-click menu option for tray icon to open the Desktop application.
+ - v1.2.0, released 2016-05-13
+     - Original v1.2 release
+
+### Improvements
+
+#### Windows
+- Improved the style for tab badges.
+- Added **Allow mixed content** option to render images with `http://`.
+- Added the login dialog for `http` authentication.
+
+#### OS X
+- Improved the style for tab badges.
+- Added **Allow mixed content** option to render images with `http://`.
+- Added the login dialog for `http` authentication.
+- Added an option to show a black dot indicating unread messages on the team tab bar.
+
+#### Linux
+- Improved the style for tab badges.
+- Added an **Allow mixed content** option to render images with `http://`.
+- Added a login dialog for `http` authentication.
+- Added **.deb** packages to support installation.
+
+### Bug Fixes
+
+#### Windows
+- Node.js environment is enabled in the new window.
+- The link other than `http://` and `https://` is opened by clicking.
+
+#### OS X
 - Node.js environment is enabled in the new window.
 - The link other than `http://` and `https://` is opened by clicking.
 
 #### Linux
+- Node.js environment is enabled in the new window.
+- The link other than `http://` and `https://` is opened by clicking.
 - Desktop notification is shown as a dialog on Ubuntu 16.04.
 
-### Improvements
-- Improve the style for tab badges.
-- Add **Allow mixed content** option to render images with `http://`.
-- Add the login dialog for http authentication.
-
-#### OS X
-- Add the option to show the icon on menu bar.
-
-#### Linux
-- Add **.deb** packages to support installation.
+### Known issues
+- The shortcuts can't switch teams twice in a row.
+- The team pages are not correctly rendered until the window is resized when the zoom level is changed.
 
 ### Contributors
 
@@ -233,19 +247,15 @@ Many thanks to all our contributors. In alphabetical order:
 
 ## Release v1.1.1 (Beta)
 
-- **Released:** 2016-04-13
+Release date: 2016-04-13
 
-### Fixes
+This release contains a security update and it is highly recommended that users upgrade to this version.
 
-#### All platforms
-- **Settings** page doesn't return to the main page when the located path contains a blank.
-
-#### Linux
-- Alt+Shift opens menu on Cinnamon desktop environment.
-
-## Release v1.1.0 (Beta)
-
-- **Released:** 2016-03-30
+ - v1.1.1, released 2016-04-13
+     - If the specified team URL on the **Settings** page contains an additional space, the app now properly redirects to the team page
+     - `Alt+Shift` now opens the menu on Cinnamon desktop environment.
+ - v1.1.0, released 2016-03-30
+     - Original v1.1 release
 
 The `electron-mattermost` project is now the official desktop application for the Mattermost open source project.
 
@@ -264,31 +274,60 @@ The `electron-mattermost` project is now the official desktop application for th
 ### Improvements
 
 #### All platforms
-- Refine application icon.
-- Show error messages when the application failed in loading Mattermost server.
-- Show confirmation dialog to continue connection when there is certificate error.
-- Add validation to check whether both of **Name** and **URL** fields are not blank.
-- Add simple basic HTTP authentication (requires a command line).
+- Refined the application icon.
+- Show error messages when the application fails to load the Mattermost server.
+- Show confirmation dialog to continue connection when there is a certificate error.
+- Added validation to check whether **Name** or **URL** are blank when adding or editing a team on the **Settings** page.
+- Added simple basic HTTP authentication (requires a command line).
 
 #### Windows
 - Show a small circle on the tray icon when there are new messages.
 
-### Fixes
+### Bug Fixes
 
 #### Windows
-- **File** > **About** does not bring up version number dialog.
+- **File** > **About** now shows the version number dialog.
 
 #### Linux
-- **File** > **About** does not bring up version number dialog.
-- Ubuntu: Notification is not showing up.
-- The view crashes when freetype 2.6.3 is used in system.
+- **File** > **About** now shows the version number dialog.
+- Ubuntu: Notifications now work properly.
+- The view mp longer crashes when freetype 2.6.3 is used on the system.
 
 ### Known issues
 
 #### All platforms
-- Basic Authentication is not working.
-- Some keyboard shortcuts are missing. (e.g. <kbd>Ctrl+W</kbd>, <kbd>Command+,</kbd>)
-- Basic authentication requires a command line.
+- Basic authentication is not working and requires a command line.
+- Some keyboard shortcuts are missing (e.g. <kbd>Ctrl+W</kbd>, <kbd>Command+,</kbd>).
 
 #### Windows
 - Application does not appear properly in Windows volume mixer.
+
+**List of releases before the project was promoted as the official desktop application for Mattermost.**
+
+[Release v1.0.7 (Unofficial) - 2016-02-20](https://github.com/mattermost/desktop/releases/tag/v1.0.7)
+
+[Release v1.0.6 (Unofficial) - 2016-02-16](https://github.com/mattermost/desktop/releases/tag/v1.0.6)
+
+[Release v1.0.5 (Unofficial) - 2016-02-13](https://github.com/mattermost/desktop/releases/tag/v1.0.5)
+
+[Release v1.0.4 (Unofficial) - 2016-02-12](https://github.com/mattermost/desktop/releases/tag/v1.0.4)
+
+[Release v1.0.3 (Unofficial) - 2016-02-03](https://github.com/mattermost/desktop/releases/tag/v1.0.3)
+
+[Release v1.0.2 (Unofficial) - 2016-01-16](https://github.com/mattermost/desktop/releases/tag/v1.0.2)
+
+[Release v1.0.1 (Unofficial) - 2016-01-06](https://github.com/mattermost/desktop/releases/tag/v1.0.1)
+
+[Release v1.0.0 (Unofficial) - 2015-12-27](https://github.com/mattermost/desktop/releases/tag/v1.0.0)
+
+[Release v0.5.1 (Unofficial) - 2015-12-12](https://github.com/mattermost/desktop/releases/tag/v0.5.1)
+
+[Release v0.5.0 (Unofficial) - 2015-12-06](https://github.com/mattermost/desktop/releases/tag/v0.5.0)
+
+[Release v0.4.0 (Unofficial) - 2015-11-03](https://github.com/mattermost/desktop/releases/tag/v0.4.0)
+
+[Release v0.3.0 (Unofficial) - 2015-10-24](https://github.com/mattermost/desktop/releases/tag/v0.3.0)
+
+[Release v0.2.0 (Unofficial) - 2015-10-14](https://github.com/mattermost/desktop/releases/tag/v0.2.0)
+
+[Release v0.1.0 (Unofficial) - 2015-10-10](https://github.com/mattermost/desktop/releases/tag/v0.1.0)

--- a/source/help/apps/desktop-changelog.md
+++ b/source/help/apps/desktop-changelog.md
@@ -2,7 +2,7 @@
 
 ## Release v3.4.0
 
-Expected release date: End of September 2016
+Expected release date: September 22, 2016
 
 This release contains a security update and it is highly recommended that users upgrade to this version.
 
@@ -11,8 +11,8 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
 ### Improvements
 
 #### Windows
- - Current team and channel name shown in window caption
- - Team tab is bolded for unread messages and has a red dot with a numbeer counter for unread mentions
+ - Current team and channel name shown in window title bar
+ - Team tab is bolded for unread messages and has a red dot with a count of unread mentions
  - Added an option to configure whether a red badge is shown on taskbar icon for unread messages
  - Added new shortcuts:
      - `CTRL + S`: sets focus on the Mattermost search box
@@ -23,10 +23,10 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
  - Added access to the settings menu from the system tray icon
  - Added validation for name and URL when adding a new team on the Settings page
  - The app now tries to reconnect periodically if a page fails to load
- - The app now works as a single instance (an existing application instance will be used when launching a new one)
+ - Only one instance of the desktop application will now load at a time
 
 #### OS X
- - Current team and channel name shown in window caption
+ - Current team and channel name shown in window title bar
  - Team tab is bolded for unread messages and has a red dot with a count of unread mentions
  - Added an option to configure whether a red badge is shown on taskbar icon for unread messages
  - Added new shortcuts:
@@ -39,7 +39,7 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
  - Added validation for name and URL when adding a new team on the Settings page
 
 #### Linux (Beta)
- - Current team and channel name shown in window caption
+ - Current team and channel name shown in window title bar
  - Team tab is bolded for unread messages and has a red dot with a count of unread mentions
  - Added an option to flash taskbar icon when a new message is received
  - Added a red badge to count mentions on the taskbar icon (for Unity)
@@ -53,7 +53,7 @@ Version number updated to 3.4 to make numbering consistent with Mattermost serve
  - Added access to the settings menu from the system tray icon
  - The app now tries to reconnect periodically if a page fails to load
  - Added validation for name and URL when adding a new team on the Settings page
- - The app now works as a single instance (an existing application instance will be used when launching a new one)
+ - Only one instance of the desktop application will now load at a time
 
 ### Bug Fixes
 

--- a/source/help/apps/desktop-changelog.md
+++ b/source/help/apps/desktop-changelog.md
@@ -1,0 +1,294 @@
+# Desktop Application Changelog
+
+## Release v3.4.0
+
+Expected release date: September 2016
+
+This release contains a security update and it is highly recommended that users upgrade to this version. 
+
+### Improvements
+
+#### Windows
+ - Current team and channel name shown in window caption
+ - Team tab is bolded for unread messages and has a red dot with a numbeer counter for unread mentions
+ - Added an option to configure whether a red badge is shown on taskbar icon for unread messages
+ - Added new shortcuts:
+     - `CTRL + S`: sets focus on the Mattermost search box
+     - `CTRL + SHIFT + S`: sets focus on the Mattermost search box and adds `in:[channel_url]` to search in current channel
+     - `ALT + Left Arrow`: go to previous page in history
+     - `ALT + Right Arrow`: go to next page in history
+ - Upgraded the Settings page user interface
+ - Added access to the settings menu from the system tray icon
+ - Added validation for name and URL when adding a new team on the Settings page
+ - The app now tries to reconnect periodically if a page fails to load
+ - The app now works as a single instance (an existing application instance will be used when launching a new one)
+
+#### OS X
+ - Current team and channel name shown in window caption
+ - Team tab is bolded for unread messages and has a red dot with a count of unread mentions
+ - Added an option to configure whether a red badge is shown on taskbar icon for unread messages
+ - Added new shortcuts:
+     - `CMD + S`: sets focus on the Mattermost search box
+     - `CMD + SHIFT + S`: sets focus on the Mattermost search box and adds `in:[channel_url]` to search in current channel
+     - `CMD + [`: go to previous page in history
+     - `CMD + ]`: go to next page in history
+ - Upgraded the Settings page user interface
+ - The app now tries to reconnect periodically if a page fails to load
+ - Added validation for name and URL when adding a new team on the Settings page
+
+#### Linux (Beta)
+ - Current team and channel name shown in window caption
+ - Team tab is bolded for unread messages and has a red dot with a count of unread mentions
+ - Added an option to flash taskbar icon when a new message is received
+ - Added a red badge to count mentions on the taskbar icon (for Unity)
+ - Added a script to create `Mattermost.desktop` desktop entry to help [integrate the application into a desktop environment](https://wiki.archlinux.org/index.php/Desktop_entries) more easily
+ - Added new shortcuts:
+     - `CTRL + S`: sets focus on the Mattermost search box
+     - `CTRL + SHIFT + S`: sets focus on the Mattermost search box and adds `in:[channel_url]` to search in current channel
+     - `ALT + Left Arrow`: go to previous page in history
+     - `ALT + Right Arrow`: go to next page in history
+ - Upgraded the Settings page user interface
+ - Added access to the settings menu from the system tray icon
+ - The app now tries to reconnect periodically if a page fails to load
+ - Added validation for name and URL when adding a new team on the Settings page
+ - The app now works as a single instance (an existing application instance will be used when launching a new one)
+
+### Bug Fixes
+
+#### Windows
+ - Cut, copy and paste are shown in the user interface only when the commands are available
+ - Copying link addresses now work properly
+ - Saving images by right-clicking the image preview now works
+ - Refreshing the app page no longer takes you to the team selection page, but keeps you on the current channel
+ - Removed misleading shortcuts from the system tray menu
+ - Removed unclear desktop notifications when the application page fails to load
+ - Fixed the Mattermost icon for desktop notifications in Windows 10
+ - Fixed an issue where the maximized state of the app window was lost in some cases
+ - Fixed an issue where shortcuts didn't work when switching applications or tabs in some cases
+ - Fixed a pixelated application icon in top left of the window
+ - Fixed an issue where the application kept focus after closing the app window
+
+#### OS X
+ - Cut, copy and paste are shown in the user interface only when the commands are available
+ - Copying link addresses now work properly
+ - Saving images by right-clicking the image preview now works
+ - Refreshing the app page no longer takes you to the team selection page, but keeps you on the current channel
+ - Fixed an issue where the maximized state of the app window was lost in some cases
+ - Fixed an issue where shortcuts didn't work when switching applications or tabs in some cases
+
+#### Linux (Beta)
+ - Cut, copy and paste are shown in the user interface only when the commands are available
+ - Copying link addresses now work properly
+ - Saving images by right-clicking the image preview now works
+ - Refreshing the app page no longer takes you to the team selection page, but keeps you on the current channel
+ - Removed misleading shortcuts from the system tray menu
+ - Removed unclear desktop notifications when the application page fails to load
+ - Fixed an issue where the maximized state of the app window was lost in some cases
+ - Fixed an issue where shortcuts didn't work when switching applications or tabs in some cases
+
+### Known Issues
+
+#### Windows
+ - Copying a link address and pasting it inside the app doesn't work
+ - YouTube videos do not work if mixed content is enabled from app settings
+
+#### OS X
+ - YouTube videos do not work if mixed content is enabled from app settings
+
+#### Linux
+ - YouTube videos do not work if mixed content is enabled from app settings
+ - [Ubuntu - 64 bit] Right clicking taskbar icon and choosing **Quit** only minimizes the app
+ - [Ubuntu - 64 bit] [Direct message notification comes as a streak of line instead of a pop up](https://github.com/mattermost/platform/issues/3589)
+
+### Contributors
+
+Many thanks to all our contributors. In alphabetical order:
+
+- [akashnimare](https://github.com/akashnimare), [asaadmahmood](https://github.com/asaadmahmood), [jasonblais](https://github.com/jasonblais), [jgis](https://github.com/jgis), [jnugh](https://github.com/jnugh), [Razzeee](https://github.com/Razzeee), [St-Ex](https://github.com/St-Ex), [timroes](https://github.com/timroes), [yuya-oc](https://github.com/yuya-oc)
+
+## Release v1.3.0
+
+Release date: 2016-07-18
+
+[Download the latest version here](https://about.mattermost.com/downloads/).
+
+### Improvements
+
+#### Windows
+- Added an installer for better install experience.
+- The app now minimizes to the system tray when application window is closed.
+- Added an option to launch application on login.
+- Added an option to blink the taskbar icon when a new message has arrived.
+- Added tooltip text for the system tray icon in order to show count of unread channels/mentions.
+- Added an option to toggle the app to minimize/restore when clicking on the system tray icon.
+- Added auto-reloading when tab fails to load the team.
+- Added the ability to access all of your teams by right clicking the system tray icon.
+
+#### OS X
+- Added colored badges to the menu icon when there are unread channels/mentions.
+- Added an option to minimize the app to the system tray when application window is closed.
+- Added auto-reloading when tab fails to load the team.
+- Added the ability to access all of your teams by right clicking the system tray icon.
+
+#### Linux (Beta)
+- Added an option to show the icon on menu bar (requires libappindicator1 on Ubuntu).
+- Added an option to launch application on login.
+- Added an option to minimize the app to the system tray when application window is closed.
+- Added auto-reloading when tab fails to load the team.
+- Added the ability to access all of your teams by right clicking the system tray icon.
+
+#### Menu Bar
+- New Keyboard Shortcuts
+  - Adjust text size
+    - Ctrl+0 (Menu Bar -> View -> Actual Size): Reset the zoom level.
+    - Ctrl+Plus (Menu Bar -> View -> Zoom In): Increase text size
+    - Ctrl+Minus (Menu Bar -> View -> Zoom Out): Decrease text size
+  - Control window
+    - Ctrl+W (Menu Bar -> Window -> Close): On Linux, this minimizes the main window.
+    - Ctrl+M (Menu Bar -> Window -> Minimize)
+  - Switch teams (these shotcuts also reopen the main window)
+    - Ctrl+{1-9} (Menu Bar -> Window -> *Team name*): Open the *n*-th tab.
+    - Ctrl+Tab or Alt+Command+Right (Menu Bar -> Window -> Select Next Team): Switch to the next window.
+    - Ctrl+Shift+Tab or Alt+Command+Left (Menu Bar -> Window -> Select Previous Team): Switch to the previous window.
+    - Right click on the tray item, to see an overview of all your teams. You can also select one and jump right into it.
+- Added **Help** to the Menu Bar, which includes
+    - Link to [**Mattermost Docs**](docs.mattermost.com)
+    - Field to indicate the application version number.
+
+#### Settings Page
+- Added a "+" button next to the **Teams** label, which allows you to add more teams.
+- Added the ability to edit team information by clicking on the pencil icon to the right of the team name.
+
+### Other Changes
+- Application license changed from MIT License to Apache License, Version 2.0.
+
+### Bug Fixes
+
+#### All platforms
+- Fixed authentication dialog not working for proxy.
+
+#### Windows
+- Fixed the blurred system tray icon.
+- Fixed a redundant description appearing in the pinned start menu on Windows 7.
+
+#### OS X
+- Fixed two icons appearing on a notification.
+
+### Known Issues
+
+#### Linux
+- [Ubuntu - 64 bit] Right clicking taskbar icon and choosing **Quit** only minimizes the app
+- [Ubuntu - 64 bit] [Direct message notification comes as a streak of line instead of a pop up](https://github.com/mattermost/platform/issues/3589)
+
+### Contributors
+
+Many thanks to all our contributors. In alphabetical order:
+
+- [CarmDam](https://github.com/CarmDam), [it33](https://github.com/it33), [jasonblais](https://github.com/jasonblais), [jnugh](https://github.com/jnugh), [magicmonty](https://github.com/magicmonty), [MetalCar](https://github.com/MetalCar), [Razzeee](https://github.com/Razzeee), [yuya-oc](https://github.com/yuya-oc)
+
+## Release v1.2.1 (Beta)
+
+### Fixes
+- Fixed issue to remove "Electron" from appearing in the title bar on startup.
+
+### Improvements
+- Added a dialog to confirm use of non-http(s) protocols prior to opening links. For example, clicking on a link to `file://test` will open a dialog to confirm the user intended to open a file.
+
+#### Windows and OS X
+- Added a right-click menu option for tray icon to open the Desktop application on Windows and OS X.
+
+### Known issues
+- The shortcuts can't switch teams twice in a row.
+- The team pages are not correctly rendered until the window is resized when the zoom level is changed.
+
+## Release v1.2.0 (Beta)
+
+- **Released:** 2016-05-17
+
+This release contains a security update and it is highly recommended that users upgrade to this version.
+
+### Fixes
+- Node.js environment is enabled in the new window.
+- The link other than `http://` and `https://` is opened by clicking.
+
+#### Linux
+- Desktop notification is shown as a dialog on Ubuntu 16.04.
+
+### Improvements
+- Improve the style for tab badges.
+- Add **Allow mixed content** option to render images with `http://`.
+- Add the login dialog for http authentication.
+
+#### OS X
+- Add the option to show the icon on menu bar.
+
+#### Linux
+- Add **.deb** packages to support installation.
+
+### Contributors
+
+Many thanks to all our contributors. In alphabetical order:
+ 
+- [asaadmahmoodspin](https://github.com/asaadmahmoodspin), [jeremycook](https://github.com/jeremycook), [jnugh](https://github.com/jnugh), [jwilander](https://github.com/jwilander), [mgielda](https://github.com/mgielda), [lloeki](https://github.com/lloeki), [yuya-oc](https://github.com/yuya-oc)
+
+## Release v1.1.1 (Beta)
+
+- **Released:** 2016-04-13
+
+### Fixes
+
+#### All platforms
+- **Settings** page doesn't return to the main page when the located path contains a blank.
+
+#### Linux
+- Alt+Shift opens menu on Cinnamon desktop environment.
+
+## Release v1.1.0 (Beta)
+
+- **Released:** 2016-03-30
+
+The `electron-mattermost` project is now the official desktop application for the Mattermost open source project.
+
+### Changes
+
+#### All platforms
+
+- Rename project from `electron-mattermost` to  `desktop`
+- Rename the executable file from `electron-mattermost` to `Mattermost`
+  - The configuration directory is also different from previous versions.
+  - Should execute following command to take over `config.json`.
+    - Windows: `mkdir %APPDATA%\Mattermost & copy %APPDATA%\electron-mattermost\config.json %APPDATA%\Mattermost\config.json`
+    - OS X: `ditto ~/Library/Application\ Support/electron-mattermost/config.json ~/Library/Application\ Support/Mattermost/config.json`
+    - Linux: `mkdir -p ~/.config/Mattermost && cp ~/.config/electron-mattermost/config.json ~/.config/Mattermost/config.json`
+
+### Improvements
+
+#### All platforms
+- Refine application icon.
+- Show error messages when the application failed in loading Mattermost server.
+- Show confirmation dialog to continue connection when there is certificate error.
+- Add validation to check whether both of **Name** and **URL** fields are not blank.
+- Add simple basic HTTP authentication (requires a command line).
+
+#### Windows
+- Show a small circle on the tray icon when there are new messages.
+
+### Fixes
+
+#### Windows
+- **File** > **About** does not bring up version number dialog.
+
+#### Linux
+- **File** > **About** does not bring up version number dialog.
+- Ubuntu: Notification is not showing up.
+- The view crashes when freetype 2.6.3 is used in system.
+
+### Known issues
+
+#### All platforms
+- Basic Authentication is not working.
+- Some keyboard shortcuts are missing. (e.g. <kbd>Ctrl+W</kbd>, <kbd>Command+,</kbd>)
+- Basic authentication requires a command line.
+
+#### Windows
+- Application does not appear properly in Windows volume mixer.

--- a/source/help/apps/desktop-guide.rst
+++ b/source/help/apps/desktop-guide.rst
@@ -1,5 +1,5 @@
 ===================================
-Desktop Application's End User's Guide
+Desktop Application's User Guide
 ===================================
 
 Mattermost desktop applications are available for Windows, Mac and Linux operating systems. 
@@ -30,7 +30,7 @@ To add a new server on the Mattermost instance,
 
 You can now access all teams you have joined in the server once you have saved the settings, and each will appear as a separate tab in the app. 
 
-You may also add a separate instance for each team, if you'd like.
+You may also add each team separately, if you'd like.
 
 Editing servers and teams
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,7 +44,7 @@ To edit a server,
 Removing servers and teams
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To remove a server from your desktop app environment, click on **Remove** next to the server or a team you want removed. Note that this action cannot be undone.
+To remove a server from your desktop app environment, click on **Remove** next to the server or a team you want removed.
 
 Settings
 ---------------------------------------------------------------------
@@ -94,14 +94,14 @@ Note: Enabling mixed content will disable YouTube video previews [due to an issu
 Show icon on Menu Bar (OS X only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When enabled, a black dot indicating unread messages is displayed on the team tab bar.
+When enabled, a red dot with a count of unread mentions is displayed on the team tab bar.
 
 This setting is off by default.
 
 Start app on login (Windows, Linux only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When enabled, Mattermost application starts when you login to your machine.
+When enabled, Mattermost application starts when you log in to your machine.
 
 This setting is on by default.
 

--- a/source/help/apps/desktop-guide.rst
+++ b/source/help/apps/desktop-guide.rst
@@ -57,6 +57,8 @@ Description of each setting is included below this table.
 +-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Allow mixed content                                                           | v1.2.0 +                  | v1.2.0 +                  | v1.2.0 +                  | `yuya-oc <https://github.com/yuya-oc>`_                                                                                                                |
 +-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Show icon on menu bar                                                         | N/A                       | v1.2.0 +                  | N/A                       | `yuya-oc <https://github.com/yuya-oc>`_                                                                                                                |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Start app on login                                                            | v1.3.0 +                  | v1.3.0 +                  | v1.3.0 +                  | `Razzeee <https://github.com/Razzeee>`_                                                                                                                |
 +-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Toggle window visibility when clicking on the tray icon                       | v1.3.0 +                  | N/A                       | N/A                       | `magicmonty <https://github.com/magicmonty>`_                                                                                                          |
@@ -82,6 +84,12 @@ If your server is hosted on `https://`, insecure content, images and scripts wit
 This setting is on by default.
 
 Note: Enabling both secure and insecure content will break YouTube videos. An open issue for ``electron`` on which the app is built is under investigation: https://github.com/electron/electron/issues/2749
+
+**Show icon on Menu Bar** (OS X)
+
+When enabled, a black dot indicating unread messages is displayed on the team tab bar.
+
+This setting is off by default.
 
 **Start app on login**
 

--- a/source/help/apps/desktop-guide.rst
+++ b/source/help/apps/desktop-guide.rst
@@ -1,0 +1,168 @@
+===================================
+Desktop Guide
+===================================
+
+Mattermost desktop applications are available for Windows, Mac and Linux operation systems. 
+
+You can `download the apps directly from our download page <https://about.mattermost.com/downloads/>`_ and you can visit our `installation guides <https://docs.mattermost.com/install/desktop.html>`_ for help during set up.
+
+Below are a few tips to get you started and configuring your experience on the desktop app:
+
+ - `Team Management <https://docs.mattermost.com/help/apps/desktop-guide.html#team-management>`_
+ - `Settings <https://docs.mattermost.com/help/apps/desktop-guide.html#settings>`_
+ - `Menu Bar <https://docs.mattermost.com/help/apps/desktop-guide.html#menu-bar>`_
+
+Team management
+---------------------------------------------------------------------
+
+You can connect to multiple Mattermost servers from a single interface on the desktop app.
+
+**Adding servers and teams**
+
+To add a new server on the Mattermost instance, 
+
+1. Click **Add new team** next to the right of Team Management section.
+2. Enter **Name** and a valid **URL**, which begins with either ``http://`` or ``https://``.
+3. Click **Add**.
+
+You can now access all teams you have joined in the server once you have saved the settings, and each will appear as a separate tab in the app. 
+
+You may also add a separate instance for each team, if you'd like.
+
+**Editing servers and teams**
+
+To edit a server, 
+
+1. To the right of the team or server you want update, click **Edit**.
+2. Edit **Name** and/or **URL**.
+3. Click **Save**.
+
+**Removing servers and teams**
+
+To remove a server from your desktop app environment, click on **Remove** next to the server or a team you want removed. Note that this action cannot be undone.
+
+Settings
+---------------------------------------------------------------------
+
+In addition to `Mattermost Account Settings <https://docs.mattermost.com/help/settings/account-settings.html>`_ , the desktop app provides additional options to customize your experience. 
+
+The Settings Page is available from the `File` menu under `Settings`, and can be accessed with `CTRL + COMMA` on Windows and Linux, and with `CMD + COMMA` on Mac.
+
+Description of each setting is included below this table.
+
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Setting                                                                       | On Windows                | On OS X                   | On Linux                  | Contributors                                                                                                                                           | 
++===============================================================================+===========================+===========================+===========================+========================================================================================================================================================+
+| Hide menu bar                                                                 | v0.5.0 +                  | v0.5.0 +                  | v1.0.3 +                  | `yuya-oc <https://github.com/yuya-oc>`_ (Windows, OS X); `alerque <https://github.com/alerque>`_ (Linux)                                               |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Allow mixed content                                                           | v1.2.0 +                  | v1.2.0 +                  | v1.2.0 +                  | `yuya-oc <https://github.com/yuya-oc>`_                                                                                                                |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Start app on login                                                            | v1.3.0 +                  | v1.3.0 +                  | v1.3.0 +                  | `Razzeee <https://github.com/Razzeee>`_                                                                                                                |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Toggle window visibility when clicking on the tray icon                       | v1.3.0 +                  | N/A                       | N/A                       | `magicmonty <https://github.com/magicmonty>`_                                                                                                          |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Leave app running in notification center when application window is closed    | N/A                       | v1.3.0 +                  | v1.3.0 +                  | `magicmonty <https://github.com/magicmonty>`_ (OS X); `yuya-oc <https://github.com/yuya-oc>`_ (Linux)                                                  |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Show red badge on taskbar icon to indicate unread messages                    | v1.4.0 +                  | v1.4.0 +                  | N/A                       | `Razzeee <https://github.com/Razzeee>`_                                                                                                                |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Flash taskbar icon when a new message is received                             | v1.3.0 +                  | N/A                       | v1.4.0 +                  | `MetalCar <https://github.com/metalcar>`_ (Windows); `jnugh <https://github.com/jnugh>`_ (Linux)                                                       |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
+**Hide menu bar**
+
+Hides the menu bar. When enabled, pressing ``ALT`` will toggle whether the menu bar is shown or hidden.
+
+This setting is off by default.
+
+**Allow mixed content**
+
+If your server is hosted on `https://`, insecure content, images and scripts with `http://` are not rendered by default. This option allows such content to be rendered. If you do enable it, please be mindful of potential security risks shared over `http://` protocols.
+
+This setting is on by default.
+
+Note: Enabling both secure and insecure content will break YouTube videos. An open issue for ``electron`` on which the app is built is under investigation: https://github.com/electron/electron/issues/2749
+
+**Start app on login**
+
+When enabled, Mattermost application starts when you login to your machine.
+
+This setting is on by default.
+
+**Toggle window visibility when clicking on the tray icon** (Windows)
+
+When enabled, clicking on the system tray icon allows you to toggle the window open and minimized.
+
+This setting is off by default.
+
+**Leave app running in notification center when application window is closed.** (OS X, Linux)
+
+When enabled, closing the application window will leave the Mattermost desktop app running in your notification center. This can be useful if you’d like to check for unread mentions while away from the app.
+
+This setting is off by default.
+
+**Show red badge on taskbar icon to indicate unread messages** (Windows, OS X)
+
+If you have multiple active teams (either on a single or multiple servers), having a red badge for unread messages may be annoying as it would likely be displayed most of the time. You may use this setting to configure when the red badge is shown on the taskbar icon. 
+If enabled, a red badge is shown for unread messages with a number count indicating unread mentions. If disabled, a red badge is only shown for unread mentions (with a number count).
+
+This setting is on by default.
+
+**Flash taskbar icon when a new message is received** (Windows, Linux)
+
+Configure whether the taskbar icon flashes when a new message is received on any of your active teams and servers.
+
+This setting is off by default.
+
+Menu Bar
+---------------------------------------------------------------------
+
+The desktop app contains a menu bar with additional features and shortcuts to streamline your experience. 
+
+If the menu bar is hidden, you may use the ``ALT`` key to display the menu. To have the menu displayed at all times, go to the Settings page and uncheck the **Hide menu bar** setting.
+
+Below is a list of menu options with the corresponding keyboard shortcuts. For Mac OS X, replace `CTRL` by `CMD` unless otherwise specified.
+
+**File**
+
+ - Settings (CTRL + COMMA): Opens app settings where you can manage your servers and configure desktop app settings
+ - Exit (CTRL + Q): Closes the application. Labeled `Quit` on Mac OS X
+
+**Edit**
+
+ - Undo (CTRL + Z): Reverses previous action
+ - Redo (CTRL + SHIFT + Z; CTRL + Y): Redoes the most recent action
+ - Cut (CTRL + X): Cuts selected text
+ - Copy (CTRL + C): Copies selected text
+ - Paste (CTRL + V): Pastes text from the clipboard
+ - Select All (CTRL + A): Selects all text in input box
+ - Search in Team (CTRL + S): Sets focus on the Mattermost search box
+ - Search in Channel (CTRL + SHIFT + S): Sets focus on the Mattermost search box and adds `in:[Channel]` to search in current channel
+
+**View**
+
+ - Reload (CTRL + R): Reloads the current page
+ - Clear Cache and Reload (CTRL + SHIFT + R): Clears cached content in application and reloads the current page
+ - Toggle Full Screen (F11): Toggles the application window full screen mode
+ - Actual Size (CTRL + 0) - Resets zoom level to default
+ - Zoom In (CTRL + =; CTRL + SHIFT + =) - Increase font size (zoom in)
+ - Zoom In (CTRL + MINUS) - Decrease font size (zoom out)
+ - Toggle Developer Tools (CTRL + SHIFT + I): Toggles sidebar showing developer tools
+
+**History**
+
+ - Back (ALT + Left Arrow; CMD + [ on OS X): Go to previous page in history
+ - Forward (ALT + Right Arrow; CMD + [ on OS X): Go to next page in history
+
+**Window**
+
+ - Close (CTRL + W) - Closes the application window
+ - Minimize (CTRL + M) - Minimizes the application window to the taskbar
+ - Team Name (CTRL + {1-9}) - Opens the n-th tab
+ - Select Next Team (CTRL + TAB; ALT + CMD + Right Arrow on OS X) - Opens the next tab
+ - Select Previous Team (CTRL+ SHIFT + TAB; ALT + CMD + Left Arrow on OS X) - Open the previous tab
+
+**Help**
+
+ - Mattermost Docs - Links to a parent page for `Desktop applications documentation <https://docs.mattermost.com/install/desktop.html>`_ .
+ - Version - Indicates the desktop application version in use

--- a/source/help/apps/desktop-guide.rst
+++ b/source/help/apps/desktop-guide.rst
@@ -4,9 +4,9 @@ Desktop Application's End User's Guide
 
 Mattermost desktop applications are available for Windows, Mac and Linux operating systems. 
 
-You can `download the apps directly from our download page <https://about.mattermost.com/downloads/>`_ and you can visit our `installation guides <https://docs.mattermost.com/install/desktop.html>`_ for help during set up.
+You can `download the apps directly from our download page <https://about.mattermost.com/downloads/>`_ and visit our `installation guides <https://docs.mattermost.com/install/desktop.html>`_ for help during set up.
 
-For latest updates, please see our `changelog <https://docs.mattermost.com/help/apps/desktop-changelog.html>`_.
+To view the latest updates, please see our `changelog <https://docs.mattermost.com/help/apps/desktop-changelog.html>`_.
 
 Below are a few tips to get you started and configuring your experience on the desktop app:
 

--- a/source/help/apps/desktop-guide.rst
+++ b/source/help/apps/desktop-guide.rst
@@ -2,9 +2,11 @@
 Desktop Application's End User's Guide
 ===================================
 
-Mattermost desktop applications are available for Windows, Mac and Linux operation systems. 
+Mattermost desktop applications are available for Windows, Mac and Linux operating systems. 
 
 You can `download the apps directly from our download page <https://about.mattermost.com/downloads/>`_ and you can visit our `installation guides <https://docs.mattermost.com/install/desktop.html>`_ for help during set up.
+
+For latest updates, please see our `changelog <https://docs.mattermost.com/help/apps/desktop-changelog.html>`_.
 
 Below are a few tips to get you started and configuring your experience on the desktop app:
 

--- a/source/help/apps/desktop-guide.rst
+++ b/source/help/apps/desktop-guide.rst
@@ -1,5 +1,5 @@
 ===================================
-Desktop Guide
+Desktop Application's End User's Guide
 ===================================
 
 Mattermost desktop applications are available for Windows, Mac and Linux operation systems. 
@@ -17,7 +17,8 @@ Team management
 
 You can connect to multiple Mattermost servers from a single interface on the desktop app.
 
-**Adding servers and teams**
+Adding servers and teams
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To add a new server on the Mattermost instance, 
 
@@ -29,7 +30,8 @@ You can now access all teams you have joined in the server once you have saved t
 
 You may also add a separate instance for each team, if you'd like.
 
-**Editing servers and teams**
+Editing servers and teams
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To edit a server, 
 
@@ -37,7 +39,8 @@ To edit a server,
 2. Edit **Name** and/or **URL**.
 3. Click **Save**.
 
-**Removing servers and teams**
+Removing servers and teams
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To remove a server from your desktop app environment, click on **Remove** next to the server or a team you want removed. Note that this action cannot be undone.
 
@@ -50,73 +53,79 @@ The Settings Page is available from the `File` menu under `Settings`, and can be
 
 Description of each setting is included below this table.
 
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Setting                                                                       | On Windows                | On OS X                   | On Linux                  | Contributors                                                                                                                                           | 
-+===============================================================================+===========================+===========================+===========================+========================================================================================================================================================+
-| Hide menu bar                                                                 | v0.5.0 +                  | v0.5.0 +                  | v1.0.3 +                  | `yuya-oc <https://github.com/yuya-oc>`_ (Windows, OS X); `alerque <https://github.com/alerque>`_ (Linux)                                               |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Allow mixed content                                                           | v1.2.0 +                  | v1.2.0 +                  | v1.2.0 +                  | `yuya-oc <https://github.com/yuya-oc>`_                                                                                                                |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Show icon on menu bar                                                         | N/A                       | v1.2.0 +                  | N/A                       | `yuya-oc <https://github.com/yuya-oc>`_                                                                                                                |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Start app on login                                                            | v1.3.0 +                  | v1.3.0 +                  | v1.3.0 +                  | `Razzeee <https://github.com/Razzeee>`_                                                                                                                |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Toggle window visibility when clicking on the tray icon                       | v1.3.0 +                  | N/A                       | N/A                       | `magicmonty <https://github.com/magicmonty>`_                                                                                                          |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Leave app running in notification center when application window is closed    | N/A                       | v1.3.0 +                  | v1.3.0 +                  | `magicmonty <https://github.com/magicmonty>`_ (OS X); `yuya-oc <https://github.com/yuya-oc>`_ (Linux)                                                  |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Show red badge on taskbar icon to indicate unread messages                    | v1.4.0 +                  | v1.4.0 +                  | N/A                       | `Razzeee <https://github.com/Razzeee>`_                                                                                                                |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Flash taskbar icon when a new message is received                             | v1.3.0 +                  | N/A                       | v1.4.0 +                  | `MetalCar <https://github.com/metalcar>`_ (Windows); `jnugh <https://github.com/jnugh>`_ (Linux)                                                       |
-+-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Setting                                                                       | On Windows                | On OS X                   | On Linux                  |
++===============================================================================+===========================+===========================+===========================+
+| Hide menu bar                                                                 | v0.5.0 +                  | v0.5.0 +                  | v1.0.3 +                  |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Allow mixed content                                                           | v1.2.0 +                  | v1.2.0 +                  | v1.2.0 +                  |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Show icon on menu bar                                                         | N/A                       | v1.2.0 +                  | N/A                       |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Start app on login                                                            | v1.3.0 +                  | v1.3.0 +                  | v1.3.0 +                  |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Toggle window visibility when clicking on the tray icon                       | v1.3.0 +                  | N/A                       | N/A                       |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Leave app running in notification center when application window is closed    | N/A                       | v1.3.0 +                  | v1.3.0 +                  |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Show red badge on taskbar icon to indicate unread messages                    | v1.4.0 +                  | v1.4.0 +                  | N/A                       |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
+| Flash taskbar icon when a new message is received                             | v1.3.0 +                  | N/A                       | v1.4.0 +                  |
++-------------------------------------------------------------------------------+---------------------------+---------------------------+---------------------------+
 
-
-**Hide menu bar**
+Hide menu bar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Hides the menu bar. When enabled, pressing ``ALT`` will toggle whether the menu bar is shown or hidden.
 
 This setting is off by default.
 
-**Allow mixed content**
+Allow mixed content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If your server is hosted on `https://`, insecure content, images and scripts with `http://` are not rendered by default. This option allows such content to be rendered. If you do enable it, please be mindful of potential security risks shared over `http://` protocols.
 
 This setting is on by default.
 
-Note: Enabling both secure and insecure content will break YouTube videos. An open issue for ``electron`` on which the app is built is under investigation: https://github.com/electron/electron/issues/2749
+Note: Enabling mixed content will disable YouTube video previews [due to an issue in the underlying technology](https://github.com/electron/electron/issues/2749) used by the Mattermost Desktop app.
 
-**Show icon on Menu Bar** (OS X)
+Show icon on Menu Bar (OS X only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When enabled, a black dot indicating unread messages is displayed on the team tab bar.
 
 This setting is off by default.
 
-**Start app on login**
+Start app on login (Windows, Linux only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When enabled, Mattermost application starts when you login to your machine.
 
 This setting is on by default.
 
-**Toggle window visibility when clicking on the tray icon** (Windows)
+Toggle window visibility when clicking on the tray icon (Windows only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When enabled, clicking on the system tray icon allows you to toggle the window open and minimized.
 
 This setting is off by default.
 
-**Leave app running in notification center when application window is closed.** (OS X, Linux)
+Leave app running in notification center when application window is closed (OS X, Linux only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When enabled, closing the application window will leave the Mattermost desktop app running in your notification center. This can be useful if you’d like to check for unread mentions while away from the app.
 
 This setting is off by default.
 
-**Show red badge on taskbar icon to indicate unread messages** (Windows, OS X)
+Show red badge on taskbar icon to indicate unread messages (Windows, OS X only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you have multiple active teams (either on a single or multiple servers), having a red badge for unread messages may be annoying as it would likely be displayed most of the time. You may use this setting to configure when the red badge is shown on the taskbar icon. 
-If enabled, a red badge is shown for unread messages with a number count indicating unread mentions. If disabled, a red badge is only shown for unread mentions (with a number count).
+When enabled, a red badge is shown on the taskbar icon for unread messages with a number count indicating unread mentions. If disabled, a red badge is only shown for unread mentions (with a number count).
 
 This setting is on by default.
 
-**Flash taskbar icon when a new message is received** (Windows, Linux)
+Flash taskbar icon when a new message is received (Windows, Linux only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Configure whether the taskbar icon flashes when a new message is received on any of your active teams and servers.
 

--- a/source/help/apps/desktop-mvp.rst
+++ b/source/help/apps/desktop-mvp.rst
@@ -1,0 +1,9 @@
+**The following awards have been given for significant contributions to the Mattermost Desktop App:**
+
+Mattermost Desktop Top Contributor: **Kolja Lampe** (`Razzeee <https://github.com/Razzeee>`_) - v1.3 - July 18, 2016
+
+Mattermost Desktop Quality Champion : **Michael Bisbjerg** (`LordMike <https://github.com/LordMike>`_) - v1.3 - July 18, 2016
+
+Mattermost Desktop Quality Champion: **Steve MacQuiddy** - v1.3, July 18 - 2016
+
+Mattermost Desktop Quality Champion: **David Lu** (`DavidLu1997 <https://github.com/DavidLu1997>`_) - v1.3 - July 18, 2016

--- a/source/install/desktop.rst
+++ b/source/install/desktop.rst
@@ -1,0 +1,56 @@
+===================================
+Desktop Applications 
+===================================
+
+Mattermost desktop applications are available for Windows, Mac and Linux operation systems. 
+
+They support all the features of the web experience, plus: 
+
+- Connect to multiple Mattermost servers from a single interface, and switch with shortcut keys.
+- Auto-start Mattermost when a user logs into their machine
+- (Windows) Add Mattermost to Start menu, taskbar and system tray
+- (Mac) Add Mattermost to the applications Dock
+- (Linux) ``Desktop Entry`` for the application to more easily `integrate into a desktop environment <https://wiki.archlinux.org/index.php/Desktop_entries>`_
+
+Below is a list of additional resources:
+
+ - `Guide for configuring your desktop app experience <https://docs.mattermost.com/help/apps/desktop-guide.html>`_
+ - `Changelog <https://docs.mattermost.com/help/apps/desktop-changelog.html>`_
+ - Contributor’s guide (coming soon)
+ - `Source code <https://github.com/mattermost/desktop>`_
+
+You can `download the apps directly from our downloads page <https://about.mattermost.com/downloads/>`_. You may also use the following installation guides for Windows, Mac and Linux:
+
+**Windows 7+:**
+
+1. Download latest version of the Mattermost desktop app:
+
+   - `64-bit version of Windows <https://releases.mattermost.com/desktop/1.3.0/mattermost-setup-1.3.0-win64.exe>`_
+   - `32-bit version of Windows <https://releases.mattermost.com/desktop/1.3.0/mattermost-setup-1.3.0-win32.exe>`_
+
+2. From the ``\Downloads`` directory right-click on the file `mattermost-setup-1.3.0...` and select **Open**.
+
+This will start an installer for the app. Once finished, the Mattermost desktop app will open automatically.
+
+**Mac OS X 10.9+:**
+
+1. Download `latest version of the Mattermost desktop app <https://releases.mattermost.com/desktop/1.3.0/mattermost-desktop-1.3.0-osx.tar.gz>`_
+
+2. From the ``/Downloads`` directory, find ``/mattermost-desktop...`` folder.
+
+   - If one doesn’t exist, from the ``/Downloads`` directory, find a file ending in ``-osx.tar.gz`` and double-click on the file. The ``/mattermost-desktop...`` folder should now be created.
+
+3. From the ``/mattermost-desktop...`` folder, right-click on ``Mattermost`` package and select **Open**. If you see a dialog to confirm the application, choose **Open**.
+
+The Mattermost desktop should open automatically.
+
+**Linux (Beta):**
+
+1. Download latest version of the Mattermost desktop app:
+
+   - `x64.tar.gz <https://releases.mattermost.com/desktop/1.3.0/mattermost-desktop-1.3.0-linux-x64.tar.gz>`_
+   - `ia32.tar.gz <https://releases.mattermost.com/desktop/1.3.0/mattermost-desktop-1.3.0-linux-ia32.tar.gz>`_
+
+2. Extract the archive, then execute ``Mattermost`` which is located inside the extracted directory.
+
+3. If you need a Desktop Entry for the application to integrate into a desktop environment, please refer to https://wiki.archlinux.org/index.php/Desktop_entries

--- a/source/install/desktop.rst
+++ b/source/install/desktop.rst
@@ -1,5 +1,5 @@
 ===================================
-Desktop Applications 
+Desktop Application Install Guides
 ===================================
 
 Mattermost desktop applications are available for Windows, Mac and Linux operation systems. 
@@ -21,7 +21,8 @@ Below is a list of additional resources:
 
 You can `download the apps directly from our downloads page <https://about.mattermost.com/downloads/>`_. You may also use the following installation guides for Windows, Mac and Linux:
 
-**Windows 7+:**
+ Windows 10+, Windows 8.1+, Windows 7+
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download latest version of the Mattermost desktop app:
 
@@ -32,7 +33,8 @@ You can `download the apps directly from our downloads page <https://about.matte
 
 This will start an installer for the app. Once finished, the Mattermost desktop app will open automatically.
 
-**Mac OS X 10.9+:**
+Mac OS X 10.9:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download `latest version of the Mattermost desktop app <https://releases.mattermost.com/desktop/1.3.0/mattermost-desktop-1.3.0-osx.tar.gz>`_
 
@@ -44,7 +46,8 @@ This will start an installer for the app. Once finished, the Mattermost desktop 
 
 The Mattermost desktop should open automatically.
 
-**Linux (Beta):**
+Linux (Beta)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download latest version of the Mattermost desktop app:
 


### PR DESCRIPTION
This is an extension of the [original PR submitted for the desktop docs](https://github.com/mattermost/docs/pull/440). It includes
 - installation guides, which will act as the parent page for other resources
 - changelog
 - MVP page
 - guide to help configure desktop experience 

This is the first version of desktop app docs planned for docs.mattermost.com. Some updates are also planned for the [desktop repo](https://github.com/mattermost/desktop) prior to the v3.4 desktop release.

