### PR TITLE
Added install notes for CentOS, Oracle Linux, and Scientific Linux

### DIFF
--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -15,6 +15,7 @@ Installing Mattermost
    Installing on Ubuntu 16.04 LTS </install/install-ubuntu-1604.rst>
    Installing on RHEL 6.6 </install/install-rhel-66.rst>
    Installing on RHEL 7.1 </install/install-rhel-71.rst>
+   Installing on CentOS, Oracle Linux, and Scientific Linux </install/install-centos-oracle-scientific.rst>
    /install/docker-local*
    /install/docker-ebs*
    /install/ee-install*

--- a/source/install/install-centos-oracle-scientific.rst
+++ b/source/install/install-centos-oracle-scientific.rst
@@ -1,0 +1,8 @@
+Installing Mattermost on CentOS, Oracle Linux, and Scientific Linux
+===================================================================
+
+To install Mattermost on CentOS, Oracle Linux, and Scientific Linux, you can use the instructions for installing Mattermost on RHEL. With the exception of the operating system that you install, the process is identical.
+
+To install Mattermost on CentOS 6, Oracle Linux 6, and Scientific Linux 6, see :doc:`install-rhel-66`
+
+To install Mattermost on CentOS 7, Oracle Linux 7, and Scientific Linux 7, see :doc:`install-rhel-71`

--- a/source/install/install-rhel-66.rst
+++ b/source/install/install-rhel-66.rst
@@ -4,14 +4,14 @@
 Installing Mattermost on RHEL 6.6
 =================================
 
-Install a production-ready Mattermost system on 1 to 3 machines.
+You can also use these instructions to install Mattermost on CentOS 6, Oracle Linux 6, or Scientific Linux 6. With the exception of the operating system that you install, the process is identical.
 
 .. include:: install-common-intro.rst
 
 .. contents:: Install and configure the components in the following order. Note that you need only one database, either MySQL or PostgreSQL.
   :backlinks: top
   :local:
-  
+
 .. include:: install-rhel-66-server.rst
 .. include:: install-rhel-66-mysql.rst
 .. include:: install-rhel-66-postgresql.rst

--- a/source/install/install-rhel-71.rst
+++ b/source/install/install-rhel-71.rst
@@ -4,14 +4,14 @@
 Installing Mattermost on RHEL 7.1
 =================================
 
-Install a production-ready Mattermost system on 1 to 3 machines.
+You can also use these instructions to install Mattermost on CentOS 7, Oracle Linux 7, or Scientific Linux 7. With the exception of the operating system that you install, the process is identical.
 
 .. include:: install-common-intro.rst
 
 .. contents:: Install and configure the components in the following order. Note that you need only one database, either MySQL or PostgreSQL.
   :backlinks: top
   :local:
-  
+
 .. include:: install-rhel-71-server.rst
 .. include:: install-rhel-71-mysql.rst
 .. include:: install-rhel-71-postgresql.rst


### PR DESCRIPTION
Adding support for CentOS, Oracle Linux, and Scientific Linux to the installation docs. The installs for these OS's are the same as RHEL.