### PR TITLE
Fixed trailing space in JSX tags

### DIFF
--- a/source/developer/style-guide.md
+++ b/source/developer/style-guide.md
@@ -149,11 +149,11 @@ The following is a subset of what ESLint checks for. ESLint is always the author
     propertyOne="1"
     propertyTwo="2"
 >
-  <Child />
+  <Child/>
 </Tag>
 
 // Correct
-<Tag propertyOne="1" />
+<Tag propertyOne="1"/>
 ```
 
 ### Naming
@@ -164,5 +164,5 @@ The following is a subset of what ESLint checks for. ESLint is always the author
 
 ```xml
 // Correct
-<ReactComponent propertyOne="value" />
+<ReactComponent propertyOne="value"/>
 ```


### PR DESCRIPTION
ESLint already enforces that there shouldn't be a space there