### PR TITLE
Added MySQL database instructions

### DIFF
--- a/source/install/prod-ubuntu.rst
+++ b/source/install/prod-ubuntu.rst
@@ -135,31 +135,30 @@ Set up MySQL Database Server
 Set up Mattermost Server
 ------------------------
 
-For the purposes of this guide we will assume this server has an IP
-   address of ``10.10.10.2``
+For the purposes of this guide we will assume this server has an IP address of ``10.10.10.2``
 
-2. Create a mattermost user and group
+1. Create a mattermost user and group
 
     - ``sudo adduser --system --group mattermost``
 
-3. Change to the mattermost home directory.
+2. Change to the mattermost home directory.
 
     ``cd /home/mattermost``
 
-4. Download `any version of the Mattermost Server <https://docs.mattermost.com/administration/upgrade.html#version-archive>`_ by typing:
+3. Download `the latest version of the Mattermost Server <https://docs.mattermost.com/administration/upgrade.html#version-archive>`_ by typing:
 
    -  ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
    -  Where ``vX.X.X`` is the latest version.
 
-5. Extract the Mattermost Server files by typing:
+4. Extract the Mattermost Server files by typing:
 
    -  ``sudo tar -xvzf *.gz``
 
-6. Change the user and group of the extracted files to mattermost
+5. Change the user and group of the extracted files to mattermost
 
    - ``sudo chown -R mattermost:mattermost mattermost/``
 
-7. Create the storage directory for files. We assume you will have
+6. Create the storage directory for files. We assume you will have
    attached a large drive for storage of images and files. For this
    setup we will assume the directory is located at
    ``/mattermost/data``.
@@ -175,12 +174,12 @@ For the purposes of this guide we will assume this server has an IP
    -  ``cd /home/mattermost/mattermost/config``
    -  Edit the file by typing:
    -  ``vi config.json``
-   - If you are using PostgreSQL:
-      1. Set ``DriverName":`` to ``"postgres"``
-      2. Set ``"DataSource:"`` to the following value: ``"postgres://mmuser:mmuser_password@10.10.10.1:5432/mattermost?sslmode=disable&connect_timeout=10"``
-   - If you are using MySQL:
-      1. Set ``DriverName":`` to ``"mysql"``
-      2. Set ``"DataSource":`` to the following value: ``"mmuser:mmuser_password@tcp(10.10.10.1:3306)/mattermost?charset=utf8"``
+   -  If you are using PostgreSQL:    
+     -  Set ``DriverName":`` to ``"postgres"``
+     -  Set ``"DataSource:"`` to the following value: ``"postgres://mmuser:mmuser_password@10.10.10.1:5432/mattermost?sslmode=disable&connect_timeout=10"``
+   -  If you are using MySQL:    
+     -  Set ``DriverName":`` to ``"mysql"``
+     -  Set ``"DataSource":`` to the following value: ``"mmuser:mmuser_password@tcp(10.10.10.1:3306)/mattermost?charset=utf8"``
    -  You can continue to edit configuration settings in
       ``config.json`` or use the System Console described in a later
       section to finish the configuration.

--- a/source/install/prod-ubuntu.rst
+++ b/source/install/prod-ubuntu.rst
@@ -3,7 +3,7 @@
 Production Install on Ubuntu 14.04 LTS
 ======================================
 
-Install Mattermost in production mode on one, two or three machines, using the following steps: 
+Install Mattermost in production mode on one, two or three machines, using the following steps:
 
 - `Install Ubuntu Server (x64) 14.04 LTS <#production-install-on-ubuntu-14-04-lts>`_
 - `Set up Database Server <#set-up-database-server>`_
@@ -19,7 +19,7 @@ Install Ubuntu Server (x64) 14.04 LTS
    servers will be used for the Proxy, Mattermost (must be
    x64), and Database.
 
-   -  **Optional:** You can also use a **1 machine setup** (Proxy, Mattermost and Database on one machine) or a **2 machine setup** (Proxy and Mattermost on one machine, Database on another) depending on your data center standards. 
+   -  **Optional:** You can also use a **1 machine setup** (Proxy, Mattermost and Database on one machine) or a **2 machine setup** (Proxy and Mattermost on one machine, Database on another) depending on your data center standards.
 
 2. Make sure the system is up to date with the most recent security
    patches.
