### PR TITLE
Fix broken links to formatting text document.

### DIFF
--- a/source/developer/webhooks-incoming.md
+++ b/source/developer/webhooks-incoming.md
@@ -5,7 +5,7 @@ Incoming webhooks allow external applications, written in the programming langua
 A couple key points:
 
 - **Mattermost incoming webhooks are Slack-compatible.** If you've used Slack's incoming webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../help/messaging/formatting-text.rst) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
+- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../help/messaging/formatting-text.rst) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown.
 
 _Example:_
 

--- a/source/developer/webhooks-incoming.md
+++ b/source/developer/webhooks-incoming.md
@@ -5,7 +5,7 @@ Incoming webhooks allow external applications, written in the programming langua
 A couple key points:
 
 - **Mattermost incoming webhooks are Slack-compatible.** If you've used Slack's incoming webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../help/messaging/formatting-text.md) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
+- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through [markdown support](../help/messaging/formatting-text.rst) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
 
 _Example:_
 
@@ -74,7 +74,7 @@ Additional Notes:
 
 4. With **Enable Overriding of Icon from Webhooks** turned on, you can similarly change the icon the message posts with by providing a link to an image in the `icon_url` parameter of your payload. For example, ```payload={"icon_url": "http://somewebsite.com/somecoolimage.jpg", "text": "Hello, this is some text."}``` will post using whatever image is located at `http://somewebsite.com/somecoolimage.jpg` as the icon for the post
 
-5. Also, as mentioned previously, [markdown](../help/messaging/formatting-text.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return and bold text for "the"
+5. Also, as mentioned previously, [markdown](../help/messaging/formatting-text.rst) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return and bold text for "the"
 
 6. Including `@username` in the JSON payload will trigger a mention notification for the person with the specified username. Channels can be mentioned by including `@channel` or `<!channel>`. For example:  ```payload={"text": "<!channel> this is a notification""}``` would create a message that mentions `@channel`
 

--- a/source/developer/webhooks-outgoing.md
+++ b/source/developer/webhooks-outgoing.md
@@ -5,7 +5,7 @@ Outgoing webhooks allow external applications, written in the programming langua
 A couple key points:
 
 - **Mattermost outgoing webhooks are Slack-compatible.** If you've used Slack's outgoing webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost outgoing webhooks support full markdown.** When an integration responds with a message to post, it will have access to a rich range of formatting unavailable in Slack that is made possible through [markdown support](../help/messaging/formatting-text.md) in Mattermost. This includes headings, formatted fonts, tables, inline images and other options supported by [Mattermost Markdown]
+- **Mattermost outgoing webhooks support full markdown.** When an integration responds with a message to post, it will have access to a rich range of formatting unavailable in Slack that is made possible through [markdown support](../help/messaging/formatting-text.rst) in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown.
 - **Outgoing webhooks are only supported in public channels.** If you need something that works in a private channel, consider using a [Slash Command](http://docs.mattermost.com/developer/slash-commands.html). 
 
 _Example:_
@@ -99,7 +99,7 @@ Additional Notes:
 
 2. With **Enable Overriding of Icon from Webhooks** turned on, you can similarly change the icon the message posts with by providing a link to an image in the `icon_url` parameter of your JSON response. For example, ```{"icon_url": "http://somewebsite.com/somecoolimage.jpg", "text": "Hello, this is some text."}``` will post using whatever image is located at `http://somewebsite.com/somecoolimage.jpg` as the icon for the post
 
-3. Also, as mentioned previously, [markdown](../help/messaging/formatting-text.md) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return, italicized text for "text" and bold text for "the"
+3. Also, as mentioned previously, [markdown](../help/messaging/formatting-text.rst) can be used to create richly formatted payloads, for example: ```payload={"text": "# A Header\nThe _text_ below **the** header."}``` creates a messages with a header, a carriage return, italicized text for "text" and bold text for "the"
 
 4. Including `@username` in the JSON payload will trigger a mention notification for the person with the specified username. Channels can be mentioned by including `@channel` or `<!channel>`. For example:  ```payload={"text": "<!channel> this is a notification""}``` would create a message that mentions `@channel`
 


### PR DESCRIPTION
Links referring to "markdown support" are broken on the following page. This PR is a quick fix.
https://docs.mattermost.com/developer/webhooks-incoming.html