### PR TITLE
Add legacy CLI commands back to the docs

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -34,6 +34,11 @@ From the directory where the Mattermost platform is installed, a
 .. contents::
     :backlinks: top
 
+Mattermost 3.6 and later
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The new CLI tool is supported in Mattermost 3.6 and later. To see available commands in the old CLI tool, see `Mattermost 3.5 and earlier`_.
+
 Typing ``platform help`` and ``platform help {command}`` returns help documentation for the CLI tool or any CLI command in particular.
 
 Notes:
@@ -655,3 +660,184 @@ platform version
     .. code-block:: none
 
       platform version
+
+Mattermost 3.5 and earlier
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Using the CLI tool
+-------------------
+
+Typing ``platform -help`` brings up documentation for the CLI tool.
+
+Notes:
+
+- Parameters in CLI commands are order-specific.
+- If special characters (``!``, ``|``, ``(``, ``)``, ``\``, `````, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``-password mypassword/!``).
+- Team name and channel name refer to the handles, not the display names. So in the url ``https://pre-release.mattermost.com/core/channels/town-square`` team name would be ``core`` and channel name would be ``town-square``
+
+
+.. tip :: If you automate user creation through the CLI tool with SMTP enabled emails will be sent to all new users created. If you run such a load script, it is best to disable SMTP or to use test accounts so that new account creation emails aren't unintentionally set to people at your organization who aren't expecting them.
+CLI Documentation:
+
+::
+
+  Mattermost commands to help configure the system
+
+  NAME:
+      platform -- platform configuration tool
+
+  USAGE:
+      platform [options]
+
+  FLAGS:
+      -config="config.json"             Path to the config file
+
+      -username="someuser"              Username used in other commands
+
+      -license="ex.mattermost-license"  Path to your license file
+
+      -email="user@example.com"         Email address used in other commands
+
+      -password="mypassword"            Password used in other commands
+
+      -team_name="name"                 The team name used in other commands
+
+      -channel_name="name"	        The channel name used in other commands
+
+      -channel_header="string"	        The channel header used in other commands
+
+      -channel_purpose="string"	        The channel purpose used in other commands
+
+      -channel_type="type"	        The channel type used in other commands
+                                        valid values are
+                                          "O" - public channel
+                                          "P" - private group
+
+      -role="system_admin"               The role used in other commands
+                                         valid values are
+                                           "" - The empty role is basic user
+                                              permissions
+                                           "system_admin" - Represents a system
+                                              admin who has access to all teams
+                                              and configuration settings.
+  COMMANDS:
+      -create_team                      Creates a team.  It requires the -team_name
+                                        and -email flag to create a team.
+          Example:
+              platform -create_team -team_name="name" -email="user@example.com"
+
+      -create_user                      Creates a user.  It requires the -email and -password flag,
+                                         and -team_name and -username are optional to create a user.
+          Example:
+              platform -create_user -team_name="name" -email="user@example.com" -password="mypassword" -username="user"
+
+      -invite_user                      Invites a user to a team by email. It requires the -team_name
+                                          and -email flags.
+          Example:
+              platform -invite_user -team_name="name" -email="user@example.com"
+
+      -join_team                        Joins a user to the team.  It requires the -email and
+                                         -team_name flags.  You may need to logout of your current session
+                                         for the new team to be applied.
+          Example:
+              platform -join_team -email="user@example.com" -team_name="name"
+
+      -assign_role                      Assigns role to a user.  It requires the -role and
+                                        -email flag.  You may need to log out
+                                        of your current sessions for the new role to be
+                                        applied.
+          Example:
+              platform -assign_role -email="user@example.com" -role="system_admin"
+
+      -create_channel		        Create a new channel in the specified team. It requires the -email,
+                                        -team_name, -channel_name, -channel_type flags. Optional you can set
+                                        the -channel_header and -channel_purpose.
+          Example:
+              platform -create_channel -email="user@example.com" -team_name="name" -channel_name="channel_name" -channel_type="O"
+
+      -join_channel                     Joins a user to the channel.  It requires the -email, -channel_name and
+                                        -team_name flags.  You may need to logout of your current session
+                                        for the new channel to be applied.  Requires an enterprise license.
+          Example:
+              platform -join_channel -email="user@example.com" -team_name="name" -channel_name="channel_name"
+
+      -leave_channel                     Removes a user from the channel.  It requires the -email, -channel_name and
+                                         -team_name flags.  You may need to logout of your current session
+                                         for the channel to be removed.  Requires an enterprise license.
+          Example:
+              platform -leave_channel -email="user@example.com" -team_name="name" -channel_name="channel_name"
+
+      -list_channels                     Lists all public channels and private groups for a given team.
+                                         It will append ' (archived)' to the channel name if archived.  It requires the
+                                         -team_name flag.  Requires an enterprise license.
+          Example:
+              platform -list_channels -team_name="name"
+
+      -restore_channel                  Restores a previously deleted channel.
+                                        It requires the -channel_name flag and
+                                        -team_name flag.  Requires an enterprise license.
+          Example:
+              platform -restore_channel -team_name="name" -channel_name="channel_name"
+
+      -reset_password                   Resets the password for a user.  It requires the
+                                        -email and -password flag.
+          Example:
+              platform -reset_password -email="user@example.com" -password="newpassword"
+
+      -reset_mfa                        Turns off multi-factor authentication for a user.  It requires the
+                                        -email or -username flag.
+          Example:
+              platform -reset_mfa -username="someuser"
+
+      -reset_database                   Completely erases the database causing the loss of all data. This
+                                        will reset Mattermost to it's initial state. (note this will not
+                                        erase your configuration.)
+
+          Example:
+              platform -reset_database
+
+      -permanent_delete_user            Permanently deletes a user and all related information
+                                        including posts from the database.  It requires the
+                                        -email flag.  You may need to restart the
+                                        server to invalidate the cache
+          Example:
+              platform -permanent_delete_user -email="user@example.com"
+
+      -permanent_delete_all_users       Permanently deletes all users and all related information
+                                        including posts from the database.  It requires the
+                                        -team_name, and -email flag.  You may need to restart the
+                                        server to invalidate the cache
+          Example:
+              platform -permanent_delete_all_users -team_name="name" -email="user@example.com"
+
+      -permanent_delete_team            Permanently deletes a team along with
+                                        all related information including posts from the database.
+                                        It requires the -team_name flag.  You may need to restart
+                                        the server to invalidate the cache.
+          Example:
+              platform -permanent_delete_team -team_name="name"
+
+      -upload_license                   Uploads a license to the server. Requires the -license flag.
+
+          Example:
+              platform -upload_license -license="/path/to/license/example.mattermost-license"
+
+      -migrate_accounts                 Migrates accounts from one authentication provider to another.
+                                        Requires -from_auth -to_auth and -match_field flags. Supported
+                                        options for -from_auth: email, gitlab, saml. Supported options
+                                        for -to_auth: ldap. Supported options for -match_field: email,
+                                        username. Output will display any accounts that are not migrated
+                                        successfully.
+
+          Example:
+              platform -migrate_accounts -from_auth email -to_auth ldap -match_field username
+
+      -upgrade_db_30                   Upgrades the database from a version 2.x schema to version 3 see
+                                        http://www.mattermost.org/upgrading-to-mattermost-3-0/
+
+          Example:
+              platform -upgrade_db_30
+
+      -version                          Display the current of the Mattermost platform
+
+      -help                             Displays this help page

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -33,18 +33,21 @@ From the directory where the Mattermost platform is installed, a
 
 .. contents::
     :backlinks: top
+    :local:
 
 Mattermost 3.6 and later
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The new CLI tool is supported in Mattermost 3.6 and later. To see available commands in the old CLI tool, see `Mattermost 3.5 and earlier`_.
 
-Typing ``platform help`` and ``platform help {command}`` returns help documentation for the CLI tool or any CLI command in particular.
+Typing ``sudo ./platform help`` and ``sudo ./platform help {command}`` returns help documentation for the CLI tool or any CLI command in particular.
+
+To return the help documentation in GitLab omnibus, type ``sudo -u mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json help``
 
 Notes:
 
 -  Parameters in CLI commands are order-specific.
--  If special characters (``!``, ``|``, ``(``, ``)``, ``\``, ``'``, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``-password mypassword/!``).
+-  If special characters (``!``, ``|``, ``(``, ``)``, ``\``, ``'``, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``-password mypassword\!``).
 -  Team name and channel name refer to the handles, not the display names. So in the url ``https://pre-release.mattermost.com/core/channels/town-square`` team name would be ``core`` and channel name would be ``town-square``
 
 .. tip::
@@ -97,12 +100,12 @@ platform channel add
   Format
     .. code-block:: none
 
-      platform channel add {channel} {users}
+      sudo ./platform channel add {channel} {users}
 
   Example
     .. code-block:: none
 
-      platform channel add mychannel user@example.com username
+      sudo ./platform channel add mychannel user@example.com username
 
 platform channel create
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -113,13 +116,13 @@ platform channel create
   Format
     .. code-block:: none
 
-      platform channel create
+      sudo ./platform channel create
 
   Examples
     .. code-block:: none
 
-      platform channel create --team myteam --name mynewchannel --display_name "My New Channel"
-      platform channel create --team myteam --name mynewprivatechannel --display_name "My New Private Channel" --private
+      sudo ./platform channel create --team myteam --name mynewchannel --display_name "My New Channel"
+      sudo ./platform channel create --team myteam --name mynewprivatechannel --display_name "My New Private Channel" --private
 
   Options
     .. code-block:: none
@@ -140,12 +143,12 @@ platform channel delete
   Format
     .. code-block:: none
 
-      platform channel delete {channels}
+      sudo ./platform channel delete {channels}
 
   Example
     .. code-block:: none
 
-      platform channel delete myteam:mychannel
+      sudo ./platform channel delete myteam:mychannel
 
 platform channel list
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -156,12 +159,12 @@ platform channel list
   Format
     .. code-block:: none
 
-      platform channel list {teams}
+      sudo ./platform channel list {teams}
 
   Example
     .. code-block:: none
 
-      platform channel list myteam
+      sudo ./platform channel list myteam
 
 platform channel remove
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,12 +175,12 @@ platform channel remove
   Format
     .. code-block:: none
 
-      platform channel remove {channel} {users}
+      sudo ./platform channel remove {channel} {users}
 
   Example
     .. code-block:: none
 
-      platform channel remove mychannel user@example.com username
+      sudo ./platform channel remove mychannel user@example.com username
 
 platform channel restore
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,12 +191,12 @@ platform channel restore
   Format
     .. code-block:: none
 
-      platform channel restore {channels}
+      sudo ./platform channel restore {channels}
 
   Example
     .. code-block:: none
 
-      platform channel restore myteam:mychannel
+      sudo ./platform channel restore myteam:mychannel
 
 platform help
 ---------------
@@ -204,7 +207,7 @@ platform help
   Format
     .. code-block:: none
 
-      platform help {outputdir}
+      sudo ./platform help {outputdir}
 
 platform import
 ----------------
@@ -224,12 +227,12 @@ platform import slack
   Format
     .. code-block:: none
 
-      platform import slack {team} {file}
+      sudo ./platform import slack {team} {file}
 
   Example
     .. code-block:: none
 
-      platform import slack myteam slack_export.zip
+      sudo ./platform import slack myteam slack_export.zip
 
 platform ldap
 -------------
@@ -249,12 +252,12 @@ platform ldap sync
   Format
     .. code-block:: none
 
-      platform ldap sync
+      sudo ./platform ldap sync
 
   Example
     .. code-block:: none
 
-      platform ldap sync
+      sudo ./platform ldap sync
 
 platform license
 -----------------
@@ -274,12 +277,12 @@ platform license upload
   Format
     .. code-block:: none
 
-      platform license upload {license}
+      sudo ./platform license upload {license}
 
   Example
     .. code-block:: none
 
-      platform license upload /path/to/license/mylicensefile.mattermost-license
+      sudo ./platform license upload /path/to/license/mylicensefile.mattermost-license
 
 platform reset
 ---------------
@@ -290,7 +293,7 @@ platform reset
   Format
     .. code-block:: none
 
-      platform reset
+      sudo ./platform reset
 
   Options
     .. code-block:: none
@@ -316,12 +319,12 @@ platform roles member
   Format
     .. code-block:: none
 
-      platform roles member {users}
+      sudo ./platform roles member {users}
 
   Example
     .. code-block:: none
 
-      platform roles member user1
+      sudo ./platform roles member user1
 
 platform roles system\_admin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -332,12 +335,12 @@ platform roles system\_admin
   Format
     .. code-block:: none
 
-      platform roles system_admin {users}
+      sudo ./platform roles system_admin {users}
 
   Example
     .. code-block:: none
 
-      platform roles system_admin user1
+      sudo ./platform roles system_admin user1
 
 platform server
 ----------------
@@ -348,7 +351,7 @@ platform server
   Format
     .. code-block:: none
 
-      platform server
+      sudo ./platform server
 
 platform team
 ----------------
@@ -371,12 +374,12 @@ platform team add
   Format
     .. code-block:: none
 
-      platform team add {team} {users}
+      sudo ./platform team add {team} {users}
 
   Example
     .. code-block:: none
 
-      platform team add myteam user@example.com username
+      sudo ./platform team add myteam user@example.com username
 
 platform team create
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -387,13 +390,13 @@ platform team create
   Format
     .. code-block:: none
 
-      platform team create
+      sudo ./platform team create
 
   Examples
     .. code-block:: none
 
-      platform team create --name mynewteam --display_name "My New Team"
-      platform teams create --name private --display_name "My New Private Team" --private
+      sudo ./platform team create --name mynewteam --display_name "My New Team"
+      sudo ./platform teams create --name private --display_name "My New Private Team" --private
 
   Options
     .. code-block:: none
@@ -412,12 +415,12 @@ platform team delete
   Format
     .. code-block:: none
 
-      platform team delete {teams}
+      sudo ./platform team delete {teams}
 
   Example
     .. code-block:: none
 
-      platform team delete myteam
+      sudo ./platform team delete myteam
 
   Options
     .. code-block:: none
@@ -433,12 +436,12 @@ platform team remove
   Format
     .. code-block:: none
 
-      platform team remove {team} {users}
+      sudo ./platform team remove {team} {users}
 
   Example
     .. code-block:: none
 
-      platform team remove myteam user@example.com username
+      sudo ./platform team remove myteam user@example.com username
 
 platform user
 ---------------
@@ -467,13 +470,13 @@ platform user activate
   Format
     .. code-block:: none
 
-      platform user activate {emails, usernames, userIds}
+      sudo ./platform user activate {emails, usernames, userIds}
 
   Examples
     .. code-block:: none
 
-      platform user activate user@example.com
-      platform user activate username1 username2
+      sudo ./platform user activate user@example.com
+      sudo ./platform user activate username1 username2
 
 platform user create
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -484,13 +487,13 @@ platform user create
   Format
     .. code-block:: none
 
-      platform user create
+      sudo ./platform user create
 
   Examples
     .. code-block:: none
 
-      platform user create --email user@example.com --username userexample --password Password1 
-      platform user create --firstname Joe --system_admin --email joe@example.com --username joe --password Password1
+      sudo ./platform user create --email user@example.com --username userexample --password Password1 
+      sudo ./platform user create --firstname Joe --system_admin --email joe@example.com --username joe --password Password1
 
   Options
     .. code-block:: none
@@ -513,13 +516,13 @@ platform user deactivate
   Format
     .. code-block:: none
 
-      platform user deactivate {emails, usernames, userIds}
+      sudo ./platform user deactivate {emails, usernames, userIds}
 
   Examples
     .. code-block:: none
 
-      platform user deactivate user@example.com
-      platform user deactivate username
+      sudo ./platform user deactivate user@example.com
+      sudo ./platform user deactivate username
 
 platform user delete
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -530,12 +533,12 @@ platform user delete
   Format
     .. code-block:: none
 
-      platform user delete {users}
+      sudo ./platform user delete {users}
 
   Example
     .. code-block:: none
 
-        platform user delete user@example.com
+      sudo ./platform user delete user@example.com
 
   Options
     .. code-block:: none
@@ -551,12 +554,12 @@ platform user deleteall
   Format
     .. code-block:: none
 
-      platform user deleteall
+      sudo ./platform user deleteall
 
   Example
     .. code-block:: none
 
-      platform user deleteall
+      sudo ./platform user deleteall
 
   Options
     .. code-block:: none
@@ -572,13 +575,13 @@ platform user invite
   Format
     .. code-block:: none
 
-      platform user invite {email} {teams}
+      sudo ./platform user invite {email} {teams}
 
   Examples
     .. code-block:: none
 
-      platform user invite user@example.com myteam
-      platform user invite user@example.com myteam1 myteam2
+      sudo ./platform user invite user@example.com myteam
+      sudo ./platform user invite user@example.com myteam1 myteam2
 
 platform user migrate\_auth
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -595,12 +598,12 @@ platform user migrate\_auth
   Format
     .. code-block:: none
 
-      platform user migrate_auth {from_auth} {to_auth} {match_field}
+      sudo ./platform user migrate_auth {from_auth} {to_auth} {match_field}
 
   Example
     .. code-block:: none
 
-      platform user migrate_auth email ladp email
+      sudo ./platform user migrate_auth email ladp email
 
 platform user password
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -611,12 +614,12 @@ platform user password
   Format
     .. code-block:: none
 
-      platform user password {user} {password}
+      sudo ./platform user password {user} {password}
 
   Example
     .. code-block:: none
 
-      platform user password user@example.com Password1
+      sudo ./platform user password user@example.com Password1
 
 platform user resetmfa
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -627,12 +630,12 @@ platform user resetmfa
   Format
     .. code-block:: none
 
-      platform user resetmfa {users}
+      sudo ./platform user resetmfa {users}
 
   Example
     .. code-block:: none
 
-      platform user resetmfa user@example.com
+      sudo ./platform user resetmfa user@example.com
 
 platform user verify
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -643,12 +646,12 @@ platform user verify
   Format
     .. code-block:: none
 
-      platform user verify {users}
+      sudo ./platform user verify {users}
 
   Example
     .. code-block:: none
 
-        platform user verify user1
+      sudo ./platform user verify user1
 
 platform version
 ------------------
@@ -659,17 +662,17 @@ platform version
   Format
     .. code-block:: none
 
-      platform version
+      sudo ./platform version
 
 Mattermost 3.5 and earlier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Typing ``platform -help`` brings up documentation for the CLI tool.
+Typing ``sudo ./platform -help`` brings up documentation for the CLI tool. To return the help documentation in GitLab omnibus, type ``sudo -u mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json -help``.
 
 Notes:
 
 - Parameters in CLI commands are order-specific.
-- If special characters (``!``, ``|``, ``(``, ``)``, ``\``, `````, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``-password mypassword/!``).
+- If special characters (``!``, ``|``, ``(``, ``)``, ``\``, `````, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``-password mypassword\!``).
 - Team name and channel name refer to the handles, not the display names. So in the url ``https://pre-release.mattermost.com/core/channels/town-square`` team name would be ``core`` and channel name would be ``town-square``
 
 

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -664,9 +664,6 @@ platform version
 Mattermost 3.5 and earlier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Using the CLI tool
--------------------
-
 Typing ``platform -help`` brings up documentation for the CLI tool.
 
 Notes:

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -42,7 +42,11 @@ The new CLI tool is supported in Mattermost 3.6 and later. To see available comm
 
 Typing ``sudo ./platform help`` and ``sudo ./platform help {command}`` returns help documentation for the CLI tool or any CLI command in particular.
 
-To return the help documentation in GitLab omnibus, type ``sudo -u mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json help``
+To return the help documentation in GitLab omnibus, type
+
+    .. code-block:: none
+
+      sudo -u mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json help
 
 Notes:
 
@@ -100,7 +104,7 @@ platform channel add
   Format
     .. code-block:: none
 
-      sudo ./platform channel add {channel} {users}
+      platform channel add {channel} {users}
 
   Example
     .. code-block:: none
@@ -116,7 +120,7 @@ platform channel create
   Format
     .. code-block:: none
 
-      sudo ./platform channel create
+     platform channel create
 
   Examples
     .. code-block:: none
@@ -143,7 +147,7 @@ platform channel delete
   Format
     .. code-block:: none
 
-      sudo ./platform channel delete {channels}
+      platform channel delete {channels}
 
   Example
     .. code-block:: none
@@ -159,7 +163,7 @@ platform channel list
   Format
     .. code-block:: none
 
-      sudo ./platform channel list {teams}
+      platform channel list {teams}
 
   Example
     .. code-block:: none
@@ -175,7 +179,7 @@ platform channel remove
   Format
     .. code-block:: none
 
-      sudo ./platform channel remove {channel} {users}
+      platform channel remove {channel} {users}
 
   Example
     .. code-block:: none
@@ -191,7 +195,7 @@ platform channel restore
   Format
     .. code-block:: none
 
-      sudo ./platform channel restore {channels}
+      platform channel restore {channels}
 
   Example
     .. code-block:: none
@@ -207,7 +211,7 @@ platform help
   Format
     .. code-block:: none
 
-      sudo ./platform help {outputdir}
+      platform help {outputdir}
 
 platform import
 ----------------
@@ -227,7 +231,7 @@ platform import slack
   Format
     .. code-block:: none
 
-      sudo ./platform import slack {team} {file}
+      platform import slack {team} {file}
 
   Example
     .. code-block:: none
@@ -252,7 +256,7 @@ platform ldap sync
   Format
     .. code-block:: none
 
-      sudo ./platform ldap sync
+      platform ldap sync
 
   Example
     .. code-block:: none
@@ -277,7 +281,7 @@ platform license upload
   Format
     .. code-block:: none
 
-      sudo ./platform license upload {license}
+      platform license upload {license}
 
   Example
     .. code-block:: none
@@ -293,7 +297,7 @@ platform reset
   Format
     .. code-block:: none
 
-      sudo ./platform reset
+      platform reset
 
   Options
     .. code-block:: none
@@ -319,7 +323,7 @@ platform roles member
   Format
     .. code-block:: none
 
-      sudo ./platform roles member {users}
+      platform roles member {users}
 
   Example
     .. code-block:: none
@@ -335,7 +339,7 @@ platform roles system\_admin
   Format
     .. code-block:: none
 
-      sudo ./platform roles system_admin {users}
+      platform roles system_admin {users}
 
   Example
     .. code-block:: none
@@ -351,7 +355,7 @@ platform server
   Format
     .. code-block:: none
 
-      sudo ./platform server
+      platform server
 
 platform team
 ----------------
@@ -374,7 +378,7 @@ platform team add
   Format
     .. code-block:: none
 
-      sudo ./platform team add {team} {users}
+      platform team add {team} {users}
 
   Example
     .. code-block:: none
@@ -390,7 +394,7 @@ platform team create
   Format
     .. code-block:: none
 
-      sudo ./platform team create
+      platform team create
 
   Examples
     .. code-block:: none
@@ -415,7 +419,7 @@ platform team delete
   Format
     .. code-block:: none
 
-      sudo ./platform team delete {teams}
+      platform team delete {teams}
 
   Example
     .. code-block:: none
@@ -436,7 +440,7 @@ platform team remove
   Format
     .. code-block:: none
 
-      sudo ./platform team remove {team} {users}
+      platform team remove {team} {users}
 
   Example
     .. code-block:: none
@@ -470,7 +474,7 @@ platform user activate
   Format
     .. code-block:: none
 
-      sudo ./platform user activate {emails, usernames, userIds}
+      platform user activate {emails, usernames, userIds}
 
   Examples
     .. code-block:: none
@@ -487,7 +491,7 @@ platform user create
   Format
     .. code-block:: none
 
-      sudo ./platform user create
+      platform user create
 
   Examples
     .. code-block:: none
@@ -516,7 +520,7 @@ platform user deactivate
   Format
     .. code-block:: none
 
-      sudo ./platform user deactivate {emails, usernames, userIds}
+      platform user deactivate {emails, usernames, userIds}
 
   Examples
     .. code-block:: none
@@ -533,7 +537,7 @@ platform user delete
   Format
     .. code-block:: none
 
-      sudo ./platform user delete {users}
+      platform user delete {users}
 
   Example
     .. code-block:: none
@@ -554,7 +558,7 @@ platform user deleteall
   Format
     .. code-block:: none
 
-      sudo ./platform user deleteall
+      platform user deleteall
 
   Example
     .. code-block:: none
@@ -575,7 +579,7 @@ platform user invite
   Format
     .. code-block:: none
 
-      sudo ./platform user invite {email} {teams}
+      platform user invite {email} {teams}
 
   Examples
     .. code-block:: none
@@ -598,7 +602,7 @@ platform user migrate\_auth
   Format
     .. code-block:: none
 
-      sudo ./platform user migrate_auth {from_auth} {to_auth} {match_field}
+      platform user migrate_auth {from_auth} {to_auth} {match_field}
 
   Example
     .. code-block:: none
@@ -614,7 +618,7 @@ platform user password
   Format
     .. code-block:: none
 
-      sudo ./platform user password {user} {password}
+      platform user password {user} {password}
 
   Example
     .. code-block:: none
@@ -630,7 +634,7 @@ platform user resetmfa
   Format
     .. code-block:: none
 
-      sudo ./platform user resetmfa {users}
+      platform user resetmfa {users}
 
   Example
     .. code-block:: none
@@ -646,7 +650,7 @@ platform user verify
   Format
     .. code-block:: none
 
-      sudo ./platform user verify {users}
+      platform user verify {users}
 
   Example
     .. code-block:: none
@@ -662,12 +666,16 @@ platform version
   Format
     .. code-block:: none
 
-      sudo ./platform version
+      platform version
 
 Mattermost 3.5 and earlier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Typing ``sudo ./platform -help`` brings up documentation for the CLI tool. To return the help documentation in GitLab omnibus, type ``sudo -u mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json -help``.
+Typing ``sudo ./platform -help`` brings up documentation for the CLI tool. To return the help documentation in GitLab omnibus, type 
+
+    .. code-block:: none
+
+      sudo -u mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json -help
 
 Notes:
 


### PR DESCRIPTION
Admins are trying to use the new CLI commands on older Mattermost deployments. This is causing a lot of unnecessary pain for them.

Propose we add the legacy CLI commands back until majority of deployments are running Mattermost 3.6 or later