### PR TITLE
Team names now at least 2 characters long instead of 4

### DIFF
--- a/source/help/getting-started/creating-teams.md
+++ b/source/help/getting-started/creating-teams.md
@@ -1,8 +1,6 @@
 # Creating Teams
 ___
 
-This documentation refers to Mattermost v3.0. For v2.2, see [archived documentation](http://docs.mattermost.com/archives/docs-v2.2.html#creating-teams).
-
 New teams can be created if the System Admin has *Enable Team Creation* set to true from the System Console.
 
 ## Methods to Create a Team
@@ -22,13 +20,13 @@ This is the display name of your team that appears in menus and headings.
 
 - It can contain any letters, numbers or symbols.
 - It is case sensitive.
-- It must be 4 - 15 characters in length.
+- It must be 2 - 15 characters in length.
 
 #### Team URL
 The team URL is part of the web address that navigates to your team on the system domain, `https://domain.com/teamurl/`. 
 
 - It may contain only lowercase letters, numbers and dashes.
 - It must start with a letter and cannot end in a dash.
-- It must be 4 - 15 characters in length.
+- It must be 2 - 15 characters in length.
 
 If the System Admin has *Restrict Team Names* set to true, the team URL cannot start with the following restricted words: www, web, admin, support, notify, test, demo, mail, team, channel, internal, localhost, dockerhost, stag, post, cluster, api, oauth.

--- a/source/help/settings/team-settings.md
+++ b/source/help/settings/team-settings.md
@@ -15,7 +15,7 @@ General settings under the **Team Settings** > **General** configure how a team 
 
 Your **Team Name** is displayed on the sign-in page, and in the top of the left-hand sidebar for your team. 
 
-You can enter a name up to 22 characters in length. The length of team names is limited to ensure readability.
+You can enter a name up to 15 characters in length. The length of team names is limited to ensure readability.
 
 #### Allow anyone to join this team
 


### PR DESCRIPTION
Also fixes a bug in `../settings/team-settings.md` as team name should only be at most 15 characters long.
