### PR TITLE
Clarifying TE principles

### DIFF
--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -57,7 +57,10 @@ Users should never run into anything unexpected with Mattermost. We ship on time
 7. Empower trusted users 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enable people to achieve what the team needs simply. Focus on emplowering "trusted users" through education and social norms to guide behavior instead of hard limits or outside control on what someone in the system can do.
+Enable people to work simply. Focus on empowering "trusted users" through education and social norms to guide behavior instead of hard limits or outside control on what someone in the system can do.
+
+8. Upgradable to enterprise  
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When organizations need enterprise-level solutions, such as granular permissions, corporate directory integration, high availability deployment, compliance reporting and other advanced features, commerical Enterprise Edition upgrades should be available and easily incorporated. 
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -44,7 +44,6 @@ Minimalism is providing the correct amount of functionality and not more and not
 
 Make decisions instead of providing options. Every time you present an option, you force the user to make a decision which can lead to frustration if it's not for the majority of users. 
 
-Enable people to achieve what the team needs simply. Focus on building trust and education within a team and control via social norms instead of hard limits on what someone in the system can do. 
 
 5. Built for teams behind firewalls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -56,10 +55,17 @@ Mattermost is built for teams needing a modern communication experience secured 
 
 Users should never run into anything unexpected with Mattermost. We ship on time and document our features and product changes. Users should be able to know well in advance what is being considered for inclusion and change in upcoming versions. 
 
+7. Empower the users 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable people to achieve what the team needs simply. Focus on building trust and education within a team and control via social norms instead of hard limits on what someone in the system can do.
+
 7. Primary, not secondary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. We don't include features such as using email as a Mattermost interface (impoverished experience). Also, while there could potentially be options to use your Mattermost account to sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 
+Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. 
+
+Avoid features such as using email as a Mattermost interface (impoverished experience). Also, while there could potentially be options to use your Mattermost account to sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 
 
 -----
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -59,7 +59,7 @@ Users should never run into anything unexpected with Mattermost. We ship on time
 
 Enable people to achieve what the team needs simply. Focus on emplowering "trusted users" through education and social norms to guide behavior instead of hard limits or outside control on what someone in the system can do.
 
-When organizations need more complex solutions, with the enforcement of "policies" such as granular permissions, corporate directory integration, high availability deployment, compliance reporting and other advanced features, commerical add-ons for Mattermost Enterprise Edition should be available and easily incorporated. 
+When organizations need enterprise-level solutions, such as granular permissions, corporate directory integration, high availability deployment, compliance reporting and other advanced features, commerical Enterprise Edition upgrades should be available and easily incorporated. 
 
 -----
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -60,7 +60,7 @@ Users should never run into anything unexpected with Mattermost. We ship on time
 
 Enable people to achieve what the team needs simply. Focus on building trust and education within a team and control via social norms instead of hard limits on what someone in the system can do.
 
-7. Primary, not secondary
+8. Primary, not secondary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -47,7 +47,7 @@ Make decisions instead of providing options. Every time you present an option, y
 5. Built for teams behind firewalls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Team Edition is built for teams needing a modern communication experience secured behind a firewall. For our target audience, we should be far the best solution in the world. 
+Team Edition is built for teams needing a modern communication experience secured behind a firewall. For our target audience, we should be by far the best solution in the world. 
 
 6. No surprises 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -62,7 +62,7 @@ Let people work simply. Team Edition is for teams needing a "virtual office" whe
 8. Open source alternative  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For non-technical users with basic IT skills, Team Edition aspires to be an ideal workplace messaging solution deployed on a private network, emphasizing simplicity and fast time-to-value. For sophisticated organizations with advanced security, configurability and scalability needs, the commercial Enterprise Edition add-on strives to be an ideal solution. 
+For non-technical users with basic IT skills, Team Edition aspires to be an ideal workplace messaging solution deployed on a private network, emphasizing simplicity and fast time-to-value. For sophisticated organizations with advanced security, configurability and scalability needs, the commercial Enterprise Edition extension strives to be an ideal solution. 
 
 For organizations who seek other options, full source code of the platform for creating Team Edition should be available for the development of open source variants, including commercial variants, `provided the Mattermost trademark is not used and other protocols are respected. <https://docs.mattermost.com/overview/faq.html#how-can-i-create-a-derivative-work-of-mattermost-as-my-own-commercial-solution>`_ 
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -44,7 +44,6 @@ Minimalism is providing the correct amount of functionality and not more and not
 
 Make decisions instead of providing options. Every time you present an option, you force the user to make a decision which can lead to frustration if it's not for the majority of users. 
 
