### PR TITLE
Mobile / Fix LHS Menu Button

### DIFF
--- a/source/theme.css
+++ b/source/theme.css
@@ -274,6 +274,9 @@ header .header__links li a {
 	header .links__icon {
 		display: block;
 	}
+	.wy-nav-top {
+		display: none;
+	}
 	.wy-side-nav-search {
 		position: relative;
 	}


### PR DESCRIPTION
Github Issue #631 

Removed the sphinx-generated top navigation bar from the mobile view entirely.  It only provided access to the table of contents, which on a mobile view, was not responsive.  In the mobile view, relying on the use of the TOC tree and use of the breadcrumbs for navigation.  Will need to enable a means to access the search box w/in the mobile view from any page in a later PR....

