### PR TITLE
PLT-4320 Fix table of contents links in install guides

### DIFF
--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -5,11 +5,11 @@ Production Enterprise Install on RHEL 6.6
 
 Install Mattermost Enterprise Edition in production mode on one, two or three machines, using the following steps: 
 
-- `Install Red Hat Enterprise Linux (x64) 6.6 <#install-red-hat-enterprise-linux-x64-66>`_
-- `Set up Database Server <#set-up-database-server>`_
-- `Set up Mattermost Server <#set-up-mattermost-server>`_
-- `Set up NGINX Server <#set-up-nginx-server>`_
-- `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_
+- `Install Red Hat Enterprise Linux (x64) 6.6`_
+- `Set up Database Server`_
+- `Set up Mattermost Server`_
+- `Set up NGINX Server`_
+- `Test setup and configure Mattermost Server`_
 
 Install Red Hat Enterprise Linux (x64) 6.6
 ------------------------------------------

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -5,11 +5,11 @@ Production Enterprise Install on RHEL 7.1+
 
 Install Mattermost Enterprise Edition in production mode on one, two or three machines, using the following steps:
 
-- `Install Red Hat Enterprise Linux (x64) 7.1 <#install-red-hat-enterprise-linux-x64-71>`_
-- `Set up Database Server <#set-up-database-server>`_
-- `Set up Mattermost Server <#set-up-mattermost-server>`_
-- `Set up NGINX Server <#set-up-nginx-server>`_
-- `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_
+- `Install Red Hat Enterprise Linux (x64) 7.1+`_
+- `Set up Database Server`_
+- `Set up Mattermost Server`_
+- `Set up NGINX Server`_
+- `Test setup and configure Mattermost Server`_
 
 
 Install Red Hat Enterprise Linux (x64) 7.1+

--- a/source/install/ee-prod-ubuntu.rst
+++ b/source/install/ee-prod-ubuntu.rst
@@ -5,11 +5,11 @@ Production Enterprise Install on Ubuntu 14.04 LTS
 
 Install Mattermost Enterprise Edition in production mode on one, two or three machines, using the following steps: 
 
-- `Install Ubuntu Server (x64) 14.04 LTS <#production-install-on-ubuntu-14-04-lts>`_
-- `Set up Database Server <#set-up-database-server>`_
-- `Set up Mattermost Server <#set-up-mattermost-server>`_
-- `Set up NGINX Server <#set-up-nginx-server>`_
-- `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_
+- `Install Ubuntu Server (x64) 14.04 LTS`_
+- `Set up Database Server`_
+- `Set up Mattermost Server`_
+- `Set up NGINX Server`_
+- `Test setup and configure Mattermost Server`_
 
 
 Install Ubuntu Server (x64) 14.04 LTS

--- a/source/install/prod-rhel-6.rst
+++ b/source/install/prod-rhel-6.rst
@@ -5,11 +5,11 @@ Production Install on RHEL 6.6
 
 Install Mattermost in production mode on one, two or three machines, using the following steps: 
 
-- `Install Red Hat Enterprise Linux (x64) 6.6 <#install-red-hat-enterprise-linux-x64-66>`_
-- `Set up Database Server <#set-up-database-server>`_
-- `Set up Mattermost Server <#set-up-mattermost-server>`_
-- `Set up NGINX Server <#set-up-nginx-server>`_
-- `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_
+- `Install Red Hat Enterprise Linux (x64) 6.6`_
+- `Set up Database Server`_
+- `Set up Mattermost Server`_
+- `Set up NGINX Server`_
+- `Test setup and configure Mattermost Server`_
 
 Install Red Hat Enterprise Linux (x64) 6.6
 ------------------------------------------

--- a/source/install/prod-rhel-7.rst
+++ b/source/install/prod-rhel-7.rst
@@ -5,11 +5,11 @@ Production Install on RHEL 7.1+
 
 Install Mattermost in production mode on one, two or three machines, using the following steps: 
 
-- `Install Red Hat Enterprise Linux (x64) 7.1 <#install-red-hat-enterprise-linux-x64-71>`_
-- `Set up Database Server <#set-up-database-server>`_
-- `Set up Mattermost Server <#set-up-mattermost-server>`_
-- `Set up NGINX Server <#set-up-nginx-server>`_
-- `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_
+- `Install Red Hat Enterprise Linux (x64) 7.1+`_
+- `Set up Database Server`_
+- `Set up Mattermost Server`_
+- `Set up NGINX Server`_
+- `Test setup and configure Mattermost Server`_
 
 
 Install Red Hat Enterprise Linux (x64) 7.1+

--- a/source/install/prod-ubuntu.rst
+++ b/source/install/prod-ubuntu.rst
@@ -5,11 +5,11 @@ Production Install on Ubuntu 14.04 LTS
 
 Install Mattermost in production mode on one, two or three machines, using the following steps: 
 
-- `Install Ubuntu Server (x64) 14.04 LTS <#production-install-on-ubuntu-14-04-lts>`_
-- `Set up Database Server <#set-up-database-server>`_
-- `Set up Mattermost Server <#set-up-mattermost-server>`_
-- `Set up NGINX Server <#set-up-nginx-server>`_
-- `Test setup and configure Mattermost Server <#test-setup-and-configure-mattermost-server>`_
+- `Install Ubuntu Server (x64) 14.04 LTS`_
+- `Set up Database Server`_
+- `Set up Mattermost Server`_
+- `Set up NGINX Server`_
+- `Test setup and configure Mattermost Server`_
 
 
 Install Ubuntu Server (x64) 14.04 LTS


### PR DESCRIPTION
On install pages (eg https://docs.mattermost.com/install/prod-rhel-6.html), if you click the links "Set up Database Server", "Set up Mattermost Server", etc, the page currently does not jump. 

This should fix the issue. 