### PR TITLE
Update changelog.rst

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -42,7 +42,7 @@ Release Date: April 16, 2017
 - Reduced the margins and line height in compact view.
 - There is now a confirmation dialog before deleting a custom emoji.
 - Updated error page for invalid permalinks.
-- Updated error page for "Private browsing not supported" page in Safari.
+- Updated error page for "Private browsing not supported" in Safari.
 
 #### Performance
 - Added index and cache to reactions store
@@ -65,7 +65,6 @@ Release Date: April 16, 2017
 
 #### Link Previews
 - Updated UI for link previews by removing an extra blue vertical bar.
-- Link preview image no longer appears outside of the preview container.
 - Added support for link preview requests through a separate proxy.
 
 #### Notifications
@@ -96,6 +95,7 @@ Release Date: April 16, 2017
 - Usernames on channel member list are now properly aligned.
 - Fixed a console error thrown when switching teams.
 - Fixed channel autocomplete sometimes flickering.
+- Link preview image no longer appears outside of the preview container.
 
 ### Compatibility  
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -41,8 +41,8 @@ Release Date: April 16, 2017
 - The "Add Members" modal now autofocuses on the search box when opened from the "Manage Members" modal.
 - Reduced the margins and line height in compact view.
 - There is now a confirmation dialog before deleting a custom emoji.
-- Updated error page for invalid permalinks.
-- Updated error page for "Private browsing not supported" in Safari.
+- Updated the error page for invalid permalinks.
+- Updated the error page for "Private browsing not supported" in Safari.
 
 #### Performance
 - Added index and cache to reactions store
@@ -64,7 +64,7 @@ Release Date: April 16, 2017
 - The integrations confirmation page can now be dismissed with the ENTER key.
 
 #### Link Previews
-- Updated UI for link previews by removing an extra blue vertical bar.
+- Updated the UI for link previews by removing an extra blue vertical bar.
 - Added support for link preview requests through a separate proxy.
 
 #### Notifications
@@ -76,7 +76,7 @@ Release Date: April 16, 2017
 #### Enterprise Edition
 - Policy controls for restricting permissions to add and remove members from private channels.
 - Added the ability to read the license file from the disk.
-- Configuration file now reloaded after applying an Enterprise Edition license on startup.
+- The configuration file is now reloaded after applying an Enterprise Edition license on startup.
 
 ### Bug Fixes
 - Fixed line wrapping of the timestamp in Account Settings > Security > View Access History.
@@ -92,10 +92,10 @@ Release Date: April 16, 2017
 - Fixed an issue where link previews would sometimes cause a horizontal scroll bar to appear.
 - iOS code blocks no longer wrap to the next line.
 - Removed an extra border in Markdown tables on iOS.
-- Usernames on channel member list are now properly aligned.
-- Fixed a console error thrown when switching teams.
-- Fixed channel autocomplete sometimes flickering.
-- Link preview image no longer appears outside of the preview container.
+- Usernames in the channel member list are now properly aligned.
+- Fixed a console error that was thrown when switching teams.
+- Fixed occasionial flickering of channel autocomplete.
+- Link preview images no longer appear outside of the preview container.
 
 ### Compatibility  
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -41,6 +41,11 @@ Release Date: April 16, 2017
 - The "Add Members" modal now autofocuses on the search box when opened from the "Manage Members" modal.
 - Reduced the margins and line height in compact view.
 - There is now a confirmation dialog before deleting a custom emoji.
+- Updated error page for invalid permalinks.
+- Updated error page for "Private browsing not supported" page in Safari.
+
+#### Performance
+- Added index and cache to reactions store
 
 #### Search
 - File attachments thumbnails are now shown in search results.
@@ -58,6 +63,11 @@ Release Date: April 16, 2017
 #### Integrations
 - The integrations confirmation page can now be dismissed with the ENTER key.
 
+#### Link Previews
+- Updated UI for link previews by removing an extra blue vertical bar.
+- Link preview image no longer appears outside of the preview container.
+- Added support for link preview requests through a separate proxy.
+
 #### Notifications
 - Users can no longer configure email notification settings if the notifications are disabled for the system.
 
@@ -67,6 +77,7 @@ Release Date: April 16, 2017
 #### Enterprise Edition
 - Policy controls for restricting permissions to add and remove members from private channels.
 - Added the ability to read the license file from the disk.
+- Configuration file now reloaded after applying an Enterprise Edition license on startup.
 
 ### Bug Fixes
 - Fixed line wrapping of the timestamp in Account Settings > Security > View Access History.
@@ -81,6 +92,10 @@ Release Date: April 16, 2017
 - Fixed an issue where usernames sometimes did not appear when hovering over reactions.
 - Fixed an issue where link previews would sometimes cause a horizontal scroll bar to appear.
 - iOS code blocks no longer wrap to the next line.
+- Removed an extra border in Markdown tables on iOS.
+- Usernames on channel member list are now properly aligned.
+- Fixed a console error thrown when switching teams.
+- Fixed channel autocomplete sometimes flickering.
 
 ### Compatibility  
 


### PR DESCRIPTION
Add missing v3.8 changelog entries.

Reviewed GitHub PR query [that needed a changelog entry](https://github.com/mattermost/platform/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aclosed%20merged%3A%3E%3D2017-03-06%20-label%3A%22Changelog%3A%20Done%22%20%20-label%3A%22Changelog%3A%20Not%20needed%22%20) and found a few for 3.8.

@esethna Do you think any changes are needed for the GitHub label process? https://docs.google.com/document/d/1S4VWtDXCTXw6toXBbbWrdmWuPas1NkKV33YCp9YCy-k/edit#bookmark=id.5xtcqvftngwa