### PR TITLE
use correct role values in "Example User object"

### DIFF
--- a/source/deployment/bulk-loading-data-format.rst
+++ b/source/deployment/bulk-loading-data-format.rst
@@ -295,11 +295,11 @@ For clarity, the object is shown using regular JSON formatting, but in the data 
       teams: [
         {
           name: "team-name",
-          roles: "team_member team_admin",
+          roles: "team_user team_admin",
           channels: [
             {
               name: "channel-name",
-              roles: "channel_member",
+              roles: "channel_user",
               notify_props: {
                 desktop: "default",
                 mark_unread: "all"


### PR DESCRIPTION
The correct roles are [`team_user`](https://github.com/mattermost/platform/blob/fb6f2a123c7fefc8d8270e273e9ef4007f88cefd/model/authorization.go#L334) and [`channel_user`](https://github.com/mattermost/platform/blob/fb6f2a123c7fefc8d8270e273e9ef4007f88cefd/model/authorization.go#L302).