### PR TITLE
Update slack import command

### DIFF
--- a/source/administration/migrating.rst
+++ b/source/administration/migrating.rst
@@ -94,7 +94,7 @@ Migrating from Slack using the Mattermost CLI
 
 2. Run the following Mattermost CLI command, with the name of a team you have already created:
 
-   ``$ platform -slack_import -team_name="your-team" -import_archive /path/to/your-slack-export.zip``
+   ``$ platform import slack team_name /path/to/your-slack-export.zip``
 
 Using the Imported Team
 +++++++++++++++++++++++


### PR DESCRIPTION
`platform -slack_import` has been deprecated.

```
---------------------------------------------------------------------------------------------
DEPRECATED! All previous commands are now deprecated. Run: platform help to see the new ones.
---------------------------------------------------------------------------------------------
Running Slack Import. This may take a long time for large teams or teams with many messages.
```