### PR TITLE
Update docs for shortcuts to follow text formatting guidelines

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -396,7 +396,7 @@ Thanks also to those who reported bugs that benefited the release, in alphabetic
 - If a webhook is sent to a direct message channel that has not been created yet, the channel is now automatically created
 
 #### Keyboard Shortcuts
-- `CTRL + SHIFT + M` now toggles recent mentions results
+- CTRL/CMD+SHIFT+M now toggles recent mentions results
 
 #### Team Settings
 - Team names are now restricted to be a minimum of two characters long, instead of four, to support abbreviated team names
@@ -410,8 +410,8 @@ Thanks also to those who reported bugs that benefited the release, in alphabetic
 ### Bug Fixes
 - Files can now be sent in Direct Messages across teams
 - Correct login method now shown in System Console user lists
-- Channel switcher (`CTRL + K`) no longer throws an error when switching to a user outside of your current team
-- Channel switcher (CTRL / CMD + K) now works for creating new Direct Message channels
+- Channel switcher (CTRL/CMD+K) no longer throws an error when switching to a user outside of your current team
+- Channel switcher (CTRL/CMD+K) now works for creating new Direct Message channels
 - Channels on the left hand side now sort numerically, alphabetically, and based on locale
 - Fixed incorrect error message when trying a team URL with one character
 - `/join` no longer throws an error for non-admin accounts
@@ -675,7 +675,7 @@ Release date: 2016-09-16
 - Messages can now be flagged from the search results list
 - Count of unread mentions are no longer mixed when switching between multiple teams.
 - Recent Mentions search on mobile no longer contains `@all`
-- For those using the mobile view on desktop, Ctrl+Enter now sends messages on mobile web view 
+- For those using the mobile view on desktop, CTRL+ENTER now sends messages on mobile web view 
 - User removed from team now shows up in DM list under "Outside this team"
 - Mentions update properly when team is switched
 
@@ -744,7 +744,7 @@ The following config settings will only work on servers with an Enterprise Licen
 - Files sent in private chat to members in a different team are not accessible.
 - YouTube video links show as “Video not found” on Desktop App if "Allow mixed content" is turned on.
 - “More” option under Direct Message list no longer shows count of team members not in your direct message list.
-- On Firefox, CTRL/CMD + U keyboard shortcut to upload a file doesn’t work.
+- On Firefox, CTRL/CMD+U keyboard shortcut to upload a file doesn’t work.
 - Webhook attachments don’t show up in search results.
 - Messages sometimes don't appear deleted until the page is refreshed.
 - When joining a channel from a public link, the page sometimes loads for a long time and requires a refresh.
@@ -839,8 +839,8 @@ Expected release date: 2016-08-16
 - Mention notifications can be turned on for any new messages in comment threads that you participate in.
 
 #### Keyboard Shortcuts
-- Added icons next to channel names and improved sorting in the channel switcher (`CTRL/CMD+K`).
-- Keyboard shortcuts that open modals can now toggle them open and closed (`CTRL/CMD+SHIFT+A`, `CTRL/CMD+K`).
+- Added icons next to channel names and improved sorting in the channel switcher (CTRL/CMD+K).
+- Keyboard shortcuts that open modals can now toggle them open and closed (CTRL/CMD+SHIFT+A, CTRL/CMD+K).
 
 #### Integrations
 - Added an option to trigger outgoing webhook if the first word starts with the specified trigger word.
@@ -998,7 +998,7 @@ The following config settings will only work on servers with an Enterprise Licen
 - YouTube videos show as “Video not found” on Desktop App.
 - “More” option under Direct Message list no longer shows count of team members not in your direct message list.
 - /join sometimes throws an error.
-- On Firefox, CTRL/CMD + U keyboard shortcut doesn’t work.
+- On Firefox, CTRL/CMD+U keyboard shortcut doesn’t work.
 - Sometimes only the last character typed in the channel switcher appears.
 - Webhook attachments don’t show up in search results.
 - Count of unread mentions are sometimes mixed when switching between multiple teams.
@@ -1149,7 +1149,7 @@ Release date: 2016-07-16
 - Direct Messages modal loads faster since it is no longer cleared from memory each time it closes.
 - Graphs in the **System Console > Site Statistics** now have the same start date for comparison.
 - Fixed an issue where new languages are not added by default. Any server which is upgraded to Mattermost v3.1 will need to manually set **System Console > Localization > Available Languages** blank to have new languages added by default.
