### PR TITLE
Fixed broken links and turned off index page generation

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -128,11 +128,11 @@ todo_include_todos = False
 html_context = {
     # Enable the "Edit in GitHub link within the header of each page.
     'display_github': True,
-    # Set the following variables to generate the resulting github URL for each page. 
+    # Set the following variables to generate the resulting github URL for each page.
     # Format Template: https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}
     'github_user': 'mattermost',
     'github_repo': 'docs',
-    'github_version': 'master/source/' 
+    'github_version': 'master/source/'
 }
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -195,7 +195,7 @@ html_additional_pages = {
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False

--- a/source/developer/api.md
+++ b/source/developer/api.md
@@ -9,7 +9,7 @@ There's a [vibrant community developing open source apps on Mattermost](https://
 To learn more about the Mattermost Web Service API, see the references listed below:
 
 - [API Reference for latest Mattermost release](https://api.mattermost.com/)
-- [API Reference for master branch](https://api.mattermost.com/master.html)
+- [API Reference for master branch](https://api.mattermost.com/master/)
 
 We accept bug reports and contributions to our API references at [our repository here](https://github.com/mattermost/mattermost-api-reference).
 
@@ -21,11 +21,11 @@ Mattermost drivers offer access to the Mattermost web service API in different p
 
 [web-client.jsx](https://github.com/mattermost/platform/blob/master/webapp/client/client.jsx) - This Javascript driver connects with the ReactJS components of Mattermost. The web client does the vast majority of its work by connecting to a RESTful JSON web service. There is a very small amount of processing for error checking and set up that happens on the web server.
 
-- The Javascript Driver is [mirrored in an external repository](https://github.com/mattermost/mattermost-driver-javascript) that can be included in custom projects. 
+- The Javascript Driver is [mirrored in an external repository](https://github.com/mattermost/mattermost-driver-javascript) that can be included in custom projects.
 
 ### [Golang Driver](https://github.com/mattermost/platform/blob/master/model/client.go)
 
-[client.go](https://github.com/mattermost/platform/blob/master/model/client.go) - This is a RESTful driver connecting with the Golang-based webservice of Mattermost and is used by unit tests. 
+[client.go](https://github.com/mattermost/platform/blob/master/model/client.go) - This is a RESTful driver connecting with the Golang-based webservice of Mattermost and is used by unit tests.
 
 - See [GoDocs](https://godoc.org/github.com/mattermost/platform/model) for documentation on the Golang Driver.
 
@@ -35,7 +35,7 @@ If you're building a deep integration with Mattermost, for example a mobile nati
 
 If no driver is available for the programming language of your choice, you can view the [Golang Driver](https://github.com/mattermost/platform/blob/master/model/client.go) source code to understand how it exercises the Web Service API. You can also learn more by reviewing open source projects that use the Web Service API, like [matterircd](https://github.com/42wim/matterircd).
 
-There are a wide range of [installation guides](http://www.mattermost.org/installation/) for setting up your own Mattermost server on which to develop and test your integrations. 
+There are a wide range of [installation guides](http://www.mattermost.org/installation/) for setting up your own Mattermost server on which to develop and test your integrations.
 
 ## Mattermost Golang Bot Sample (Driver Example)
 

--- a/source/developer/api4.rst
+++ b/source/developer/api4.rst
@@ -31,7 +31,7 @@ To add an endpoint to API version 4, each item on the following checklist must b
    test <https://docs.mattermost.com/developer/api4.html#writing-a-unit-test>`__
 -  `Submit your
    implementation! <https://docs.mattermost.com/developer/api4.html#submitting-your-pull-request>`__
-   
+
 A full example can be found through these two pull requests:
 
 - Documenting the ``POST /teams`` endpoint: `/mattermost-api-reference #72 <https://github.com/mattermost/mattermost-api-reference/pull/72>`_
@@ -63,10 +63,10 @@ repository. To document an endpoint, follow these steps:
    `mattermost-api-reference <https://github.com/mattermost/mattermost-api-reference>`__
    and create a branch for your changes.
 2. Find the ``.yaml`` file in the
-   `/source/v4 <https://github.com/mattermost/mattermost-api-reference/tree/master/source/v4>`__
+   `/source/v4 <https://github.com/mattermost/mattermost-api-reference/tree/master/v4/source>`__
    directory that fits your endpoint.
 
-   -  For example, if you were adding the ``GET /users/{user_id}`` endpoint you would be looking for `users.yaml <https://github.com/mattermost/mattermost-api-reference/tree/master/source/v4/users.yaml>`__
+   -  For example, if you were adding the ``GET /users/{user_id}`` endpoint you would be looking for `users.yaml <https://github.com/mattermost/mattermost-api-reference/blob/master/v4/source/users.yaml>`__
    -  If the file doesn't exist yet, you might need to create it and update the `Makefile <https://github.com/mattermost/mattermost-api-reference/tree/master/Makefile>`__ to include it
 
 3. Copy an existing endpoint from the same or a different file.
@@ -101,12 +101,12 @@ environment <https://docs.mattermost.com/developer/developer-setup.html>`__, the
 
 2. Implement the handler for your endpoint.
 
-   -  The general pattern for handlers is 
-   
+   -  The general pattern for handlers is
+
    .. code-block::
-   
-     func handlerName(c *Context, w http.ResponseWriter, r *\ http.Request) { 
-     
+
+     func handlerName(c *Context, w http.ResponseWriter, r *\ http.Request) {
+
        // 1. Parsing of request URL and body
 
        // 2. Permissions check if required
@@ -115,18 +115,18 @@ environment <https://docs.mattermost.com/developer/developer-setup.html>`__, the
 
        // 4. (Optional) Check the Etag
 
-       // 5. Format the response and write the response 
+       // 5. Format the response and write the response
      }
 
    - For examples, see the `updateUser() <https://github.com/mattermost/platform/tree/master/api4/user.go#L86>`_ and the `getUser() <https://github.com/mattermost/platform/tree/master/api4/user.go#L58>`_ handlers.
 
-3. Run the server using ``make run-server`` to check for syntax errors. 
+3. Run the server using ``make run-server`` to check for syntax errors.
 4. (Optional) Use ``curl`` or `Postman <https://www.getpostman.com/>`__ to test the basics of your endpoint. The endpoint will also be tested `through a unit test <https://docs.mattermost.com/developer/api4.html#writing-a-unit-test>`_, so this step is optional.
 
 Updating the Go Driver
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The Go driver for APIv4 is in `/model/client4.go <https://github.com/mattermost/platform/tree/master/model/client4.go>`__. 
+The Go driver for APIv4 is in `/model/client4.go <https://github.com/mattermost/platform/tree/master/model/client4.go>`__.
 
 To add a function to support your new endpoint:
 
@@ -168,7 +168,7 @@ Returning the correct error code might require investigation in the
 `app <https://github.com/mattermost/platform/tree/master/app>`__ or
 `store <https://github.com/mattermost/platform/tree/master/store>`__
 packages to find the source of errors. Status codes on errors should be
-set at the creation of the error. 
+set at the creation of the error.
 
 When completing this step, please make sure to
 use the new ``model.NewAppError()`` function (`see example <https://github.com/mattermost/platform/tree/master/store/sql_user_store.go#L112>`__).

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -1,16 +1,16 @@
 ..  _docker-local-machine:
 
-Production Docker Deployment 
+Production Docker Deployment
 ==============================
 
-Deploy Mattermost using a multi-node production configuration using `Docker Compose <https://docs.docker.com/compose/>`_. Docker Compose experience recommended. 
+Deploy Mattermost using a multi-node production configuration using `Docker Compose <https://docs.docker.com/compose/>`_. Docker Compose experience recommended.
 
-For a single-node preview of Mattermost (without email) see `Local Machine Setup using Docker <http://docs.mattermost.com/install/docker-local-machine.html>`_. 
+For a single-node preview of Mattermost (without email) see `Local Machine Setup using Docker <http://docs.mattermost.com/install/docker-local-machine.html>`_.
 
-Production Docker Setup on Ubuntu 
+Production Docker Setup on Ubuntu
 ----------------------------------------------------
 
-1. **Install Docker Compose** using `the Ubuntu online guide <https://docs.docker.com/installation/ubuntulinux/>`_ or these instructions: 
+1. **Install Docker Compose** using `the Ubuntu online guide <https://docs.docker.com/installation/ubuntulinux/>`_ or these instructions:
 
    .. code:: bash
 
@@ -21,7 +21,7 @@ Production Docker Setup on Ubuntu
        sudo service docker start
        newgrp docker
 
-2. **Deploy the Mattermost Production Docker** setup by running: 
+2. **Deploy the Mattermost Production Docker** setup by running:
 
    .. code:: bash
 
@@ -32,24 +32,21 @@ Production Docker Setup on Ubuntu
 
 3. **Configure TLS** by following `the instructions <https://github.com/mattermost/mattermost-docker#install-with-ssl-certificate>`_
 
-4. **Configure Email** by following the `SMTP email setup guide <http://docs.mattermost.com/install/smtp-email-setup.html>`_ 
+4. **Configure Email** by following the `SMTP email setup guide <http://docs.mattermost.com/install/smtp-email-setup.html>`_
 
 5. (Optional) to enable enterprise features under **System Console** > **Edition and License** upload your `trial license <https://about.mattermost.com/trial/>`_ or `subscription license file <https://about.mattermost.com/pricing/>`_ received via email.
 
 6. **Configure your server** based on `configuration settings documentation <http://docs.mattermost.com/administration/config-settings.html>`_
 
-Additional Guides: 
+Additional Guides:
 
-- **Start, stop and remove containers** using `management instructions. <https://github.com/mattermost/mattermost-docker/tree/team-and-enterprise#startingstopping>`_
- 
-- **Setup Database Backup** following the `database backup instructions. <https://github.com/mattermost/mattermost-docker/tree/team-and-enterprise#database-backup>`_
+- **Start, stop and remove containers** using `management instructions. <https://github.com/mattermost/mattermost-docker/#startingstopping>`_
 
-Production Docker Setup on Mac OS X 
+- **Setup Database Backup** following the `database backup instructions. <https://github.com/mattermost/mattermost-docker/#database-backup>`_
+
+Production Docker Setup on Mac OS X
 ------------------------------------------------------------
 
-You can run a test deployment on Mac OS X by `installing Docker Compose using the online guide <http://docs.docker.com/installation/mac/>`_ then following the above instructions. 
+You can run a test deployment on Mac OS X by `installing Docker Compose using the online guide <http://docs.docker.com/installation/mac/>`_ then following the above instructions.
 
 **Other options:** To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, repeat steps above excluding ``-b enterprise`` from ``git clone`` command.
-
-
-


### PR DESCRIPTION
In addition to fixing broken links, modified config.py so that the auto-generated index page, which was empty anyway, is not generated. The generated page had an "Edit on Github" link but since it's a generated page, there's nothing on Gitub to edit resulting in chronic 404ism.

And my text editor removed superfluous whitespace.