@@ -30,9 +30,14 @@ Install Ubuntu Server (x64) 14.04 LTS
 Set up Database Server
 ----------------------
 
+Install and set up either PostgreSQL 9.3 or MySQL 5.6.
+
+Set up PostreSQL
+~~~~~~~~~~~~~~~~
+
 1.  For the purposes of this guide we will assume this server has an IP
     address of 10.10.10.1
-2.  Install PostgreSQL 9.3+ (or MySQL 5.6+)
+2.  Install PostgreSQL 9.3+
 
     -  ``sudo apt-get install postgresql postgresql-contrib``
 
@@ -80,11 +85,11 @@ Set up Database Server
 12. Reload Postgres database
 
     -  ``sudo /etc/init.d/postgresql reload``
-    
+
     check with netstat command to see postgresql actually running on given ip and port
-    
+
     - ``sudo netstat -anp | grep 5432``
-    
+
     try restarting the postgresql service if reload won't work
 
     - ``sudo service postgresql restart``
@@ -94,6 +99,38 @@ Set up Database Server
 
     -  ``psql --host=10.10.10.1 --dbname=mattermost --username=mmuser --password``
     -  ``mattermost=> \q``
+
+Set up MySQL Database Server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Install MySQL 5.6.
+
+    - ``sudo apt-get install mysql-server-5.6``
+
+2. Log in to MySQL as root.
+
+    - ``mysql -u root -p``
+
+    When prompted, enter the root password that you created when installing MySQL.
+
+3. Create the Mattermost user.
+
+    - ``mysql> create user 'mmuser'@'%' identified by 'mmuser-password';``
+
+    **Notes**:
+
+    1. Use a password that is more secure than 'mmuser-password'
+    2. The '%' means that mmuser can connect from any machine on the network.   However, it's more secure to use the IP address of the machine that hosts Mattermost. For example, if you install Mattermost on the machine with IP address 10.10.10.2, then use the following command:
+
+    - ``mysql> create user 'mmuser'@'10.10.10.2' identified by 'mmuser-password';``
+
+4. Create the Mattermost database.
+
+    - ``mysql> create database mattermost;``
+
+5. Grant access privileges to the mmuser
+
+    - ``mysql> grant all privileges on mattermost.* to 'mmuser'@'%';``
 
 Set up Mattermost Server
 ------------------------
@@ -109,8 +146,8 @@ Set up Mattermost Server
 4. Download `any version of the Mattermost Server <https://docs.mattermost.com/administration/upgrade.html#version-archive>`_ by typing:
 
    -  ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
-   -  Where ``vX.X.X`` is typically the latest Mattermost release version, which is currently ``v3.3.0``. 
-   
+   -  Where ``vX.X.X`` is typically the latest Mattermost release version, which is currently ``v3.3.0``.
+
 5. Unzip the Mattermost Server by typing:
 
    -  ``tar -xvzf mattermost-X.X.X-linux-amd64.tar.gz``

--- a/source/install/prod-ubuntu.rst
+++ b/source/install/prod-ubuntu.rst
@@ -113,7 +113,7 @@ Set up MySQL Database Server
 
     When prompted, enter the root password that you created when installing MySQL.
 
-3. Create the Mattermost user.
+3. Create the Mattermost user, 'mmuser'.
 
     - ``mysql> create user 'mmuser'@'%' identified by 'mmuser-password';``
 
@@ -128,52 +128,60 @@ Set up MySQL Database Server
 
     - ``mysql> create database mattermost;``
 
-5. Grant access privileges to the mmuser
+5. Grant access privileges to the user 'mmuser'
 
     - ``mysql> grant all privileges on mattermost.* to 'mmuser'@'%';``
 
 Set up Mattermost Server
 ------------------------
 
-1. For the purposes of this guide we will assume this server has an IP
+For the purposes of this guide we will assume this server has an IP
    address of ``10.10.10.2``
