### PR TITLE
Add start of core developer handbook

### DIFF
--- a/source/developer/core-developer-handbook.md
+++ b/source/developer/core-developer-handbook.md
@@ -1,0 +1,36 @@
+Core Developer Handbook
+-----------------------------
+
+This handbook contains documentation useful for Mattermost core developers. A core developer is 
+a maintainer on the Mattermost project that has merge access to the Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community and guiding the technical vision of Mattermost.
+
+### Current Core Developers ###
+
+Below is the list of core developers working on Mattermost:
+* Corey Hulen - @corey on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@coreyhulen](https://github.com/coreyhulen) on GitHub
+* Joram Wilander - @joram on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@jwilander](https://github.com/jwilander) on GitHub
+* Christopher Speller - @christopoher on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@crspeller](https://github.com/crspeller) on GitHub
+* Harrison Healey - @harrison on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@hmhealey](https://github.com/hmhealey) on GitHub
+* Elias Nahum - @elias on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@enahum](https://github.com/enahum) on GitHub
+* George Goldberg - @george on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@grundleborg](https://github.com/grundleborg) on GitHub
+
+### Reviewing & Merging Pull Requests ###
+
+Core developers are expected to code review pull requests submitted to the Mattermost repositories. Below are some guidelines for reviewing code:
+
+* Responsibility for the submitted code relies on that of the submitter, it is their responsibility to test and implement any changes at high quality. As a result, code reviewers are not required to do a full audit of code changes but should read through the code to:
+ * Make sure the implementation matches the description of the ticket being completed
+ * Ask questions about anything that is not clear
+ * To request changes when the code looks incorrect or doesn't match the correct design patterns
+* Stable respositories that have had a 1.0.0 release require two approved reviews before the changes can be merged
+* Unstable repositories that are still in development may be merged with a single approved review
+* Trivial changes, such as PM-approved text changes or typo fixes, maybe merged with only a single approved review for both stable and unstable repositories
+
+### Technical Direction Resolutions ###
+
+Technical direction resolutions are any decisions made by the team affecting the technical direction of Mattermost. The current resolutions in effect are listed below:
+
+1. Removing usage of jQuery. When working in a file that imports jQuery, developers should mke an effort to replace it with vanilla JavaScript and remove the import. When reviewing pull requests that add more jQuery, please ask the submitter to use vanilla JS.
+2. Server and client changes for the [platform respository](https://github.com/mattermost/platform) must be submitted in separate pull requests. First add server support, then add client support.
+3. As of server 3.8, all new API endpoints should be made in API version 4. API version 3 should only be modified for bug fixes, security and/or performance issues. ([https://pre-release.mattermost.com/core/pl/xcyqqdpkgtb4mcexxxu7mpfssh](https://pre-release.mattermost.com/core/pl/xcyqqdpkgtb4mcexxxu7mpfssh))
+4. Moving the webapp over to share a service layer built on top of Redux. ([https://pre-release.mattermost.com/core/pl/x49ra6zk9frq7yccpo753a377o](https://pre-release.mattermost.com/core/pl/x49ra6zk9frq7yccpo753a377o))

--- a/source/developer/core-developer-handbook.md
+++ b/source/developer/core-developer-handbook.md
@@ -7,24 +7,24 @@ a maintainer on the [Mattermost project](https://github.com/mattermost) that has
 ### Current Core Developers ###
 
 Below is the list of core developers working on Mattermost:
-* Corey Hulen - @corey on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@coreyhulen](https://github.com/coreyhulen) on GitHub
-* Joram Wilander - @joram on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@jwilander](https://github.com/jwilander) on GitHub
-* Christopher Speller - @christopoher on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@crspeller](https://github.com/crspeller) on GitHub
-* Harrison Healey - @harrison on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@hmhealey](https://github.com/hmhealey) on GitHub
-* Elias Nahum - @elias on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@enahum](https://github.com/enahum) on GitHub
-* George Goldberg - @george on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@grundleborg](https://github.com/grundleborg) on GitHub
+- Corey Hulen - @corey on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@coreyhulen](https://github.com/coreyhulen) on GitHub
+- Joram Wilander - @joram on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@jwilander](https://github.com/jwilander) on GitHub
+- Christopher Speller - @christopoher on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@crspeller](https://github.com/crspeller) on GitHub
+- Harrison Healey - @harrison on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@hmhealey](https://github.com/hmhealey) on GitHub
+- Elias Nahum - @elias on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@enahum](https://github.com/enahum) on GitHub
+- George Goldberg - @george on [pre-release.mattermost.com](https://pre-release.mattermost.com/) and [@grundleborg](https://github.com/grundleborg) on GitHub
 
 ### Reviewing & Merging Pull Requests ###
 
 Core developers are expected to code review pull requests submitted to the Mattermost repositories. Below are some guidelines for reviewing code:
 
-* Responsibility for the submitted code relies on the submitter, it is their responsibility to test and implement any changes at high quality. As a result, code reviewers are not required to do a full audit of code changes but should read through the code to:
- * Make sure the implementation matches the description of the ticket being completed
- * Ask questions about anything that is not clear
- * To request changes when the code looks incorrect or doesn't match the correct design patterns
-* Stable respositories that have had a 1.0.0 release require two approved reviews before the changes can be merged
-* Unstable repositories that are still in development may be merged with a single approved review
-* Trivial changes, such as PM-approved text changes or typo fixes, maybe merged with only a single approved review for both stable and unstable repositories
+- Responsibility for the submitted code relies on the submitter, it is their responsibility to test and implement any changes at high quality. As a result, code reviewers are not required to do a full audit of code changes but should read through the code to:
+  - Make sure the implementation matches the description of the ticket being completed
+  - Ask questions about anything that is not clear
+  - To request changes when the code looks incorrect or doesn't match the correct design patterns
+- Stable respositories that have had a 1.0.0 release require two approved reviews before the changes can be merged
+- Unstable repositories that are still in development may be merged with a single approved review
+- Trivial changes, such as PM-approved text changes or typo fixes, maybe merged with only a single approved review for both stable and unstable repositories
 
 ### Technical Direction Resolutions ###
 

--- a/source/developer/core-developer-handbook.md
+++ b/source/developer/core-developer-handbook.md
@@ -2,7 +2,7 @@ Core Developer Handbook
 -----------------------------
 
 This handbook contains documentation useful for Mattermost core developers. A core developer is 
-a maintainer on the Mattermost project that has merge access to the Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community and guiding the technical vision of Mattermost.
+a maintainer on the [Mattermost project](https://github.com/mattermost) that has merge access to the Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community and guiding the technical vision of Mattermost.
 
 ### Current Core Developers ###
 
@@ -18,7 +18,7 @@ Below is the list of core developers working on Mattermost:
 
 Core developers are expected to code review pull requests submitted to the Mattermost repositories. Below are some guidelines for reviewing code:
 
-* Responsibility for the submitted code relies on that of the submitter, it is their responsibility to test and implement any changes at high quality. As a result, code reviewers are not required to do a full audit of code changes but should read through the code to:
+* Responsibility for the submitted code relies on the submitter, it is their responsibility to test and implement any changes at high quality. As a result, code reviewers are not required to do a full audit of code changes but should read through the code to:
  * Make sure the implementation matches the description of the ticket being completed
  * Ask questions about anything that is not clear
  * To request changes when the code looks incorrect or doesn't match the correct design patterns

--- a/source/guides/core.rst
+++ b/source/guides/core.rst
@@ -5,6 +5,7 @@ This handbook is a guide to serving on the core team of the Mattermost open sour
 
 Please consider this handbook - along with all our documentation - as a work-in-progress and constantly updating to best achieve our shared mission. 
 
+
 Development Process
 -------------------
 
@@ -19,6 +20,14 @@ Development Process
    /process/marketing-guidelines*
    /process/asset-guidelines*
    /process/community-guidelines*
+
+Core Developer Handbook
+-------------------
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   /developer/core-developer-handbook*
 
 Documentation Style Guide
 -------------------------

--- a/source/guides/developer.rst
+++ b/source/guides/developer.rst
@@ -19,6 +19,7 @@ Development Process
    /developer/style*
    /developer/fx*
    /developer/localization-process.rst
+   /developer/core-developer-handbook*
 
 Definitions
 -----------


### PR DESCRIPTION
The purpose of this is to move information relevant to core developers from any old private wikis we have into the docs repo and to allow the development team to track decisions made surrounding the technical vision of Mattermost.

This should also be a useful tool for on-boarding new core developers.