-
 5. Built for teams behind firewalls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -55,7 +54,7 @@ Mattermost is built for teams needing a modern communication experience secured 
 
 Users should never run into anything unexpected with Mattermost. We ship on time and document our features and product changes. Users should be able to know well in advance what is being considered for inclusion and change in upcoming versions. 
 
-7. Empower the users 
+7. Empower users 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Enable people to achieve what the team needs simply. Focus on building trust and education within a team and control via social norms instead of hard limits on what someone in the system can do.

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -54,7 +54,7 @@ Team Edition is built for teams needing a modern communication experience secure
 
 Users should never run into anything unexpected with Mattermost. We ship on time and document our features and product changes. Users should be able to know well in advance what is being considered for inclusion and change in upcoming versions. 
 
-7. Minimize administration 
+7. Near zero administration 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Let people work simply. Team Edition is for teams needing a "virtual office" where everyone knows each other and is trusted to get things done appropriately, without hard limits and policies. The non-technical user who deployed Team Edition should spend zero time on any administration tasks. 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -39,10 +39,12 @@ Great software creates value quickly. A novice IT admin should be able to set up
 
 Minimalism is providing the correct amount of functionality and not more and not less. Great design is about doing important things extremely well, and not many things poorly. Make features work well for their intended purpose before adding new features. 
 
-4. Decisions not Options
+4. Decisions not options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Make decisions instead of providing options. Every time you present an option, you force the user to make a decision which can lead to frustration if it's not for the majority of users. 
+
+Enable people to achieve what the team needs simply. Focus on building trust and education within a team and control via social norms instead of hard limits on what someone in the system can do. 
 
 5. Built for teams behind firewalls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -54,12 +56,7 @@ Mattermost is built for teams needing a modern communication experience secured 
 
 Users should never run into anything unexpected with Mattermost. We ship on time and document our features and product changes. Users should be able to know well in advance what is being considered for inclusion and change in upcoming versions. 
 
-7. Empower trusted teams
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Enable people to achieve what the team needs simply. Focus on building trust and education within a team and control via social norms instead of hard limits on what someone in the system can do. 
-
-8. Primary, not secondary
+7. Primary, not secondary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. We don't include features such as using email as a Mattermost interface (impoverished experience). Also, while there could potentially be options to use your Mattermost account to sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -57,7 +57,7 @@ Users should never run into anything unexpected with Mattermost. We ship on time
 7. Minimize administration 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Let people work simply. Team Edition is for teams working in an "virtual office" where everyone knows each other and is trusted to get things done appropriately, without hard limits and policies getting in the way of work. 
+Let people work simply. Team Edition is for teams working in an "virtual office" where everyone knows each other and is trusted to get things done appropriately, without hard limits and policies getting in the way of work. As the product continues to progress, the non-technical user who deployed Team Edition should spend zero time on any IT maintenance tasks. 
 
 8. Open source alternative  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -4,9 +4,9 @@ About the Mattermost Open Source Project
 
 Mattermost is an open source, private cloud alternative to proprietary communication services. Hundreds of contributors around the world help develop the software in over 10 languages. 
 
-- **Mattermost Team Edition** is an open source workplace messaging solution. Combined with native Mattermost apps on mobile and desktop, it brings all your team communication to one place, with web, mobile and PC interfaces, continuous archiving, instant search and a host of 3rd party integrations. It deploys as a single Linux binary under MIT license, with either MySQL or PostgreSQL as a database. 
+- **Mattermost Team Edition** is an open source, private cloud workplace messaging solution designed for deployment by non-technical users with basic IT skills. Combined with native Mattermost apps on mobile and desktop, it brings all your team communication to one place, with web, mobile and PC interfaces, continuous archiving, instant search and a host of 3rd party integrations. It deploys as a single Linux binary under MIT license, with either MySQL or PostgreSQL as a database, with a host of simple, automated deployment options created by our community. 
 
