### PR TITLE
Update manifesto.rst

### DIFF
--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -67,5 +67,5 @@ Mattermost software, whether open source or commercial, should never withhold an
 
 -----
 
-These principles were inspired by Wordpress Philosophy and GitLab's - https://wordpress.org/about/philosophy/
+These principles were inspired by WordPress Philosophy and GitLab's - https://wordpress.org/about/philosophy/
 


### PR DESCRIPTION
Corrected "Wordpress" to "WordPress"