### PR TITLE
Add troubleshooting for YouTube videos

### DIFF
--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -60,6 +60,15 @@ Locked out of System Administrator account
 
 If email sign-in was turned off before the System Administrator switched sign-in methods, sign up for a new account and promote it to System Administrator from the command line.
 
+Youtube Videos show a "Video not found" preview
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, make sure the YouTube video exists by pasting a link to the video on your browser.
+
+If you are using the Mattermost Desktop Apps, please ensure you have installed version 3.5.0 or later.
+
+If you have specified `a Google API key <https://docs.mattermost.com/administration/config-settings.html#google-api-key>`_ to enable the display of titles for embedded YouTube video previews, re-generate the key.
+
 Mattermost Error Messages
 -------------------------
 

--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -63,11 +63,9 @@ If email sign-in was turned off before the System Administrator switched sign-in
 YouTube Videos show a "Video not found" preview
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, make sure the YouTube video exists by pasting a link to the video into your browser's address bar.
-
-If you are using the Mattermost Desktop App, please ensure you have installed version 3.5.0 or later.
-
-If you have specified `a Google API key <https://docs.mattermost.com/administration/config-settings.html#google-api-key>`_ to enable the display of titles for embedded YouTube video previews, regenerate the key.
+1. First, make sure the YouTube video exists by pasting a link to the video into your browser's address bar.
+2. If you are using the Mattermost Desktop App, please ensure you have installed version 3.5.0 or later.
+3. If you have specified `a Google API key <https://docs.mattermost.com/administration/config-settings.html#google-api-key>`_ to enable the display of titles for embedded YouTube video previews, regenerate the key.
 
 Mattermost Error Messages
 -------------------------

--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -60,14 +60,14 @@ Locked out of System Administrator account
 
 If email sign-in was turned off before the System Administrator switched sign-in methods, sign up for a new account and promote it to System Administrator from the command line.
 
-Youtube Videos show a "Video not found" preview
+YouTube Videos show a "Video not found" preview
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, make sure the YouTube video exists by pasting a link to the video on your browser.
+First, make sure the YouTube video exists by pasting a link to the video into your browser's address bar.
 
-If you are using the Mattermost Desktop Apps, please ensure you have installed version 3.5.0 or later.
+If you are using the Mattermost Desktop App, please ensure you have installed version 3.5.0 or later.
 
-If you have specified `a Google API key <https://docs.mattermost.com/administration/config-settings.html#google-api-key>`_ to enable the display of titles for embedded YouTube video previews, re-generate the key.
+If you have specified `a Google API key <https://docs.mattermost.com/administration/config-settings.html#google-api-key>`_ to enable the display of titles for embedded YouTube video previews, regenerate the key.
 
 Mattermost Error Messages
 -------------------------


### PR DESCRIPTION
We should probably revisit the troubleshooting page.

I added couple of steps for YouTube videos after at least two community members had problems with them (one using an older version of the desktop app; another had to regenerate the API key)