-- **Mattermost Enterprise Edition** is a commercial extension of Mattermost offering enterprise-grade messaging and advanced security, configurability and scalability benefits beyond the scope of team communication. 
+- **Mattermost Enterprise Edition** is a commercial extension of Mattermost offering enterprise-grade messaging and advanced security, configurability and scalability benefits for sophisticated organizations and users. 
 
 History 
 ---------------
@@ -32,7 +32,7 @@ Mattermost software, whether open source or commercial, should never withhold an
 2. Quick Time-to-Value 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Great software creates value quickly. A business user with basic IT skills should be able to set up Mattermost and roll it out to their team in just a few minutes to increase team productivity. We should automate as much as possible in a standard install, ask few technical questions, and provide full explanations for any decisions an IT admin or end user needs to make. 
+Great software creates value quickly. A non-technical user with basic IT skills should be able to set up Team Edition, understand every feature in the UI, and roll out the product and increase team productivity in just a few minutes. We should automate as much as possible in a standard install, ask few technical questions, and provide full explanations for any decisions that need to be made.  
 
 3. Minimalist
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -47,22 +47,24 @@ Make decisions instead of providing options. Every time you present an option, y
 5. Built for teams behind firewalls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost is built for teams needing a modern communication experience secured behind a firewall. 
+Team Edition is built for teams needing a modern communication experience secured behind a firewall. For our target audience, we should be far the best solution in the world. 
 
 6. No surprises 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Users should never run into anything unexpected with Mattermost. We ship on time and document our features and product changes. Users should be able to know well in advance what is being considered for inclusion and change in upcoming versions. 
 
-7. Empower trusted users 
+7. Minimize administration 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enable people to work simply. Focus on empowering "trusted users" through education and social norms to guide behavior instead of hard limits or outside control on what someone in the system can do.
+Let people work simply. Team Edition is for teams working in an "virtual office" where everyone knows each other and is trusted to get things done appropriately, without hard limits and policies getting in the way of work. 
 
-8. Transitions to enterprise  
+8. Open source alternative  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When organizations need enterprise features, such as granular permissions, corporate directory integration, high availability deployment, compliance reporting and other advanced capabilities, commerical Enterprise Edition upgrades should be available and easily incorporated. Revenue from enterprise add-ons supports improvements, quality assurance and upkeep of Team Edition. 
+For non-technical, private cloud users with basic IT skills, Team Edition aspires to be an ideal workplace messaging solution, emphasizing simplicity and fast time-to-value. For sophisticated organizations with advanced security, configurability and scalability needs, the commercial Enterprise Edition add-on strives to be an ideal solution. 
+
+For organizations who seek other options, full source code of the platform for creation Team Edition should be available for the creation of open source variants, `provided the Mattermost trademark is not used and other protocols are respected. <https://docs.mattermost.com/overview/faq.html#how-can-i-create-a-derivative-work-of-mattermost-as-my-own-commercial-solution>`_ 
 
 -----
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -32,7 +32,7 @@ Mattermost software, whether open source or commercial, should never withhold an
 2. Quick Time-to-Value 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Great software creates value quickly. A novice IT admin should be able to set up Mattermost and roll it out to their team in just a few minutes to increase team productivity. We should automate as much as possible in a standard install, ask few technical questions, and provide full explanations for any decisions an IT admin or end user needs to make. 
+Great software creates value quickly. A business user with basic IT skills should be able to set up Mattermost and roll it out to their team in just a few minutes to increase team productivity. We should automate as much as possible in a standard install, ask few technical questions, and provide full explanations for any decisions an IT admin or end user needs to make. 
 
 3. Minimalist
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -62,7 +62,7 @@ Enable people to achieve what the team needs simply. Focus on building trust and
 8. Primary, not secondary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. We don't include features such as using email as a Mattermost interface (impoverished experience). Also, while there may be options to use your Mattermost account to sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 
+Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. We don't include features such as using email as a Mattermost interface (impoverished experience). Also, while there could potentially be options to use your Mattermost account to sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 
 
 -----
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -57,7 +57,7 @@ Users should never run into anything unexpected with Mattermost. We ship on time
 7. Minimize administration 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Let people work simply. Team Edition is for teams working in an "virtual office" where everyone knows each other and is trusted to get things done appropriately, without hard limits and policies getting in the way of work. As the product continues to progress, the non-technical user who deployed Team Edition should spend zero time on any IT maintenance tasks. 
+Let people work simply. Team Edition is for teams needing a "virtual office" where everyone knows each other and is trusted to get things done appropriately, without hard limits and policies. The non-technical user who deployed Team Edition should spend zero time on any administration tasks. 
 
 8. Open source alternative  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -54,17 +54,12 @@ Mattermost is built for teams needing a modern communication experience secured 
 
 Users should never run into anything unexpected with Mattermost. We ship on time and document our features and product changes. Users should be able to know well in advance what is being considered for inclusion and change in upcoming versions. 
 
-7. Empower users 
+7. Empower trusted users 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enable people to achieve what the team needs simply. Focus on building trust and education within a team and control via social norms instead of hard limits on what someone in the system can do.
+Enable people to achieve what the team needs simply. Focus on emplowering "trusted users" through education and social norms to guide behavior instead of hard limits or outside control on what someone in the system can do.
 
-8. Primary, not secondary
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. 
-
-Avoid features such as using email as a Mattermost interface (impoverished experience). Also, while there could potentially be options to use your Mattermost account to sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 
+When organizations need more complex solutions, with the enforcement of "policies" such as granular permissions, corporate directory integration, high availability deployment, compliance reporting and other advanced features, commerical add-ons for Mattermost Enterprise Edition should be available and easily incorporated. 
 
 -----
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -62,7 +62,7 @@ Let people work simply. Team Edition is for teams needing a "virtual office" whe
 8. Open source alternative  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For non-technical, private cloud users with basic IT skills, Team Edition aspires to be an ideal workplace messaging solution, emphasizing simplicity and fast time-to-value. For sophisticated organizations with advanced security, configurability and scalability needs, the commercial Enterprise Edition add-on strives to be an ideal solution. 
+For non-technical users with basic IT skills, Team Edition aspires to be an ideal workplace messaging solution deployed on a private network, emphasizing simplicity and fast time-to-value. For sophisticated organizations with advanced security, configurability and scalability needs, the commercial Enterprise Edition add-on strives to be an ideal solution. 
 
 For organizations who seek other options, full source code of the platform for creating Team Edition should be available for the development of open source variants, including commercial variants, `provided the Mattermost trademark is not used and other protocols are respected. <https://docs.mattermost.com/overview/faq.html#how-can-i-create-a-derivative-work-of-mattermost-as-my-own-commercial-solution>`_ 
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -64,7 +64,7 @@ Let people work simply. Team Edition is for teams working in an "virtual office"
 
 For non-technical, private cloud users with basic IT skills, Team Edition aspires to be an ideal workplace messaging solution, emphasizing simplicity and fast time-to-value. For sophisticated organizations with advanced security, configurability and scalability needs, the commercial Enterprise Edition add-on strives to be an ideal solution. 
 
-For organizations who seek other options, full source code of the platform for creation Team Edition should be available for the creation of open source variants, `provided the Mattermost trademark is not used and other protocols are respected. <https://docs.mattermost.com/overview/faq.html#how-can-i-create-a-derivative-work-of-mattermost-as-my-own-commercial-solution>`_ 
+For organizations who seek other options, full source code of the platform for creating Team Edition should be available for the development of open source variants, including commercial variants, `provided the Mattermost trademark is not used and other protocols are respected. <https://docs.mattermost.com/overview/faq.html#how-can-i-create-a-derivative-work-of-mattermost-as-my-own-commercial-solution>`_ 
 
 -----
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -62,7 +62,7 @@ Enable people to achieve what the team needs simply. Focus on building trust and
 8. Primary, not secondary
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. We don't include features such as using email as a Mattermost interface (impoverished experience). Also, while you can use your Mattermost account to securely sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 
+Mattermost is designed to be the primary way a team communicates. Deployment as a secondary system, where not everyone in a team can be reached, does not achieve our purpose. We don't include features such as using email as a Mattermost interface (impoverished experience). Also, while there may be options to use your Mattermost account to sign-in to other apps there are no plans to add sign-in to Mattermost using other accounts. 
 
 -----
 

