### PR TITLE
Fix the URL of Docker installation for Ubuntu

### DIFF
--- a/source/developer/developer-setup.md
+++ b/source/developer/developer-setup.md
@@ -49,7 +49,7 @@ Any issues? Please let us know on our forums at: https://forum.mattermost.org/
 
 ### Ubuntu ###
 
-1. Download Docker, follow the instructions at [https://docs.docker.com/installation/ubuntulinux/](https://docs.docker.com/installation/ubuntulinux/)
+1. Download Docker, follow the instructions at [https://docs.docker.com/engine/installation/linux/ubuntulinux/](https://docs.docker.com/engine/installation/linux/ubuntulinux/)
 2. Set up your dockerhost address
 	1. Edit your `/etc/hosts` file to include the following line  
 		- `127.0.0.1 dockerhost`


### PR DESCRIPTION
https://docs.docker.com/installation/ubuntulinux/ is not available.
https://docs.docker.com/engine/installation/linux/ubuntulinux/ seems new instruction.