### PR TITLE
Doc updates for 3.6.7 and 3.7.5

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -233,11 +233,11 @@ mattermost-redux:
 ### Notes on Patch Release
 
  - **v3.7.5, released 2017-04-27**
-   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
+   - Fixed a number of low to moderate severity security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
      - Note: The **System Console > Configuration > [Site URL](../../administration/config-settings.html#site-url)** field is now mandatory. Set the Site URL in the System Console, or in the `gitlab.rb` file if you are using GitLab Mattermost.
      - Note: Upgrading will invalidate existing team invite links and email verifications.
  - **v3.7.4, released 2017-04-13**
-   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
+   - Fixed a number of low to high severity security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
  - **v3.7.3, released 2017-03-23**
    - Fixed a high severity security issue, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
    - Fixed an issue with telemetry data collection
@@ -522,10 +522,12 @@ Many thanks to all our contributors. In alphabetical order:
 ### Notes on Patch Release
 
  - **v3.6.7, released 2017-04-27**
-   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
+   - Fixed a number of low to moderate severity security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
      - Note: The **System Console > Configuration > [Site URL](../../administration/config-settings.html#site-url)** field is now mandatory. Set the Site URL in the System Console, or in the `gitlab.rb` file if you are using GitLab Mattermost.
  - **v3.6.6, released 2017-04-13**
-   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
+   - Fixed a number of low to high severity security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
+   - Fixed an issue where Direct Messages list didn't always properly update in the left-hand sidebar
+   - Upgraded MySQL driver for better performance
  - **v3.6.5, released 2017-03-23**
    - Fixed a high severity security issue, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
  - **v3.6.4, released 2017-03-16**

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -228,10 +228,16 @@ mattermost-redux:
 - [crspeller](https://github.com/crspeller), [csduarte](https://github.com/csduarte)
 
 
-## Release v3.7.3
+## Release v3.7.5
 
 ### Notes on Patch Release
 
+ - **v3.7.5, released 2017-04-27**
+   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
+     - Note: The **System Console > Configuration > [Site URL](../../administration/config-settings.html#site-url)** field is now mandatory. Set the Site URL in the System Console, or in the `gitlab.rb` file if you are using GitLab Mattermost.
+     - Note: Upgrading will invalidate existing team invite links and email verifications.
+ - **v3.7.4, released 2017-04-13**
+   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
  - **v3.7.3, released 2017-03-23**
    - Fixed a high severity security issue, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
    - Fixed an issue with telemetry data collection
@@ -515,6 +521,11 @@ Many thanks to all our contributors. In alphabetical order:
 
 ### Notes on Patch Release
 
+ - **v3.6.7, released 2017-04-27**
+   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
+     - Note: The **System Console > Configuration > [Site URL](../../administration/config-settings.html#site-url)** field is now mandatory. Set the Site URL in the System Console, or in the `gitlab.rb` file if you are using GitLab Mattermost.
+ - **v3.6.6, released 2017-04-13**
+   - Fixed a number of security issues, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
  - **v3.6.5, released 2017-03-23**
    - Fixed a high severity security issue, and [upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/)
  - **v3.6.4, released 2017-03-16**

--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -11,19 +11,16 @@ To start, select one of the following guides:
 
 ## Upgrade Team Edition to 3.1.x and later
 
-**Important Note:** Security-related changes were made in 3.8 that require you to verify settings in the System Console before upgrading from version 3.7.x and earlier to any version greater than 3.8.0.
-
-**To prepare your system when upgrading from 3.7.x and earlier**:
-
-  1. In the System Console, go to **General > Configuration** and make sure that the **Site URL** is specified. It must not be empty.
-  2. In the System Console, go to **General > Logging** and make sure that the **File Log Directory** field is either empty or has a directory path only. It must not have a filename as part of the path.
+**Important Note:** Security-related changes were made in `v3.6.x` and later that require you to specify the Site URL setting in the System Console before upgrading from version `v3.5.x` and earlier to any version greater than `v3.6.x`. In the System Console, go to **General > Configuration** and make sure that the **Site URL** is specified. It must not be empty.
 
 **To upgrade your system**:
 
 1. Download the **appropriate next upgrade** of your Team Edition server and note any compatibility procedures:
       1. Run `platform -version` to check the current version of your Mattermost server
       2. Determine the appropriate next upgrade for your server:
-          - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/), but see the previous note about upgrading from 3.7.x and earlier.
+          - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/) considering the conditions below:
+              - Note: Upgrading from `v3.7.x` and earlier to `v3.8.x` and later, you must ensure that the **System Console** > **General > Logging** > **File Log Directory** field is either empty or has a directory path only. It must not have a filename as part of the path. 
+              - Note: Upgrading from `v3.5.x` and earlier to `v3.6.x` and later will invalidate existing team invite links and email verifications.
               - Note: If public links are enabled, upgrading from `v3.3.x` and earlier to `v3.4.x` and later will invalidate existing public links due to a security upgrade allowing admins to invalidate links by resetting a public link salt from the System Console.
               - Note: RHEL6 and Ubuntu installations must verify the line `limit nofile 50000 50000` is included in `/etc/init/mattermost.conf` file. See the [installation guide](https://docs.mattermost.com/guides/administrator.html#install-guides) for your operating system for more details.
               - Note: RHEL7 and Debian installations must verify the line `LimitNOFILE=49152` is included in the `/etc/systemd/system/mattermost.service` file. See the [installation guide](https://docs.mattermost.com/guides/administrator.html#install-guides) for your operating system for more details.

--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -125,12 +125,12 @@ Private cloud enterprise communications server.
 - Mattermost Enterprise Edition v3.8.2 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-8-2) - [Download](https://releases.mattermost.com/3.8.2/mattermost-3.8.2-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.8.2/mattermost-3.8.2-linux-amd64.tar.gz`
   - SHA-256 Checksum: `b99c86a2667f636eaee26331aa61a71a51b2d3d412eaa83fdebf8b53cddc6aeb`
-- Mattermost Enterprise Edition v3.7.4 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-4) - [Download](https://releases.mattermost.com/3.7.4/mattermost-3.7.4-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.7.4/mattermost-3.7.4-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `adc84d61e14812ff5bfd788be7e49f2e8b8d7803909fa83ce7e6b0f27cee2394`
-- Mattermost Enterprise Edition v3.6.6 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-6) - [Download](https://releases.mattermost.com/3.6.6/mattermost-3.6.6-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.6.6/mattermost-3.6.6-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `257400926c3a20212a210fdeec2b0ef60f6845ed4075598b374c64e224a08b9f`
+- Mattermost Enterprise Edition v3.7.5 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-5) - [Download](https://releases.mattermost.com/3.7.5/mattermost-3.7.5-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.7.5/mattermost-3.7.5-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `65e65da661edbc7b7b2b02411f13dbe498fd704d5ae1289789feca79fe00b58a`
+- Mattermost Enterprise Edition v3.6.7 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-7) - [Download](https://releases.mattermost.com/3.6.7/mattermost-3.6.7-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.6.7/mattermost-3.6.7-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `8e666708fead5fbfcf1f20617b07fda21cc8cbc85f9690321cbf4a41bfc1dd89`
 - Mattermost Enterprise Edition v3.5.1 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-5-1) - [Download](https://releases.mattermost.com/3.5.1/mattermost-3.5.1-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.5.1/mattermost-3.5.1-linux-amd64.tar.gz`
   - SHA-256 Checksum: `b972ac6f38f8b4c4f364e40a7c0e7819511315a81cb38c8a51c0622d7c5b14a1`
@@ -168,12 +168,12 @@ Open source self-hosted team communication server compiled by Mattermost, Inc, a
 - Mattermost Team Edition v3.8.2 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-8-2) - [Download](https://releases.mattermost.com/3.8.2/mattermost-team-3.8.2-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.8.2/mattermost-team-3.8.2-linux-amd64.tar.gz`
   - SHA-256 Checksum: `82cc85557dc21b3871ec89326769c11d3a89c9c41362fb3945247f8fba562ce7`
-- Mattermost Team Edition v3.7.4 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-4) - [Download](https://releases.mattermost.com/3.7.4/mattermost-team-3.7.4-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.7.4/mattermost-team-3.7.4-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `17ec3c85d7c210aa4d856aea437e7a23bb9e7c3e68031ba458a029d032730d01`
-- Mattermost Team Edition v3.6.6 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-6) - [Download](https://releases.mattermost.com/3.6.6/mattermost-team-3.6.6-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.6.6/mattermost-team-3.6.6-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `6e501390c11f74b88d0992f9fd25d53dd7e30016c692cefb6f4bcdde29575dd7`
+- Mattermost Team Edition v3.7.5 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-5) - [Download](https://releases.mattermost.com/3.7.5/mattermost-team-3.7.5-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.7.5/mattermost-team-3.7.5-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `eaee6a57ab9e2924f71853cbebf465d63f7dbf1112716c0e4768984de39f83a2`
+- Mattermost Team Edition v3.6.7 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-7) - [Download](https://releases.mattermost.com/3.6.7/mattermost-team-3.6.7-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.6.7/mattermost-team-3.6.7-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `8378f15a6bd070386077798f36d8e521b63844bc838f6553915c6fd4fba3b01d`
 - Mattermost Team Edition v3.5.1 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-5-1) - [Download](https://releases.mattermost.com/3.5.1/mattermost-team-3.5.1-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.5.1/mattermost-team-3.5.1-linux-amd64.tar.gz`
   - SHA-256 Checksum: `2c6bc8b1c25e48d1ac887cd6cbef77df1f80542127b4d98c4d7c0dfbfade04d5`

--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -11,7 +11,7 @@ To start, select one of the following guides:
 
 ## Upgrade Team Edition to 3.1.x and later
 
-**Important Note:** Security-related changes were made in `v3.6.x` and later that require you to specify the Site URL setting in the System Console before upgrading from version `v3.5.x` and earlier to any version greater than `v3.6.x`. In the System Console, go to **General > Configuration** and make sure that the **Site URL** is specified. It must not be empty.
+**Important Note:** Security-related changes require you to specify the Site URL setting when upgrading to `v3.6.x` and later. The Site URL can be set in the `config.json` or in **System Console** > **General > Configuration** > [**Site URL**](https://docs.mattermost.com/administration/config-settings.html#site-url). If you are using GitLab Mattermost, you must set the Site URL in the `gitlab.rb` file.
 
 **To upgrade your system**:
 
@@ -19,8 +19,8 @@ To start, select one of the following guides:
       1. Run `platform -version` to check the current version of your Mattermost server
       2. Determine the appropriate next upgrade for your server:
           - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/) considering the conditions below:
-              - Note: Upgrading from `v3.7.x` and earlier to `v3.8.x` and later, you must ensure that the **System Console** > **General > Logging** > **File Log Directory** field is either empty or has a directory path only. It must not have a filename as part of the path. 
-              - Note: Upgrading from `v3.5.x` and earlier to `v3.6.x` and later will invalidate existing team invite links and email verifications.
+              - Note: Upgrading to `v3.8.x` and later, you must ensure that the **System Console** > **General > Logging** > [**File Log Directory**](https://docs.mattermost.com/administration/config-settings.html#file-log-directory) field is either empty or contains a directory path. It must not have a filename as part of the path. 
+              - Note: Upgrading to `v3.7.x` and later will invalidate existing team invite links and email verifications.
               - Note: If public links are enabled, upgrading from `v3.3.x` and earlier to `v3.4.x` and later will invalidate existing public links due to a security upgrade allowing admins to invalidate links by resetting a public link salt from the System Console.
               - Note: RHEL6 and Ubuntu installations must verify the line `limit nofile 50000 50000` is included in `/etc/init/mattermost.conf` file. See the [installation guide](https://docs.mattermost.com/guides/administrator.html#install-guides) for your operating system for more details.
               - Note: RHEL7 and Debian installations must verify the line `LimitNOFILE=49152` is included in the `/etc/systemd/system/mattermost.service` file. See the [installation guide](https://docs.mattermost.com/guides/administrator.html#install-guides) for your operating system for more details.


### PR DESCRIPTION
Updated:
- upgrade guide (version archive and upgrade notes)
- Changelog patch release sections and compatibility notes