### PR TITLE
Fixed a typo

### DIFF
--- a/source/install/prod-ubuntu-1404.rst
+++ b/source/install/prod-ubuntu-1404.rst
@@ -256,6 +256,7 @@ Set up NGINX Server
    -  Below is a sample nginx configuration optimized for performance:
 
     ::
+    
         upstream backend {
             server 10.10.10.2:8065;
         }


### PR DESCRIPTION
A missing LF was causing the code block to not display correctly in Step 7 of _Set up NGINX Server_