### PR TITLE
Update config-tls-mattermost.rst with note on skipping section

### DIFF
--- a/source/install/config-tls-mattermost.rst
+++ b/source/install/config-tls-mattermost.rst
@@ -1,30 +1,33 @@
-Configuring TLS on the Mattermost Server
-========================================
+Configuring TLS on Mattermost Server
+====================================
 
-. Note::
-  You can skip this section if you will be using NGINX to specify the certificates in use and configure the TLS/SSL settings.
+If you want users to connect with HTTPS, you have two options. One option is to set up TLS on Mattermost Server. Another option is to install a proxy such as NGINX and set up TLS on the proxy. The easiest option is to set up TLS on Mattermost Server, but if you expect to have more than 200 users, use a proxy for better performance. A proxy server also provides standard HTTP request logs.
 
-1. Go to the **General** > **Configuration** section of the System Console.
-2. Change the **Listen Address** setting to ``:443``
-3. Change the **Connection Security** setting to ``TLS``
-4. Change the **Forward port 80 to 443** setting to ``true`` if you wish to redirect users that try to connect insecurely to a secure connection. If you're using a proxy such as NGINX in front of Mattermost this setting is unnecessary and should be set to ``false``
-5. Run ``sudo setcap cap_net_bind_service=+ep ./bin/platform`` in your Mattermost directory to allow Mattermost to bind to low ports. You will need to re-run this command every time you upgrade Mattermost or it will fail to bind to the port.
+**To configure TLS on Mattermost Server**:
 
-At this point you have two options: automatic certificate retrieval though Let's Encrypt or manually specifying a certificate.
+1. In the GENERAL section of the System Console, click **Configuration**.
+2. Change the **Listen Address** setting to ``:443``.
+3. Change the **Connection Security** setting to ``TLS``.
+4. Change the **Forward port 80 to 443** setting to ``true``.
+5. Activate the CAP_NET_BIND_SERVICE capability to allow Mattermost to bind to low ports.
 
-Automatic Certificate Retrieval
--------------------------------
+  a. Open a terminal window and change to the Mattermost ``bin`` directory.
+    ``cd /opt/mattermost/bin``
+  b. Run the following command:
+    ``sudo setcap cap_net_bind_service=+ep ./platform``
 
-In this mode a certificate will be automatically retrieved the first time a client tries to connect to the Mattermost server. Certificates will be retrieved for any hostname a client tries to reach the server at. Setting this up is only one step:
+6. Install the security certificate. You can use `Let's Encrypt <https://letsencrypt.org/>`_ to automatically install and setup the certificate, or you can specify your own certificate.
 
-1. Change the **Use Let's Encrypt** setting to ``true``.
-2. Restart the Mattermost server for these changes to take effect.
+  **To use a Let's Encrypt certificate**:
 
+    The certificate is retrieved the first time that a client tries to connect to the Mattermost server. Certificates are retrieved for any hostname a client tries to reach the server at.
 
-Manual Certificate Specification
---------------------------------
+    a. Change the **Use Let's Encrypt** setting to ``true``.
+    b. Restart the Mattermost server for these changes to take effect.
 
-1. Change the **Use Let's Encrypt** setting to ``false``.
-2. Change the **TLS Certificate File** setting to the location of the certificate file.
-3. Change the **TLS Key File** setting to the location of the private key file.
-4. Restart the Mattermost server for these changes to take effect. 
+  **To use your own certificate**:
+
+    a. Change the **Use Let's Encrypt** setting to ``false``.
+    b. Change the **TLS Certificate File** setting to the location of the certificate file.
+    c. Change the **TLS Key File** setting to the location of the private key file.
+    d. Restart the Mattermost server for these changes to take effect.

--- a/source/install/config-tls-mattermost.rst
+++ b/source/install/config-tls-mattermost.rst
@@ -1,22 +1,27 @@
 Configuring TLS on Mattermost Server
 ====================================
 
-If you want users to connect with HTTPS, you have two options. One option is to set up TLS on Mattermost Server. Another option is to install a proxy such as NGINX and set up TLS on the proxy. The easiest option is to set up TLS on Mattermost Server, but if you expect to have more than 200 users, use a proxy for better performance. A proxy server also provides standard HTTP request logs.
+You have two options if you want users to connect with HTTPS: 
 
-**To configure TLS on Mattermost Server**:
+  1. Set up TLS on Mattermost Server. 
+  2. Install a proxy such as NGINX and set up TLS on the proxy. 
 
-1. In the GENERAL section of the System Console, click **Configuration**.
-2. Change the **Listen Address** setting to ``:443``.
-3. Change the **Connection Security** setting to ``TLS``.
-4. Change the **Forward port 80 to 443** setting to ``true``.
-5. Activate the CAP_NET_BIND_SERVICE capability to allow Mattermost to bind to low ports.
+The easiest option is to set up TLS on the Mattermost Server, but if you expect to have more than 200 users, use a proxy for better performance. A proxy server also provides standard HTTP request logs.
+
+**Configure TLS on the Mattermost Server**:
+
+1. In the **System Console** > **General** > **Configuration**.
+  a. Change the **Listen Address** setting to ``:443``.
+  b. Change the **Connection Security** setting to ``TLS``.
+  c. Change the **Forward port 80 to 443** setting to ``true``.
+2. Activate the ``CAP_NET_BIND_SERVICE`` capability to allow Mattermost to bind to low ports.
 
   a. Open a terminal window and change to the Mattermost ``bin`` directory.
     ``cd /opt/mattermost/bin``
   b. Run the following command:
     ``sudo setcap cap_net_bind_service=+ep ./platform``
 
-6. Install the security certificate. You can use `Let's Encrypt <https://letsencrypt.org/>`_ to automatically install and setup the certificate, or you can specify your own certificate.
+3. Install the security certificate. You can use `Let's Encrypt <https://letsencrypt.org/>`_ to automatically install and setup the certificate, or you can specify your own certificate.
 
   **To use a Let's Encrypt certificate**:
 

--- a/source/install/config-tls-mattermost.rst
+++ b/source/install/config-tls-mattermost.rst
@@ -1,6 +1,9 @@
 Configuring TLS on the Mattermost Server
 ========================================
 
+. Note::
+  You can skip this section if you will be using NGINX to specify the certificates in use and configure the TLS/SSL settings.
+
 1. Go to the **General** > **Configuration** section of the System Console.
 2. Change the **Listen Address** setting to ``:443``
 3. Change the **Connection Security** setting to ``TLS``


### PR DESCRIPTION
The added note makes it clear that you need not specify TLS settings in both the Mattermost application as well as in the NGINX configuration. If you follow the guide (without these changes) from top to bottom, for say Ubuntu 16.04, then it might be a bit confusing as to why you would be specifying all the TLS settings and certs in the app - if later the guide explains how to do this for NGINX SSL termination.

(I did not create a ticket for this work as reading the contribution guidelines it sounds like this satisfies the "if the change to existing behaviour is small" clause for submitting without a Help Wanted ticket)