-- Previously, a few shortcuts that used `CTRL` were overwriting existing messaging shortcuts in Mac. This has been changed so they only work with `CMD`. See [documentation](http://docs.mattermost.com/help/messaging/keyboard-shortcuts.html) for more details.
+- Previously, a few shortcuts that used CTRL were overwriting existing messaging shortcuts in Mac. This has been changed so they only work with CMD. See [documentation](http://docs.mattermost.com/help/messaging/keyboard-shortcuts.html) for more details.
 - Email body now contains the `siteURL` when inviting a user by email via CLI (command line interface)
 - YouTube videos now stop playing when collapsed.
 - Fixed error when adding an incoming webhook to a public channel the user is currently not in.
@@ -1226,7 +1226,7 @@ The following config settings will only work on servers with an Enterprise Licen
 - “More” option under Direct Message list no longer shows count of team members not in your direct message list.
 - Webhook attachments don't show up in search results.
 - On Firefox, System Console sidebar completely disappears when an AD/LDAP setting is saved.
-- On Firefox, `CTRL/CMD + U` keyboard shortcut doesn't work.
+- On Firefox, CTRL/CMD+U keyboard shortcut doesn't work.
 - `/join` sometimes throws an error.
 - Sometimes only the last character typed in the channel switcher appears.
 - Formatting of multiple lists in a row breaks markdown.
@@ -1401,7 +1401,7 @@ The following config settings will only work on servers with an Enterprise Licen
 - Clicking on a desktop notification from another team doesn’t open the team.
 - Webhook attachments don't show up in search results.
 - On Firefox, System Console sidebar completely disappears when an AD/LDAP setting is saved
-- On Firefox, `CTRL/CMD + U` keyboard shortcut doesn't work
+- On Firefox, CTRL/CMD+U keyboard shortcut doesn't work
 - Copying and pasting an image from a browser doesn't work
 - Youtube videos continue playing when collapsed
 - Code theme under Account Settings > Display > Theme doesn't save unless entered in vectorized form

--- a/source/help/apps/desktop-changelog.rst
+++ b/source/help/apps/desktop-changelog.rst
@@ -512,7 +512,7 @@ This release contains a security update and it is highly recommended that users 
 -  v1.1.1, released 2016-04-13
 
    -  If the specified team URL on the **Settings** page contains an additional space, the app now properly redirects to the team page
-   -  ``Alt+Shift`` now opens the menu on Cinnamon desktop environment.
+   -  ALT+SHIFT now opens the menu on Cinnamon desktop environment.
 
 -  v1.1.0, released 2016-03-30
 

--- a/source/help/getting-started/messaging-basics.rst
+++ b/source/help/getting-started/messaging-basics.rst
@@ -4,7 +4,7 @@ Messaging Basics
 --------------
 
 **Write messages** using the text input box at the bottom of Mattermost.
-Press **ENTER** to send a message. Use **SHIFT+ENTER** to create a new
+Press ENTER to send a message. Use SHIFT+ENTER to create a new
 line without sending a message.
 
 **Reply to messages** by clicking the reply arrow next to the message

--- a/source/help/getting-started/organizing.rst
+++ b/source/help/getting-started/organizing.rst
@@ -49,11 +49,11 @@ Navigating to channels using the keyboard
 
 Another reason why channel names in Mattermost are limited to 22 characters is the common use of keyboard shortcuts to jump quickly to channels. 
 
-User use ``CTRL+K`` to bring up a dialog where they can quickly type in the first few letters of a channel, which triggers auto-complete, and hitting ``ENTER`` to jump to the channel directly. 
+User use CTRL+K to bring up a dialog where they can quickly type in the first few letters of a channel, which triggers auto-complete, and hitting ENTER to jump to the channel directly. 
 
 Keeping names clear and short lets users navigate large collections of channels quickly. 
 
-.. tip :: Use ``SHIFT+ALT+UP`` and ``SHIFT+ALT+DOWN`` to move up and down to the next channel with an unread message. 
+.. tip :: Use ALT+SHIFT+UP and ALT+SHIFT+DOWN to move up and down to the next channel with an unread message. 
 	
 ---------------------------------------------------
 How to organize channels

--- a/source/help/messaging/keyboard-shortcuts.rst
+++ b/source/help/messaging/keyboard-shortcuts.rst
@@ -3,7 +3,7 @@ Keyboard Shortcuts
 
 Keyboard shortcuts perform operations in Mattermost to help you navigate through channels and make a more efficient use of your keyboard. See also `slash commands <http://docs.mattermost.com/help/messaging/executing-commands.html>`_ for alternate ways to help carry out actions with a keyboard instead of a mouse.
 
-To display a list of available keyboard shortcuts, type ``CTRL/CMD + /``, or ``/shortcuts``.
+To display a list of available keyboard shortcuts, type CTRL+/ (CMD+/ on Mac), or ``/shortcuts``.
 
 Navigation
 ==========

--- a/source/help/messaging/sending-messages.md
+++ b/source/help/messaging/sending-messages.md
@@ -13,10 +13,10 @@ Reply to a message by clicking the reply icon next to any message text. This act
 When composing a reply in the right-hand sidebar, click the expand/collapse icon with two arrows at the top of the sidebar to make things easier to read.
 
 ## Posting a Message
-Write a message by typing into the text input box, then press **ENTER** to send it. Use **Shift + ENTER** to create a new line without sending a message. To send messages by pressing **Ctrl+Enter** go to **Main Menu > Account Settings > Send messages on Ctrl + Enter**.
+Write a message by typing into the text input box, then press ENTER to send it. Use SHIFT+ENTER to create a new line without sending a message. To send messages by pressing CTRL+ENTER go to **Main Menu > Account Settings > Send messages on CTRL+ENTER**.
 
 ## Editing a Message
-Edit a message by clicking the **[...]** icon next to any message that you’ve sent, then click **Edit**. When you're done editing, press **ENTER** to save the changes. Message edits do not trigger new @mention notifications, desktop notifications or notification sounds.
+Edit a message by clicking the **[...]** icon next to any message that you’ve sent, then click **Edit**. When you're done editing, press ENTER to save the changes. Message edits do not trigger new @mention notifications, desktop notifications or notification sounds.
 
 ## Deleting a message
 Delete a message by clicking the **[...]** icon next to any message that you've sent, then click **Delete**. System and Team Admins can delete any message on their system or team.

--- a/source/help/settings/account-settings.md
+++ b/source/help/settings/account-settings.md
@@ -149,8 +149,8 @@ Select what language Mattermost displays in the user interface. Options include:
 ## Advanced
 Setting to configure when messages are sent.
 
-#### Send Messages on Ctrl+Enter
-If enabled, press **Enter** to insert a new line and **Ctrl + Enter** posts the message. If disabled, **Shift + Enter** inserts a new line and **Enter** posts the message.
+#### Send Messages on CTRL+ENTER
+If enabled, press ENTER to insert a new line and CTRL+ENTER posts the message. If disabled, SHIFT+ENTER inserts a new line and ENTER posts the message.
 
 #### Enable Post Formatting
 This setting controls whether post formatting is rendered. When "On", posts will be rendered with [markdown formatting](http://docs.mattermost.com/help/messaging/formatting-text.html), emoji, autolinked URLs, and line breaks. When "Off", the raw text will be shown. 

--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -148,7 +148,7 @@ Set up Mattermost Server
    -  ``./platform``
    -  You should see a console log like ``Server is listening on :8065``
       letting you know the service is running.
-   -  Stop the server for now by typing ``Ctrl-C``
+   -  Stop the server for now by typing ``CTRL+C``
 
 8. Setup Mattermost to use the Upstart daemon which handles supervision
    of the Mattermost process.

--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -148,7 +148,7 @@ Set up Mattermost Server
    -  ``./platform``
    -  You should see a console log like ``Server is listening on :8065``
       letting you know the service is running.
-   -  Stop the server for now by typing ``CTRL+C``
+   -  Stop the server for now by pressing CTRL+C
 
 8. Setup Mattermost to use the Upstart daemon which handles supervision
    of the Mattermost process.

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -156,7 +156,7 @@ Set up Mattermost Server
    -  ``./platform``
    -  You should see a console log like ``Server is listening on :8065``
       letting you know the service is running.
-   -  Stop the server for now by typing ``Ctrl-C``
+   -  Stop the server for now by pressing CTRL+C
 
 8. Set up Mattermost to use the systemd init daemon which handles
    supervision of the Mattermost process. 

--- a/source/install/ee-prod-ubuntu.rst
+++ b/source/install/ee-prod-ubuntu.rst
@@ -135,7 +135,7 @@ Set up Mattermost Server
    -  ``./platform``
    -  You should see a console log like ``Server is listening on :8065``
       letting you know the service is running.
-   -  Stop the server for now by typing ``ctrl-c``
+   -  Stop the server for now by typing ``CTRL+C``
 
 9. Setup Mattermost to use the Upstart daemon which handles supervision
    of the Mattermost process.

--- a/source/install/ee-prod-ubuntu.rst
+++ b/source/install/ee-prod-ubuntu.rst
@@ -135,7 +135,7 @@ Set up Mattermost Server
    -  ``./platform``
    -  You should see a console log like ``Server is listening on :8065``
       letting you know the service is running.
-   -  Stop the server for now by typing ``CTRL+C``
+   -  Stop the server for now by pressing CTRL+C
 
 9. Setup Mattermost to use the Upstart daemon which handles supervision
    of the Mattermost process.

--- a/source/install/install-rhel-66-mattermost.rst
+++ b/source/install/install-rhel-66-mattermost.rst
@@ -54,7 +54,7 @@ Assume that the IP address of this server is 10.10.10.2
     b. Start the Mattermost server as the user *mattermost*:
       ``sudo -u mattermost ./platform``
 
-  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing ``CTRL+C`` in the terminal window.
+  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 
 9. Setup Mattermost to use the Upstart daemon which handles supervision of the Mattermost process.
 

--- a/source/install/install-rhel-71-mattermost.rst
+++ b/source/install/install-rhel-71-mattermost.rst
@@ -54,7 +54,7 @@ Assume that the IP address of this server is 10.10.10.2
     b. Start the Mattermost server as the user mattermost:
       ``sudo -u mattermost ./platform``
    
-  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing ``CTRL+C`` in the terminal window.
+  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 
 9. Set up Mattermost to use the systemd init daemon which handles
    supervision of the Mattermost process.

--- a/source/install/install-ubuntu-1404-mattermost.rst
+++ b/source/install/install-ubuntu-1404-mattermost.rst
@@ -57,7 +57,7 @@ Assume that the IP address of this server is 10.10.10.2
     b. Start the Mattermost server as the user mattermost:
       ``sudo -u mattermost ./platform``
    
-  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing CTRL+C in the terminal window.
+  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing ``CTRL+C`` in the terminal window.
   
 8. Setup Mattermost to use the Upstart daemon which handles supervision of the Mattermost process.
 

--- a/source/install/install-ubuntu-1404-mattermost.rst
+++ b/source/install/install-ubuntu-1404-mattermost.rst
@@ -57,7 +57,7 @@ Assume that the IP address of this server is 10.10.10.2
     b. Start the Mattermost server as the user mattermost:
       ``sudo -u mattermost ./platform``
    
-  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing ``CTRL+C`` in the terminal window.
+  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
   
 8. Setup Mattermost to use the Upstart daemon which handles supervision of the Mattermost process.
 

--- a/source/install/install-ubuntu-1404-mattermost.rst
+++ b/source/install/install-ubuntu-1404-mattermost.rst
@@ -57,7 +57,7 @@ Assume that the IP address of this server is 10.10.10.2
     b. Start the Mattermost server as the user mattermost:
       ``sudo -u mattermost ./platform``
    
-  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing ``CTRL+C`` in the terminal window.
+  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing CTRL+C in the terminal window.
   
 8. Setup Mattermost to use the Upstart daemon which handles supervision of the Mattermost process.
 

--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -57,7 +57,7 @@ Assume that the IP address of this server is 10.10.10.2.
     b. Start the Mattermost server as the user mattermost:
       ``sudo -u mattermost ./platform``
    
-  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by typing ``CTRL+C`` in the terminal window.
+  When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 
 8. Setup Mattermost to use *systemd* for starting and stopping.
 

--- a/source/install/prod-debian.rst
+++ b/source/install/prod-debian.rst
@@ -156,7 +156,7 @@ Set up Mattermost Server
    -  ``./platform``
    -  You should see a console log like ``Server is listening on :8065``
       letting you know the service is running.
-   -  Stop the server for now by typing ``ctrl-c``
+   -  Stop the server for now by pressing CTRL+C
 
 8. Setup Mattermost to use the systemd init daemon which handles
    supervision of the Mattermost process

--- a/source/install/prod-windows-2012.rst
+++ b/source/install/prod-windows-2012.rst
@@ -152,7 +152,7 @@ Set up Mattermost Server
 
       .. image:: ../images/windows_2_platform_exe_test.png
 
-   d. Stop the server for now by typing ``ctrl-c``
+   d. Stop the server by pressing CTRL+C
 
 Configure the Firewall
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/source/install/prod-windows-2012.rst
+++ b/source/install/prod-windows-2012.rst
@@ -152,7 +152,7 @@ Set up Mattermost Server
 
       .. image:: ../images/windows_2_platform_exe_test.png
 
-   d. Stop the server by pressing CTRL+C
+   d. Stop the server by typing ``CTRL+C`` in the terminal window.
 
 Configure the Firewall
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/source/install/prod-windows-2012.rst
+++ b/source/install/prod-windows-2012.rst
@@ -152,8 +152,8 @@ Set up Mattermost Server
 
       .. image:: ../images/windows_2_platform_exe_test.png
 
-   d. Stop the server by typing ``CTRL+C`` in the terminal window.
-
+   d. Stop the server by pressing CTRL+C
+   
 Configure the Firewall
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Update docs for shortcuts to follow [text formatting guidelines](https://docs.mattermost.com/process/documentation-guidelines.html#text-formatting).

The couple lines that appear in platform help text submitted here https://github.com/mattermost/platform/pull/5533