### PR TITLE
Update push.rst

### DIFF
--- a/source/deployment/push.rst
+++ b/source/deployment/push.rst
@@ -225,11 +225,13 @@ Here are solutions to common troubleshooting requests:
 Internal proxy configuration needed for outbound requests to HPNS 
 ^^^^^^ 
 
-When Mattermost is deployed on a private network without direct access to the internet, special steps are needed to allow the Mattermost server to reach the Mattermost Hosted Push Notification Service at ``https://push.mattermost.com`` to send outbound push notifications. 
+1. Make sure your proxy server is properly configured to support SSL. Confirm it works by checking the URL at `https://www.digicert.com/help/`. 
 
-Please speak with your internal IT staff responsible for routing and whitelisting outbound connections to enable requests to be sent from your Mattermost server to ``https://push.mattermost.com``.
+2. Setup a proxy to forward requests to `https://push.mattermost.com`. 
 
-If you need to enter an internal proxy server to relay outbound messages to ``https://push.mattermost.com`` go to **System Console** > **Notification Settings**, set **Enable Push Notifications** to ``Manually enter Push Notification Service location`` and enter the proxy in the **Push Notification Server** field.  
+3. In Mattermost set **System Console** > **Notification Settings** > **Mobile Push** > **Enable Push Notifications** to "Manually enter Push Notification Service location" and enter the URL of your proxy in the **Push Notification Server** field.
+
+Depending on how your proxy is configured you may need to add a port number and create a URL like `https://push.internalproxy.com:8000` mapped to `https://push.mattermost.com`
 
 Error message: “We would not connect to the Mattermost server or the server is running an incompatible version”
 ^^^^^^ 


### PR DESCRIPTION
Making edits per Ian's request:

1. Make sure your proxy server is properly configured to support SSL. Confirm it works by checking the URL at `https://www.digicert.com/help/`. 
2. Setup a proxy to forward requests to `https://push.mattermost.com`. 
3. In Mattermost set **System Console** > **Notification Settings** > **Mobile Push** > **Enable Push Notifications** to "Manually enter Push Notification Service location" and enter the URL of your proxy in the **Push Notification Server** field. 

Depending on how your proxy is configured you may need to add a port number and create a URL like `https://push.internalproxy.com:8000` mapped to `https://push.mattermost.com`