### PR TITLE
Revert "Added a location entry for v4 API"

### DIFF
--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -41,21 +41,6 @@ NGINX is configured using a file in the ``/etc/nginx/sites-available`` directory
            proxy_pass http://backend;
        }
 
-       location /api/v4/websocket {
-           proxy_set_header Upgrade $http_upgrade;
-           proxy_set_header Connection "upgrade";
-           client_max_body_size 50M;
-           proxy_set_header Host $http_host;
-           proxy_set_header X-Real-IP $remote_addr;
-           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-           proxy_set_header X-Forwarded-Proto $scheme;
-           proxy_set_header X-Frame-Options SAMEORIGIN;
-           proxy_buffers 256 16k;
-           proxy_buffer_size 16k;
-           proxy_read_timeout 600s;
-           proxy_pass http://backend;
-       }
-
        location / {
            client_max_body_size 50M;
            proxy_set_header Connection "";


### PR DESCRIPTION
Reverts mattermost/docs#1096

Reverting due to changes made against master by this PR: [Update NGINX configuration for websocket connections #1144](https://github.com/mattermost/docs/pull/1144)