### PR TITLE
Adding support for Ubuntu 16.04

### DIFF
--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -57,7 +57,7 @@ Server Software
 Mattermost Server Operating System
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--  Ubuntu 14.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux 6.6+, Oracle Linux 7.1+
+-  Ubuntu 14.04, Ubuntu 16.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux 6.6+, Oracle Linux 7.1+
 
 The Mattermost roadmap does not currently include production support for Fedora, FreeBSD or Arch Linux.
 


### PR DESCRIPTION
- We forgot to update this page after adding support: https://docs.mattermost.com/install/install-ubuntu-1604.html