### PR TITLE
Make deprecated features more visible in upgrade guide / changelog

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -179,7 +179,7 @@ This changelog summarizes updates to [Mattermost Team Edition](http://www.matter
    - `POST` at `/users/status/set_active_channel` (replaced by `/channels/view`)
  - All APIv3 endpoints to be removed in September/2017 release (replaced by APIv4 endpoints)
 
-For a list of past and upcoming deprecations, [see our website](https://about.mattermost.com/deprecated-features/).
+For a list of past and upcoming deprecated features, [see our website](https://about.mattermost.com/deprecated-features/).
 
 #### config.json   
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -171,8 +171,8 @@ This changelog summarizes updates to [Mattermost Team Edition](http://www.matter
 #### Removed and deprecated features
 
  - Removed `ServiceSettings: "SegmentDeveloperKey"` setting in `config.json`
- - Backwards compatibility with the old CLI tool will be removed in April/2017 release. See [documentation to learn more about the new CLI tool](https://docs.mattermost.com/administration/command-line-tools.html).
- - Deprecated APIv3 routes to be removed in April/2017 release:
+ - Backwards compatibility with the old CLI tool will be removed in Mattermost v3.8 April/2017 release. See [documentation to learn more about the new CLI tool](https://docs.mattermost.com/administration/command-line-tools.html).
+ - Deprecated APIv3 routes to be removed in Mattermost v3.8 April/2017 release:
    - `GET` at `/channels/more` (replaced by /`channels/more/{offset}/{limit}`)
    - `POST` at `/channels/update_last_viewed_at` (replaced by `/channels/view`)
    - `POST` at `/channels/set_last_viewed_at` (replaced by `/channels/view`)

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -171,12 +171,13 @@ This changelog summarizes updates to [Mattermost Team Edition](http://www.matter
 #### Removed and deprecated features
 
  - Removed `ServiceSettings: "SegmentDeveloperKey"` setting in `config.json`
- - Backwards compatibility with the old CLI tool will be removed in Mattermost v3.8. See [documentation to learn more about the new CLI tool](https://docs.mattermost.com/administration/command-line-tools.html).
- - Deprecated APIv3 routes to be removed in Mattermost v3.8:
+ - Backwards compatibility with the old CLI tool will be removed in April/2017 release. See [documentation to learn more about the new CLI tool](https://docs.mattermost.com/administration/command-line-tools.html).
+ - Deprecated APIv3 routes to be removed in April/2017 release:
    - `GET` at `/channels/more` (replaced by /`channels/more/{offset}/{limit}`)
    - `POST` at `/channels/update_last_viewed_at` (replaced by `/channels/view`)
    - `POST` at `/channels/set_last_viewed_at` (replaced by `/channels/view`)
    - `POST` at `/users/status/set_active_channel` (replaced by `/channels/view`)
+ - All APIv3 endpoints to be removed in September/2017 release (replaced by APIv4 endpoints)
 
 For a list of past and upcoming deprecations, [see our website](https://about.mattermost.com/deprecated-features/).
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -168,11 +168,19 @@ This changelog summarizes updates to [Mattermost Team Edition](http://www.matter
 
 ### Compatibility  
 
-Backwards compatibility with the old CLI tool will be removed in v3.8. See [documentation to learn more about the new CLI tool](https://docs.mattermost.com/administration/command-line-tools.html).
+#### Removed and deprecated features
 
-Changes from v3.6 to v3.7:
+ - Removed `ServiceSettings: "SegmentDeveloperKey"` setting in `config.json`
+ - Backwards compatibility with the old CLI tool will be removed in Mattermost v3.8. See [documentation to learn more about the new CLI tool](https://docs.mattermost.com/administration/command-line-tools.html).
+ - Deprecated APIv3 routes to be removed in Mattermost v3.8:
+   - `GET` at `/channels/more` (replaced by /`channels/more/{offset}/{limit}`)
+   - `POST` at `/channels/update_last_viewed_at` (replaced by `/channels/view`)
+   - `POST` at `/channels/set_last_viewed_at` (replaced by `/channels/view`)
+   - `POST` at `/users/status/set_active_channel` (replaced by `/channels/view`)
 
 #### config.json   
+
+Changes from v3.6 to v3.7:
 
 Multiple setting options were added to `config.json`. Below is a list of the additions and their default values on install. The settings can be modified in `config.json` or the System Console.
 
@@ -182,7 +190,6 @@ Multiple setting options were added to `config.json`. Below is a list of the add
    - Added `"TimeBetweenUserTypingUpdatesMilliseconds": 5000` to control how frequently the "user is typing..." messages are updated
    - Added `"EnableUserTypingMessages": true` to control whether "user is typing..." messages are displayed below the message box
    - Added `"EnableLinkPreviews": false` to control whether a preview of website content is displayed below the message
-   - Removed deprecated `"SegmentDeveloperKey"` setting
 
 **Additional Changes to Enterprise Edition**:
 
@@ -210,12 +217,6 @@ Multiple setting options were added to `config.json`. Below is a list of the add
   - Returns a post list, based on the provided channel and post ID.
 - `POST` at `/channels/{channel_id}/update_member_roles` // XXX check with developer
   - Updates the user's roles in a channel
-
-**Deprecated routes (APIv3):**
-- `GET` at `/channels/more` (replaced by /`channels/more/{offset}/{limit}`) to be removed in v3.8
-- `POST` at `/channels/update_last_viewed_at` (replaced by `/channels/view`) to be removed in v3.8
-- `POST` at `/channels/set_last_viewed_at` (replaced by `/channels/view`) to be removed in v3.8
-- `POST` at `/users/status/set_active_channel` (replaced by `/channels/view`) to be removed in v3.8
 
 ### Websocket Event Changes from v3.6 to v3.7
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -178,6 +178,8 @@ This changelog summarizes updates to [Mattermost Team Edition](http://www.matter
    - `POST` at `/channels/set_last_viewed_at` (replaced by `/channels/view`)
    - `POST` at `/users/status/set_active_channel` (replaced by `/channels/view`)
 
+For a list of past and upcoming deprecations, [see our website](https://about.mattermost.com/deprecated-features/).
+
 #### config.json   
 
 Changes from v3.6 to v3.7:

--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -22,6 +22,7 @@ To start, select one of the following guides:
           - Mattermost `v2.1.x` and below must follow the process to [upgrade to `v3.0.x`](https://docs.mattermost.com/administration/legacy-upgrade.html#upgrade-team-edition-to-3-0-x) before upgrading further
       3. Use the [Version Archive table](https://docs.mattermost.com/administration/upgrade.html#version-archive) to find the `[RELEASE URL]` for your desired version and enter `wget [RELEASE URL]` to download. For example, to download `vX.X.X`, use `wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz`.
       4. Review **Compatibility** section in [CHANGELOG](https://docs.mattermost.com/administration/changelog.html) for the version downloaded and make sure to follow any instructions.
+      5. Review past and upcoming deprecations [listed on our website](https://about.mattermost.com/deprecated-features/).
 2. Stop the Mattermost Server
       1. Consider posting an announcement to active teams about stopping the Mattermost server for an upgrade.
       2. To stop the server run `sudo stop mattermost`.
@@ -55,6 +56,7 @@ To start, select one of the following guides:
           - Mattermost `v2.1.x` and below must follow the process to [upgrade to `v3.0.x`](https://docs.mattermost.com/administration/legacy-upgrade.html#upgrade-enterprise-edition-to-3-0-x) before upgrading further
       3. Use the [Version Archive List](https://docs.mattermost.com/administration/upgrade.html#version-archive) to find the `[RELEASE URL]` for your desired version and enter `wget [RELEASE URL]` to download. For example, to download `vX.X.X`, use `wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz`.
       4. Review **Compatibility** section in [CHANGELOG](https://docs.mattermost.com/administration/changelog.html) for the version downloaded and make sure to follow any instructions.
+      5. Review past and upcoming deprecations [listed on our website](https://about.mattermost.com/deprecated-features/).
 2. Stop the Mattermost Server
       1. Consider posting an announcement to active teams about stopping the Mattermost server for an upgrade.
       2. To stop the server run `sudo stop mattermost`.

--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -22,7 +22,7 @@ To start, select one of the following guides:
           - Mattermost `v2.1.x` and below must follow the process to [upgrade to `v3.0.x`](https://docs.mattermost.com/administration/legacy-upgrade.html#upgrade-team-edition-to-3-0-x) before upgrading further
       3. Use the [Version Archive table](https://docs.mattermost.com/administration/upgrade.html#version-archive) to find the `[RELEASE URL]` for your desired version and enter `wget [RELEASE URL]` to download. For example, to download `vX.X.X`, use `wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz`.
       4. Review **Compatibility** section in [CHANGELOG](https://docs.mattermost.com/administration/changelog.html) for the version downloaded and make sure to follow any instructions.
-      5. Review past and upcoming deprecations [listed on our website](https://about.mattermost.com/deprecated-features/).
+      5. Review past and upcoming deprecation notices [listed on our website](https://about.mattermost.com/deprecated-features/).
 2. Stop the Mattermost Server
       1. Consider posting an announcement to active teams about stopping the Mattermost server for an upgrade.
       2. To stop the server run `sudo stop mattermost`.
@@ -56,7 +56,7 @@ To start, select one of the following guides:
           - Mattermost `v2.1.x` and below must follow the process to [upgrade to `v3.0.x`](https://docs.mattermost.com/administration/legacy-upgrade.html#upgrade-enterprise-edition-to-3-0-x) before upgrading further
       3. Use the [Version Archive List](https://docs.mattermost.com/administration/upgrade.html#version-archive) to find the `[RELEASE URL]` for your desired version and enter `wget [RELEASE URL]` to download. For example, to download `vX.X.X`, use `wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz`.
       4. Review **Compatibility** section in [CHANGELOG](https://docs.mattermost.com/administration/changelog.html) for the version downloaded and make sure to follow any instructions.
-      5. Review past and upcoming deprecations [listed on our website](https://about.mattermost.com/deprecated-features/).
+      5. Review past and upcoming deprecation notices [listed on our website](https://about.mattermost.com/deprecated-features/).
 2. Stop the Mattermost Server
       1. Consider posting an announcement to active teams about stopping the Mattermost server for an upgrade.
       2. To stop the server run `sudo stop mattermost`.


### PR DESCRIPTION
 - upgrade guide: Link to deprecated features webpage: https://about.mattermost.com/deprecated-features/
 - changelog: List relevant deprecations + link to webpage: https://about.mattermost.com/deprecated-features/
 - release blog posts will also have a deprecated features list in the future 
 - release process update included here: https://github.com/mattermost/docs/pull/1041