### PR TITLE
Adding credits to core team handbook

### DIFF
--- a/source/guides/core.rst
+++ b/source/guides/core.rst
@@ -1,10 +1,10 @@
 Core Team Handbook
-------------------
+==================
 
 This handbook is a guide to working at Mattermost. Please consider it--along with all our documentation--as a work-in-progress and constantly updating to best achieve our shared mission. 
 
 Development Process
-=========================
+-------------------
 
 .. toctree::
    :maxdepth: 2
@@ -18,7 +18,7 @@ Development Process
    /process/marketing-guidelines*
 
 Documentation Style Guide
-=========================
+-------------------------
 
 .. toctree::
    :maxdepth: 3
@@ -26,7 +26,7 @@ Documentation Style Guide
    /process/sg_mattermost-doc-style.rst
 
 Joining the Team 
-=========================
+-------------------------
 
 .. toctree::
    :maxdepth: 2
@@ -37,3 +37,6 @@ Joining the Team
    /process/security*
    /process/training*
    /process/people-ops*
+
+
+**Credits:** Our culture and process draws from the fantastic work of `Wordpress <https://wordpress.org/about/philosophy/>`_, `GitLab <https://gitlab.com/gitlab-com/www-gitlab-com/tree/master/source/handbook>`_, `Pixar <https://www.amazon.com/Creativity-Inc-Overcoming-Unseen-Inspiration/dp/0812993012>`_ and `Intel <https://www.amazon.com/High-Output-Management-Andrew-Grove/dp/0679762884/ref=sr_1_1?s=books&ie=UTF8&qid=1481613210&sr=1-1&keywords=high+output+management>`_ in different ways. 


### PR DESCRIPTION
- Adding credits since we're pulling from these different sources pretty frequently. 
- Also adjusting headings to match style guide