### PR TITLE
Add nasm as an install requirement for Ubuntu

### DIFF
--- a/source/developer/developer-setup.md
+++ b/source/developer/developer-setup.md
@@ -46,8 +46,8 @@ Any issues? Please let us know on our forums at: https://forum.mattermost.org/
 2. Set up your dockerhost address
 	1. Edit your `/etc/hosts` file to include the following line  
 		- `127.0.0.1 dockerhost`
-3. Install build essentials
-	1. `apt-get install build-essential`
+3. Install build dependencies
+	1. `apt-get install build-essential nasm`
 4. [Download Go 1.8](http://golang.org/dl/).
 5. Set up your Go workspace and add Go to the PATH
 	1. `mkdir ~/go`


### PR DESCRIPTION
I'm running Ubuntu 17.04.
mozjpeg needs nasm to build. So without installing it the build failed for me. After installing nasm I got my dev environment working.

  ⚠ The `/home/jonas/go/src/github.com/mattermost/platform/webapp/node_modules/mozjpeg/vendor/cjpeg` binary doesn't seem to work correctly
  ⚠ mozjpeg pre-build test failed
  ℹ compiling from source
  ✔ mozjpeg built successfully
mattermost-webapp@0.0.1 /home/jonas/go/src/github.com/mattermost/platform/webapp
└─┬ image-webpack-loader@3.2.0
  └─┬ imagemin-mozjpeg@6.0.0
    └── mozjpeg@4.1.1