### PR TITLE
Update version archive for 3.7.1

### DIFF
--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -101,9 +101,9 @@ Private cloud enterprise communications server.
 
 -------
 
-- Mattermost Enterprise Edition v3.7.0 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-0) - [Download](https://releases.mattermost.com/3.7.0/mattermost-3.7.0-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.7.0/mattermost-3.7.0-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `6ed826f7eeb35f108f243e23005e7cccb97dd76ebb8df69197437d505eb64b17`
+- Mattermost Enterprise Edition v3.7.1 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-1) - [Download](https://releases.mattermost.com/3.7.1/mattermost-3.7.1-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.7.1/mattermost-3.7.1-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `e21b5aa48022e32935d881f2b456862ddfdb72a9afe631839f902ebc37900ab9`
 - Mattermost Enterprise Edition v3.6.2 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-2) - [Download](https://releases.mattermost.com/3.6.2/mattermost-3.6.2-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.6.2/mattermost-3.6.2-linux-amd64.tar.gz`
   - SHA-256 Checksum: `f337f0eea50225de16a160af26dac94331c900c50ea6a72ecc5e7a890729b12a`
@@ -141,9 +141,9 @@ Open source self-hosted team communication server compiled by Mattermost, Inc, a
 
 -------
 
-- Mattermost Team Edition v3.7.0 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-0) - [Download](https://releases.mattermost.com/3.7.0/mattermost-team-3.7.0-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.7.0/mattermost-team-3.7.0-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `5de407fc585cd51e19be6388da5078395232e9f11edb0cdf464e5664c8a78c2c`
+- Mattermost Team Edition v3.7.1 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-1) - [Download](https://releases.mattermost.com/3.7.1/mattermost-team-3.7.1-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.7.1/mattermost-team-3.7.1-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `4a5561ae6d71424c2f8c3a3742306d8c715ea0c09a23ecf9b0dd3f3002abcdfd`
 - Mattermost Team Edition v3.6.2 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-2) - [Download](https://releases.mattermost.com/3.6.2/mattermost-team-3.6.2-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.6.2/mattermost-team-3.6.2-linux-amd64.tar.gz`
   - SHA-256 Checksum: `4b3fb74f81e56764d8d91e6ec67a79ff39c85b354ff15648f5b04a8bfceec8f1`


### PR DESCRIPTION
See [this link](https://pre-release.mattermost.com/core/pl/zfgk8oa7kjrufr4gofpagoqtse) for download links and SHA-256 checksum