### PR TITLE
Update nodejs install version for Ubuntu.

### DIFF
--- a/source/developer/developer-setup.md
+++ b/source/developer/developer-setup.md
@@ -61,7 +61,7 @@ Any issues? Please let us know on our forums at: https://forum.mattermost.org/
 	4. Set GOROOT (optional) in your `~/.bash_profile`
 		- `export GOROOT=/usr/local/go/`
 6. Install Node.js  
-	- `curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -`  
+	- `curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -`
 	- `sudo apt-get install -y nodejs`
 7. Fork Mattermost on GitHub.com from [https://github.com/mattermost/platform](https://github.com/mattermost/platform), then:
 	1. `cd ~/go`  


### PR DESCRIPTION
The 5.x releases give a warning about being deprecated and no longer
getting security fixes. Current master works fine with 6.x, which is
still maintained.