### PR TITLE
Fixing typo in config-settings.rst

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -66,7 +66,7 @@ Connection Security
 **TLS**: Encrypts the communication between Mattermost and your server. See [documentation](https://docs.mattermost.com/install/setup-tls.html) for more details.
 
 +---------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ConnectionSecurity": ""`` with options ``""`` and ``tls`` for the above settings respectively  |
+| This feature's ``config.json`` setting is ``"ConnectionSecurity": ""`` with options ``""`` and ``TLS`` for the above settings respectively  |
 +---------------------------------------------------------------------------------------------------------------------------------------------+
 
 TLS Certificate File


### PR DESCRIPTION
Entering "tls" in the config file will cause running mattermost to fail with the message "Invalid value for webserver connection security.".
However, "TLS" works and will correctly configure mattermost to run with HTTPS.