-2. For the sake of making this guide simple we located the files at
-   ``/home/ubuntu/mattermost``. In the future we will give guidance for
-   storing under ``/opt``.
-3. We have also elected to run the Mattermost Server as the ``ubuntu``
-   account for simplicity. We recommend setting up and running the
-   service under a ``mattermost`` user account with limited permissions.
+
+2. Create a mattermost user and group
+
+    - ``sudo adduser --system --group mattermost``
+
+3. Change to the mattermost home directory.
+
+    ``cd /home/mattermost``
+
 4. Download `any version of the Mattermost Server <https://docs.mattermost.com/administration/upgrade.html#version-archive>`_ by typing:
 
    -  ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
-   -  Where ``vX.X.X`` is typically the latest Mattermost release version, which is currently ``v3.3.0``.
+   -  Where ``vX.X.X`` is the latest version.
 
-5. Unzip the Mattermost Server by typing:
+5. Extract the Mattermost Server files by typing:
 
-   -  ``tar -xvzf mattermost-X.X.X-linux-amd64.tar.gz``
+   -  ``sudo tar -xvzf *.gz``
 
-6. Create the storage directory for files. We assume you will have
+6. Change the user and group of the extracted files to mattermost
+
+   - ``sudo chown -R mattermost:mattermost mattermost/``
+
+7. Create the storage directory for files. We assume you will have
    attached a large drive for storage of images and files. For this
    setup we will assume the directory is located at
    ``/mattermost/data``.
 
    -  Create the directory by typing:
    -  ``sudo mkdir -p /mattermost/data``
-   -  Set the ubuntu account as the directory owner by typing:
-   -  ``sudo chown -R ubuntu /mattermost``
+   -  Set the mattermost account as the directory owner by typing:
+   -  ``sudo chown -R mattermost:mattermost /mattermost``
 
 7. Configure Mattermost Server by editing the config.json file at
-   ``/home/ubuntu/mattermost/config``
+   ``/home/mattermost/config``
 
-   -  ``cd ~/mattermost/config``
+   -  ``cd /home/mattermost/mattermost/config``
    -  Edit the file by typing:
    -  ``vi config.json``
-   -  replace ``DriverName": "mysql"`` with ``DriverName": "postgres"``
-   -  replace
-      ``"DataSource": "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8"``
-      with
-      ``"DataSource": "postgres://mmuser:mmuser_password@10.10.10.1:5432/mattermost?sslmode=disable&connect_timeout=10"``
-   -  Optionally you may continue to edit configuration settings in
+   - If you are using PostgreSQL:
+      1. Set ``DriverName":`` to ``"postgres"``
+      2. Set ``"DataSource:"`` to the following value: ``"postgres://mmuser:mmuser_password@10.10.10.1:5432/mattermost?sslmode=disable&connect_timeout=10"``
+   - If you are using MySQL:
+      1. Set ``DriverName":`` to ``"mysql"``
+      2. Set ``"DataSource":`` to the following value: ``"mmuser:mmuser_password@tcp(10.10.10.1:3306)/mattermost?charset=utf8"``
+   -  You can continue to edit configuration settings in
       ``config.json`` or use the System Console described in a later
       section to finish the configuration.
 
@@ -199,8 +207,8 @@ Set up Mattermost Server
           stop on runlevel [016]
           respawn
           limit nofile 50000 50000
-          chdir /home/ubuntu/mattermost
-          setuid ubuntu
+          chdir /home/mattermost/mattermost
+          setuid mattermost
           exec bin/platform
 
    -  You can manage the process by typing:


### PR DESCRIPTION
I installed Mattermost on a vanilla Ubuntu 14.04 VM and it works fine. I did not set up the Nginx proxy though. Also, I could not get the Upstart daemon working; I don't know if that's my fault or the instructions. I assume it's a problem on my end.

Also:
- changed from using 'ubuntu' user to creating and using 'mattermost' user. (The user 'unbuntu' does not exist on a vanilla install of 14.04)
- future-proofed by removing 'currently v3.3.0' from step 4 in the Set up Mattermost Server section.
- changed the Mattermost file extract command to 'sudo tar -xvzf *.gz' which is easier to type
