### PR TITLE
Fix JS style-guide syntax error

### DIFF
--- a/source/developer/style-guide.md
+++ b/source/developer/style-guide.md
@@ -115,7 +115,7 @@ if (something)
 ```javascript
 // Correct
 function getStr(stuff) {
-    return "This is the ${stuff} string";
+    return `This is the ${stuff} string`;
 }
 
 // Incorrect


### PR DESCRIPTION
Strings section for javascript was using double quotes instead
of back tick.