### PR TITLE
Restore search capability (waiting on theme release for permanent fix)

### DIFF
--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -6,4 +6,14 @@
 
 {% block footer %}
 	{% include "header.html" %}
+	<script type="text/javascript">
+		/* Temporary fix for the search capability. Fix has been committed to the theme's master;
+		   however, waiting a new release to the theme.  This fix should remain in place until that
+		   time.  sphinx_rtd_theme is current v0.1.10a0. Commit for the fix in the 
+		   theme can be found at: https://github.com/snide/sphinx_rtd_theme/commit/a5e0e304
+		 */
+        if(DOCUMENTATION_OPTIONS) {
+			DOCUMENTATION_OPTIONS.SOURCELINK_SUFFIX = '{{ sourcelink_suffix }}' 
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
This PR includes a "hotfix" that will restore the search capability.  An update to Sphinx 1.5 included changes to the search capability, which in conjunction with the latest `sphinx_rtd_theme` caused errors to occur when searching for _many_ keywords.

Once `sphinx_rtd_theme` publishes a release that includes [their fix](https://github.com/snide/sphinx_rtd_theme/commit/a5e0e304), this hotfix can be removed.

On a positive note, the search capability in Sphinx 1.5 is significantly better, and searching for keywords such as Upgrade and Reply will now return all of the appropriate results, resolving theses issues:

Issue #718: Error when searching for "Reply" in docs.mattermost.com
Issue #583: Fix search for "Upgrade"