### PR TITLE
Fix WorkingDirectory path in RHEL 7 install guides

### DIFF
--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -171,7 +171,7 @@ Set up Mattermost Server
 
           [Service]
           Type=simple
-          WorkingDirectory=/opt/mattermost/bin
+          WorkingDirectory=/opt/mattermost
           User=mattermost
           ExecStart=/opt/mattermost/bin/platform
           PIDFile=/var/spool/mattermost/pid/master.pid

--- a/source/install/prod-rhel-7.rst
+++ b/source/install/prod-rhel-7.rst
@@ -171,7 +171,7 @@ Set up Mattermost Server
 
           [Service]
           Type=simple
-          WorkingDirectory=/opt/mattermost/bin
+          WorkingDirectory=/opt/mattermost
           User=mattermost
           ExecStart=/opt/mattermost/bin/platform
           PIDFile=/var/spool/mattermost/pid/master.pid


### PR DESCRIPTION
Addresses https://github.com/mattermost/platform/issues/4133

The RHEL 7 install guides don't appear to use the correct data folder, and hence Mattermost cannot read uploaded profile pictures or attachments after installation.

This PR should resolve the issue.