### PR TITLE
506 - Corrections to Security Policies TOC (fixes LHS)

### DIFF
--- a/source/process/security.md
+++ b/source/process/security.md
@@ -2,12 +2,12 @@
 
 This document summarizes the internal security policies at Mattermost, Inc. 
 
-- [Security benefits of the Mattermost open source platform](https://docs.mattermost.com/process/security.html#security-benefits-of-an-open-source-platform)
-- [Mattermost Development Guidelines](https://docs.mattermost.com/process/security.html#mattermost-development-guidelines)
-    - [Security Review Checklist](#security-checklist) 
-- [Common Security Related Questions for Enterprises](https://docs.mattermost.com/process/security.html#common-security-related-questions-for-enterprises)
-   - [Governance](https://docs.mattermost.com/process/security.html#governance)
-   - [Software Development Life Cycle (SDLC)](https://docs.mattermost.com/process/security.html#software-development-life-cycle-sdlc)
+- [Security benefits of the Mattermost open source platform](#security-benefits-of-an-open-source-platform)
+- [Mattermost Development Guidelines](#mattermost-development-guidelines)
+  - [Security Review Checklist](#security-review-checklist) 
+- [Common Security Related Questions for Enterprises](#common-security-related-questions-for-enterprises)
+   - [Governance](#governance)
+   - [Software Development Life Cycle (SDLC)](#software-development-life-cycle-sdlc)
    - [Training](#training)
    - [Validation](#validation)
    - [Security Response](#security-response)
@@ -47,8 +47,7 @@ The commercial Mattermost Enterprise Edition extends the security and productivi
 * Critical updates are delivered as dot releases, for example a critical update to release `3.1.0` would be named `3.1.1`.
 * Customers and subscribers to the Mattermost Insiders mailing list receive notification about all critical updates. 
 
-### Security Review Checklist
-
+### Security Review Checklist 
 In addition to checklists for quality and reliability, code changes receive multiple reviews for the following system security design principles: 
 
 - Reducing information disclosure 
@@ -142,7 +141,7 @@ In addition to checklists for quality and reliability, code changes receive mult
 1. Are personnel training plans and records kept for internal company compliance purposes?
    - Yes.
 
-### Validation<a name="validation"></a>
+### Validation
 
 1. Are results from the execution of test plans reported and used to track and justify release readiness?
    - Yes. 


### PR DESCRIPTION
Corrects issues cited in #506 

Removed anchor tags from the end of the headers, and replaced TOC named-anchor links w/ the permalink names generated by Sphinx.  The LHS menu was corrupt because of the inline anchors (HTML) being added to the headers w/in the markdown file.

LHS now looks as it should.

![image](https://cloud.githubusercontent.com/assets/600643/18691947/cd5f5624-7f64-11e6-952d-4a11175c3e00.png)
