### PR TITLE
Added missing word to description of -version command

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -206,6 +206,6 @@ CLI Documentation:
           Example:
               platform -upgrade_db_30
 
-      -version                          Display the current of the Mattermost platform
+      -version                          Display the current version of the Mattermost platform
 
       -help                             Displays this help page


### PR DESCRIPTION
The description for the -version CLI command was missing the word *version*. This PR changes the description to the following text: *Display the current version of the Mattermost platform*