### PR TITLE
Added a location entry for v4 API

### DIFF
--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -41,6 +41,21 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
            proxy_pass http://backend;
        }
 
+       location /api/v4/websocket {
+           proxy_set_header Upgrade $http_upgrade;
+           proxy_set_header Connection "upgrade";
+           client_max_body_size 50M;
+           proxy_set_header Host $http_host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+           proxy_set_header X-Frame-Options SAMEORIGIN;
+           proxy_buffers 256 16k;
+           proxy_buffer_size 16k;
+           proxy_read_timeout 600s;
+           proxy_pass http://backend;
+       }
+
        location / {
            client_max_body_size 50M;
            proxy_set_header Connection "";


### PR DESCRIPTION
Added a location for v4 API to the NGINX config, with contents identical to the /api/v3/users/websocket location. See https://pre-release.mattermost.com/core/pl/mrux4tmk37dnjgee9uccaoou8y

```
       location /api/v4/websocket {
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection "upgrade";
           client_max_body_size 50M;
           proxy_set_header Host $http_host;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
           proxy_set_header X-Frame-Options SAMEORIGIN;
           proxy_buffers 256 16k;
           proxy_buffer_size 16k;
           proxy_read_timeout 600s;
           proxy_pass http://backend;
       }
```