### PR TITLE
Update formatting-text.rst

### DIFF
--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -1,10 +1,10 @@
 Formatting Text
-----------------
+===============
 
 Markdown makes it easy to format messages. Type a message as you normally would, and use these rules to render it with special formatting.
 
 Emojis
-=======
+------
 
 Open the emoji autocomplete by typing ``:`` followed by two characters. A full list of emojis can be found `here <http://www.emoji-cheat-sheet.com/>`_. It is also possible to create your own `Custom Emoji <http://docs.mattermost.com/help/settings/custom-emoji.html>`_ if the emoji you want to use doesn't exist.
 
@@ -15,7 +15,7 @@ Renders as:
 .. image:: ../../images/Emoji1.PNG
 
 Text Style
-==========
+----------
 
 You can use either ``_`` or ``*`` around a word to make it italic. Use two to make it bold.
 
@@ -29,7 +29,7 @@ You can use either ``_`` or ``*`` around a word to make it italic. Use two to ma
   :width: 100px
 
 Links
-======
+-----
 
 Create labeled links by putting the desired text in square brackets and the associated link in normal brackets.
 
@@ -38,11 +38,11 @@ Create labeled links by putting the desired text in square brackets and the asso
 Renders as: `Check out Mattermost! <https://about.mattermost.com/>`_
 
 Headings
-========
+--------
 
 Make a heading by typing # and a space before your title. For smaller headings, use more #’s.
 
-.. code::
+.. code-block:: none
 
   ## Large Heading
   ### Smaller Heading
@@ -54,7 +54,7 @@ Renders as:
 
 Alternatively, you can underline the text using ``===`` or ``---`` to create headings.
 
-.. code::
+.. code-block:: none
 
   Large Heading
   -------------
@@ -64,11 +64,11 @@ Renders as:
 .. image:: ../../images/Headings2.PNG
 
 Lists
-=====
+-----
 
 Create a list by using ``*`` or ``-`` as bullets. Indent a bullet point by adding two spaces in front of it.
 
-.. code::
+.. code-block:: none
 
   * item one
   * item two
@@ -83,19 +83,36 @@ Renders as:
 
 Make it an ordered list by using numbers instead:
 
-.. code::
+.. code-block:: none
 
   1. Item one
-  2. Item two
+  1. Item two
+  1. item three
 
 Renders as:
 
 #. Item one
 #. Item two
+#. Item three
+
+You can also start a list at any number:
+
+.. code-block:: none
+
+  4. The first list number is 4.
+  1. The second list number is 5.
+  1. The third list number is 6.
+
+Renders as:
+
+4. The first list number is 4.
+5. The second list number is 5.
+6. The third list number is 6.
+
 
 Make a task list by including square brackets:
 
-.. code::
+.. code-block:: none
 
   - [ ] Item one
   - [ ] Item two
@@ -106,13 +123,14 @@ Renders as:
 .. image:: ../../images/checklist.PNG
 
 Code Block
-==========
+----------
 
 Create a code block by indenting each line by four spaces, or by placing ``````` on the line above and below your code.
 
 Example:
 
-.. code::
+.. code-block:: none
+
 
   ```
   code block
@@ -120,7 +138,8 @@ Example:
 
 Renders as:
 
-.. code::
+.. code-block:: none
+
 
   code block
 
@@ -133,7 +152,8 @@ Supported languages are:
 
 Example:
 
-.. code::
+.. code-block:: none
+
 
   ``` go
   package main
@@ -163,22 +183,24 @@ Renders as:
 
 
 In-line Code
-============
+------------
 
 Create in-line monospaced font by surrounding it with backticks.
 
-.. code::
+.. code-block:: none
+
 
   `monospace`
 
 Renders as: ``monospace``.
 
 In-line Images
-==============
+--------------
 
 Create in-line images using an ``!`` followed by the alt text in square brackets and the link in normal brackets. Add hover text by placing it in quotes after the link.
 
-.. code::
+.. code-block:: none
+
 
   ![alt text that shows when a link is broken](broken-link "hover text")
 
@@ -202,7 +224,7 @@ and
   :target: https://github.com/mattermost/platform
 
 Lines
-=====
+-----
 
 Create a line by using three ``*``, ``_``, or ``-``.
 
@@ -211,7 +233,7 @@ Create a line by using three ``*``, ``_``, or ``-``.
 ---------------------------------------------------------------------------
 
 Block quotes
-============
+------------
 
 Create block quotes using ``>``.
 
@@ -220,11 +242,12 @@ Create block quotes using ``>``.
 .. image:: ../../images/blockQuotes.PNG
 
 Tables
-======
+------
 
 Create a table by placing a dashed line under the header row and separating the columns with a pipe ``|``. (The columns don’t need to line up exactly for it to work). Choose how to align table columns by including colons ``:`` within the header row.
 
-.. code::
+.. code-block:: none
+
 
   | Left-Aligned  | Center Aligned  | Right Aligned |
   | :------------ |:---------------:| -----:|
@@ -238,11 +261,12 @@ Renders as:
 
 
 Math Formulas
-=============
+-------------
 
 Create formulas by using LaTeX in a ``latex`` `Code Block`_
 
-.. code::
+.. code-block:: none
+
 
   ```latex
   X_k = \sum_{n=0}^{2N-1} x_n \cos \left[\frac{\pi}{N} \left(n+\frac{1}{2}+\frac{N}{2}\right) \left(k+\frac{1}{2}\right) \right]


### PR DESCRIPTION
1. Added numbered list restart to the ordered list section.
2. Changed '.. code::' to '.. code-block:: none' to prevent Sphinx from using Python syntax highlighting.
3. Updated section title underlines iaw style guide.