### PR TITLE
Added a Mattermost Rollout Template

### DIFF
--- a/source/help/getting-started/template-mm-rollout.rst
+++ b/source/help/getting-started/template-mm-rollout.rst
@@ -1,0 +1,60 @@
+.. _template-mm-rollout:
+
+Mattermost Rollout Template
+===========================
+
+provides sample text and links for internal distribution. used by organizations to help their users get started with Mattermost. Assumes that the users are not familiar with other messaging systems.
+
+Announcement Template
+---------------------
+
+Welcome to Mattermost at {name-of-organization}.
+
+To get started, go to http://{web-address} and log in. The login depends on how your organization has set up Mattermost.
+
+When you log in for the first time, page through the brief tutorial. When done, you're at the Mattermost interface, where you can start chatting with colleagues.
+
+Every time you log in, you end up in the Town Square channel in a team that you are a member of. Within a team, conversations take place in channels, private groups, and direct messages. For more information about writing messages, see `Messaging Basics <https://docs.mattermost.com/help/getting-started/messaging-basics.html>`_
+
+To learn how to send, edit, and reply to messages, see `Sending Messages <https://docs.mattermost.com/help/messaging/sending-messages.html>`_
+
+Teams
+  In most cases, only one team is visible to you, but multiple teams are allowed. If you are a member of more than one team, you can see the list of teams beside the navigation panel in the Team Sidebar.
+
+  Each team has its own set of public channels, private groups, and direct messages that are visible only to the members of that team.
+
+  To create a team, see `Creating Teams <https://docs.mattermost.com/help/getting-started/creating-teams.html>`_
+
+Public Channels
+  You have access to all public channels in your team, and can add yourself to any public channel in the team. To find out how to create, join, and manage channels, see `Managing Channels <https://docs.mattermost.com/help/getting-started/organizing-conversations.html#managing-channels>`_
+
+Private Groups
+  Private groups are channels that are invite-only. The conversations are visible only to the channel members.
+
+Direct Messages and Group Messages
+  Direct Messages are for conversations between two people. Group Messages are Direct Messages that have conversations among three or more people. Both are visible only to the people involved.
+
+For more information about using channels, groups, and direct messages, see `Organizing Conversations <https://docs.mattermost.com/help/getting-started/organizing-conversations.html>`_
+
+Instructions for System Administrator
+-------------------------------------
+
+replace the login instructions with ones that are specific to your organization. The login experience varies depending on whether you have set up SSO, SAML, or LDAP.
+
+Because the login experience varies widely depending on whether or not you're using the vanilla Mattermost login or have some type of SSO where users have a user login id and password that is different from their internal access cre
+
+The following client apps are available for users to download and install:
+
+Windows PC Desktop App
+  Download: https://releases.mattermost.com/desktop/3.6.0/mattermost-setup-3.6.0-win64.exe
+  Installation Instructions: https://docs.mattermost.com/install/desktop.html#windows-10-windows-8-1-windows-7
+Apple Mac Desktop App
+  Download: https://releases.mattermost.com/desktop/3.6.0/mattermost-desktop-3.6.0-osx.tar.gz
+  Installation Instructions: https://docs.mattermost.com/install/desktop.html#mac-os-x-10-9
+Linux Desktop App (beta)
+  Download: https://releases.mattermost.com/desktop/3.6.0/mattermost-desktop-3.6.0-linux-x64.tar.gz
+  Installation Instructions: https://docs.mattermost.com/install/desktop.html#linux-beta
+iOs App
+  Download and install from the Apple App Store: https://itunes.apple.com/us/app/mattermost/id984966508?ls=1&mt=8
+Android App
+  Download and install from Google Play: https://play.google.com/store/apps/details?id=com.mattermost.mattermost&hl=en

--- a/source/help/getting-started/template-mm-rollout.rst
+++ b/source/help/getting-started/template-mm-rollout.rst
@@ -39,11 +39,9 @@ For more information about using channels, groups, and direct messages, see `Org
 Instructions for System Administrator
 -------------------------------------
 
-replace the login instructions with ones that are specific to your organization. The login experience varies depending on whether you have set up SSO, SAML, or LDAP.
+Add new user login instructions that are specific to your organization. The login experience varies depending on whether you set up SSO, SAML, LDAP, or some other method.
 
-Because the login experience varies widely depending on whether or not you're using the vanilla Mattermost login or have some type of SSO where users have a user login id and password that is different from their internal access cre
-
-The following client apps are available for users to download and install:
+Users can access Mattermost via their browsers, or they can download and install one or more of the following client apps:
 
 Windows PC Desktop App
   Download: https://releases.mattermost.com/desktop/3.6.0/mattermost-setup-3.6.0-win64.exe

--- a/source/help/getting-started/template-mm-rollout.rst
+++ b/source/help/getting-started/template-mm-rollout.rst
@@ -3,7 +3,7 @@
 Mattermost Rollout Template
 ===========================
 
-provides sample text and links for internal distribution. used by organizations to help their users get started with Mattermost. Assumes that the users are not familiar with other messaging systems.
+This template provides sample text and links for internal distribution. It can be used by organizations to help their users get started with Mattermost, and assumes that the users are not familiar with other messaging systems.
 
 Announcement Template
 ---------------------
@@ -12,7 +12,7 @@ Welcome to Mattermost at {name-of-organization}.
 
 To get started, go to http://{web-address} and log in. The login depends on how your organization has set up Mattermost.
 
-When you log in for the first time, page through the brief tutorial. When done, you're at the Mattermost interface, where you can start chatting with colleagues.
+When you log in for the first time, page through the brief tutorial. When done, you're at the Mattermost interface where you can start chatting with colleagues.
 
 Every time you log in, you end up in the Town Square channel in a team that you are a member of. Within a team, conversations take place in channels, private groups, and direct messages. For more information about writing messages, see `Messaging Basics <https://docs.mattermost.com/help/getting-started/messaging-basics.html>`_
 
@@ -39,6 +39,8 @@ For more information about using channels, groups, and direct messages, see `Org
 Instructions for System Administrator
 -------------------------------------
 
+Replace {name-of-organization} and {web-address} with appropriate values.
+
 Add new user login instructions that are specific to your organization. The login experience varies depending on whether you set up SSO, SAML, LDAP, or some other method.
 
 Users can access Mattermost via their browsers, or they can download and install one or more of the following client apps:
@@ -52,7 +54,7 @@ Apple Mac Desktop App
 Linux Desktop App (beta)
   Download: https://releases.mattermost.com/desktop/3.6.0/mattermost-desktop-3.6.0-linux-x64.tar.gz
   Installation Instructions: https://docs.mattermost.com/install/desktop.html#linux-beta
-iOs App
+iOS App
   Download and install from the Apple App Store: https://itunes.apple.com/us/app/mattermost/id984966508?ls=1&mt=8
 Android App
   Download and install from Google Play: https://play.google.com/store/apps/details?id=com.mattermost.mattermost&hl=en


### PR DESCRIPTION
This template provides sample text and links for internal distribution. It can be used by organizations to help their users get started with Mattermost, and assumes that the users are not familiar with other messaging systems.