### PR TITLE
Remove warning of trailing "/" in site URLs from Windows guides

### DIFF
--- a/source/install/prod-windows-2012.rst
+++ b/source/install/prod-windows-2012.rst
@@ -375,7 +375,7 @@ Finish Mattermost Server Setup
    
 4. Update **General** > **Configuration** settings to properly configure your reverse proxy by entering `https://mattermost.example.com` as the **Site URL**
 
-   .. attention:: Failure to properly set the Site URL properly __will__ result in unexpected behavior.  Do not include the trailing '/' on the URL.
+   .. attention:: Failure to properly set the Site URL properly __will__ result in unexpected behavior.
 
 5. Update **Notification** > **Email** settings to setup an SMTP email service. The example below assumes AmazonSES.
 


### PR DESCRIPTION
Looks like we already removed the warning from our other docs.

This was fixed a couple of releases ago where the trailing "/" is gracefully handled by the Mattermost server.