### PR TITLE
Added instructions to limit access to port 8065

### DIFF
--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -71,13 +71,9 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
 
 6. Restart NGINX.
 
-  On Ubuntu 14.04 and RHEL 6.6:
+  On Ubuntu 14.04 and RHEL 6.6: ``sudo service nginx restart``
 
-  ``sudo service nginx restart``
-
-  On Ubuntu 16.04 and RHEL 7.1:
-
-  ``sudo systemctl restart nginx``
+  On Ubuntu 16.04 and RHEL 7.1: ``sudo systemctl restart nginx``
 
 7. Verify that you can see Mattermost through the proxy.
 
@@ -94,6 +90,9 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
   b. Locate the line ``"ListenAddress": ":8065",`` and change it to ``"ListenAddress": "{IP-address}:8065",`` where *{IP-address}* is the address or domain name of the machine that hosts NGINX. For example, if NGINX and Mattermost are on the same machine, change the line to ``"ListenAddress": "localhost:8065",``
 
   c. Restart the Mattermost server for the changes to take effect.
-    ``sudo systemctl restart mattermost``
+
+    On Ubuntu 14.04 and RHEL 6.6: ``sudo service mattermost restart``
+
+    On Ubuntu 16.04 and RHEL 7.1: ``sudo systemctl restart mattermost``
 
 Now that NGINX is installed and running, you can configure it to use SSL, which allows you to use HTTPS connections and the HTTP/2 protocol.

--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -13,9 +13,9 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
   ``sudo touch /etc/nginx/sites-available/mattermost``
 
 3. Open the file ``/etc/nginx/sites-available/mattermost`` as root in a text editor and replace its contents, if any, with the following lines. Make sure that you use your own values for the Mattermost server IP address and FQDN for *server_name*.
-  
+
   .. code-block:: none
-  
+
     upstream backend {
        server 10.10.10.2:8065;
     }
@@ -72,19 +72,28 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
 6. Restart NGINX.
 
   On Ubuntu 14.04 and RHEL 6.6:
-  
+
   ``sudo service nginx restart``
-  
+
   On Ubuntu 16.04 and RHEL 7.1:
-  
+
   ``sudo systemctl restart nginx``
 
 7. Verify that you can see Mattermost through the proxy.
 
   ``curl http://localhost``
-  
+
   If everything is working, you will see the HTML for the Mattermost signup page.
 
-**What to do next**
+8. Make sure that Mattermost accepts connections only from the proxy.
 
-You can configure NGINX to use SSL, which allows you to use HTTPS connections and the HTTP/2 protocol.
+  By default, the Mattermost server accepts connections on port 8065 from every machine on the network. You should make sure that Mattermost accepts connections on port 8065 only from the machine that hosts NGINX.
+
+  a. On the Mattermost server, open ``config.json`` as root in a text editor. The default location of ``config.json`` is ``/opt/mattermost/config/config.json``.
+
+  b. Locate the line ``"ListenAddress": ":8065",`` and change it to ``"ListenAddress": "{IP-address}:8065",`` where *{IP-address}* is the address or domain name of the machine that hosts NGINX. For example, if NGINX and Mattermost are on the same machine, change the line to ``"ListenAddress": "localhost:8065",``
+
+  c. Restart the Mattermost server for the changes to take effect.
+    ``sudo systemctl restart mattermost``
+
+Now that NGINX is installed and running, you can configure it to use SSL, which allows you to use HTTPS connections and the HTTP/2 protocol.

--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -85,9 +85,11 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
 
   By default, the Mattermost server accepts connections on port 8065 from every machine on the network. You should make sure that Mattermost accepts connections on port 8065 only from the machine that hosts NGINX.
 
+  If you are setting up a high availability cluster, you might prefer to use a solution other than the one described here. Using either routing tables, security groups, or IPsec allows you to access the System Console on port 8065 when `Updating Configuration Changes While Operating Continuously <../deployment/cluster.html#updating-configuration-changes-while-operating-continuously>`_.
+
   a. On the Mattermost server, open ``config.json`` as root in a text editor. The default location of ``config.json`` is ``/opt/mattermost/config/config.json``.
 
-  b. Locate the line ``"ListenAddress": ":8065",`` and change it to ``"ListenAddress": "{IP-address}:8065",`` where *{IP-address}* is the address or domain name of the machine that hosts NGINX. For example, if NGINX and Mattermost are on the same machine, change the line to ``"ListenAddress": "localhost:8065",``
+  b. Locate the line ``"ListenAddress": ":8065",`` and change it to ``"ListenAddress": "{IP-or-domain}:8065",`` where *{IP-or-domain}* is the IP address or the domain name of the machine that hosts NGINX. For example, if NGINX and Mattermost are on the same machine, change the line to ``"ListenAddress": "localhost:8065",``
 
   c. Restart the Mattermost server for the changes to take effect.
 

--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -81,20 +81,7 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
 
   If everything is working, you will see the HTML for the Mattermost signup page.
 
-8. Make sure that Mattermost accepts connections only from the proxy.
-
-  By default, the Mattermost server accepts connections on port 8065 from every machine on the network. You should make sure that Mattermost accepts connections on port 8065 only from the machine that hosts NGINX.
-
-  If you are setting up a high availability cluster, you might prefer to use a solution other than the one described here. Using either routing tables, security groups, or IPsec allows you to access the System Console on port 8065 when `Updating Configuration Changes While Operating Continuously <../deployment/cluster.html#updating-configuration-changes-while-operating-continuously>`_.
-
-  a. On the Mattermost server, open ``config.json`` as root in a text editor. The default location of ``config.json`` is ``/opt/mattermost/config/config.json``.
-
-  b. Locate the line ``"ListenAddress": ":8065",`` and change it to ``"ListenAddress": "{IP-or-domain}:8065",`` where *{IP-or-domain}* is the IP address or the domain name of the machine that hosts NGINX. For example, if NGINX and Mattermost are on the same machine, change the line to ``"ListenAddress": "localhost:8065",``
-
-  c. Restart the Mattermost server for the changes to take effect.
-
-    On Ubuntu 14.04 and RHEL 6.6: ``sudo service mattermost restart``
-
-    On Ubuntu 16.04 and RHEL 7.1: ``sudo systemctl restart mattermost``
+8. Restrict access to port 8065.
+  By default, the Mattermost server accepts connections on port 8065 from every machine on the network. Use your firewall to deny connections on port 8065 to all machines except the machine that hosts NGINX and the machine that you use to administer Mattermost server. If you're installing on Amazon Web Services, you can use security groups to restrict access.
 
 Now that NGINX is installed and running, you can configure it to use SSL, which allows you to use HTTPS connections and the HTTP/2 protocol.


### PR DESCRIPTION
After the NGINX proxy is set up and serving Mattermost on port 80, you should restrict access to port 8065 to the machine that hosts NGINX, otherwise Mattermost is available on port 8065 to every machine on the network.

This is done by modifying "ListenAddress" in config.json.

See http://forum.mattermost.org/t/after-nginx-install-still-port-8065-open/3078 for discussion.