--- a/source/developer/manifesto.rst
+++ b/source/developer/manifesto.rst
@@ -59,10 +59,10 @@ Users should never run into anything unexpected with Mattermost. We ship on time
 
 Enable people to work simply. Focus on empowering "trusted users" through education and social norms to guide behavior instead of hard limits or outside control on what someone in the system can do.
 
-8. Upgradable to enterprise  
+8. Transitions to enterprise  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When organizations need enterprise-level solutions, such as granular permissions, corporate directory integration, high availability deployment, compliance reporting and other advanced features, commerical Enterprise Edition upgrades should be available and easily incorporated. 
+When organizations need enterprise features, such as granular permissions, corporate directory integration, high availability deployment, compliance reporting and other advanced capabilities, commerical Enterprise Edition upgrades should be available and easily incorporated. Revenue from enterprise add-ons supports improvements, quality assurance and upkeep of Team Edition. 
 
 -----
 


### PR DESCRIPTION
For two years, [the Mattermost Manifesto](https://www.mattermost.org/manifesto/) has been the framework for Team Edition and Enterprise Edition, and we're working on an upgraded version to increase clarity in design decisions. 

We will finalize Friday, April 21, 2017 and replace the existing manifesto after over three months of discussions on the [community Mattermost server](https://pre-release.mattermost.com/) and many meetings. 

All community comments are welcome, 

Comments informed by the product's goals, history and context are preferred (see below for list of readings). 

1. **Our goal is to increase the popularity of Mattermost** in terms of number of active deployments and active users in the global Workstream Collaboration market with offerings focused on private cloud solutions, while achieving venture-scale growth (similar to [Automattic](https://en.wikipedia.org/wiki/Automattic), [Acquia](https://en.wikipedia.org/wiki/Acquia), [DataStax](https://en.wikipedia.org/wiki/DataStax), [NGINX](https://en.wikipedia.org/wiki/Nginx), [Couchbase](https://en.wikipedia.org/wiki/Couchbase_Server) and other leading infrastructure companies).  
2. **We are remaining true to our origin**, [as an alternative to proprietary solutions that lock in user data.](https://www.mattermost.org/why-we-made-mattermost-an-open-source-slack-alternative/) For people who need functionality beyond the scope we have selected, our underlying source code remains available and [there is a path to use it for either commercial or non-commercial open source solutions](https://docs.mattermost.com/overview/faq.html#how-can-i-create-a-derivative-work-of-mattermost-as-my-own-commercial-solution). A product for everybody is a product for nobody, 
3. **This change is a refinement** to our [existing product vision](https://docs.mattermost.com/overview/product.html), not a change in direction. 
4. **Our manifesto should recognize the outstanding progress we've made,** in terms of [reaching a much broader, non-technical audience](https://www.youtube.com/watch?v=AKqHWqrAgpk&t=12s) than our 1.0 offering (a non-technical user can deploy a Mattermost instance to AWS/Azure/OCP/GCP and migrate in a Slack team and all its history in less than 10 minutes thank to Bitnami), as well as the massive adoption we've had in [the world's most security and privacy conscious organizations because of our partnerships.](https://about.mattermost.com/open-source-slack-alternative-for-azure-government-plus-aws-gcp-and-ocp-via-bitnami-mattermost-team-edition-stack/)
5. **Most influential discussion is informed discussions** by appropriate study of the materials discussed in the past three months, including the history, purpose and objectives of our products, partnerships, integrations community, deployment solutions community, translation community, customers, and end users. Importantly, we should deeply understand the [Wordpress philosophy](https://wordpress.org/about/philosophy/) on which our principles are modeled. At a minimum, our final review should be conducted with an understanding of the materials referenced in this outline. 
6. **Please avoid "I saw this thing" (ISTT)**. Please avoid dropping by with a random comment referencing something you read about on the internet that does things differently--it's much more useful to speak as a user of the product, and ideally as someone who's completed the readings outlined here. 

This all said, the Mattermost product line is evolving and the Manifesto represented a point in time, and will change as well. When it does change, our discussions about principles should themselves be principled. 

  