### PR TITLE
Remove flicker when navigating to links internal to the current page

### DIFF
--- a/source/myscript.js
+++ b/source/myscript.js
@@ -8,18 +8,5 @@ $(document).ready(function(){
 		var sidebarScrollPosition = $('.wy-menu-vertical li.current>a').offset().top;
 		$('.wy-side-scroll').scrollTop(sidebarScrollPosition-120);
 	}
-
-	var centerScroll = function(position){
-		setTimeout(function(){
-			var centerScrollPosition = $('.wy-nav-content-wrap').scrollTop();
-			$('.wy-nav-content-wrap').scrollTop(centerScrollPosition-position);
-		},100);
-	};
-
-	$('.wy-menu-vertical li.current li').on('click', function(){
-		centerScroll(80);
-	});
-
-	centerScroll(75);
-
+	
 });


### PR DESCRIPTION
Currently when selecting a link in the LHS that is internal to the currently displayed page, there is a noticeable "flicker" due to a recentering function.  This was previously used to accommodate the page content floating underneath of the header.  Since that issue has been fixed, the recentering is unecessary.  Removing this removes the "flicker".

To visualize the issue:
1. Navigate to the [Upgrade Guide](https://docs.mattermost.com/administration/upgrade.html)
2. Within the left-hand-sidebar, select a subsection of the document, such as **Upgrade Enterprise Edition**

Notice the flicker on the screen as the page scrolls, and then recenters (again).

Removing the javascript removes the flicker.