### PR TITLE
[PostGres Install] Ubuntu: Typo in listen_addresses

### DIFF
--- a/source/install/prod-ubuntu.rst
+++ b/source/install/prod-ubuntu.rst
@@ -68,7 +68,7 @@ Set up Database Server
 10. Allow Postgres to listen on all assigned IP Addresses
 
     -  ``sudo vi /etc/postgresql/9.3/main/postgresql.conf``
-    -  Uncomment ``listen_addresses`` and change ``localhost`` to ``\*``
+    -  Uncomment ``listen_addresses`` and change ``localhost`` to ``*``
 
 11. Alter pg\_hba.conf to allow the mattermost server to talk to the
     postgres database


### PR DESCRIPTION
I might be wrong but:

When following the doc I have

```
root@mattermost:~# sudo service postgresql restart
 * Restarting PostgreSQL 9.3 database server     
 * The PostgreSQL server failed to start. Please check the log output:
2016-10-26 07:27:01 UTC LOG:  could not translate host name "/*", service "5432" to address: Name or service not known
2016-10-26 07:27:01 UTC WARNING:  could not create listen socket for "/*"
2016-10-26 07:27:01 UTC FATAL:  could not create any TCP/IP sockets
```

The PR fixed this. I can restart PostGres
```
root@mattermost:~# sudo service postgresql restart
 * Restarting PostgreSQL 9.3 database server
```

Keep up the good work !