### PR TITLE
Update instruction for switching to team edition

### DIFF
--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -51,4 +51,4 @@ Production Docker Setup on Mac OS X
 
 You can run a production deployment on Mac OS X by `installing Docker Compose using the online guide <http://docs.docker.com/installation/mac/>`_ then following the above instructions.
 
-**Other options:** To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, repeat steps above excluding ``-b enterprise`` from ``git clone`` command.
+**Other options:** To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, please see follow this `instruction. <https://github.com/mattermost/mattermost-docker#choose-edition-to-install>`__

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -51,4 +51,4 @@ Production Docker Setup on Mac OS X
 
 You can run a production deployment on Mac OS X by `installing Docker Compose using the online guide <http://docs.docker.com/installation/mac/>`_ then following the above instructions.
 
-**Other options:** To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, please see follow this `instruction. <https://github.com/mattermost/mattermost-docker#choose-edition-to-install>`__
+**Other options:** To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, just comment out "dockerfile: Dockerfile-enterprise" in docker-compose.yaml file.    

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -54,7 +54,7 @@ You can run a production deployment on Mac OS X by `installing Docker Compose us
 Other options:
 --------------
 
-To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, open ``docker-compose.yaml`` and comment out the following line:
+To install Mattermost Team Edition instead of Mattermost Enterprise Edition, open ``docker-compose.yaml`` and comment out the following line:
 
   .. code-block:: text
 

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -51,4 +51,11 @@ Production Docker Setup on Mac OS X
 
 You can run a production deployment on Mac OS X by `installing Docker Compose using the online guide <http://docs.docker.com/installation/mac/>`_ then following the above instructions.
 
-**Other options:** To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, just comment out "dockerfile: Dockerfile-enterprise" in docker-compose.yaml file.    
+Other options:
+--------------
+
+To install a feature-equivalent version of Mattermost that does not upgrade to enterprise features using a license key, Mattermost Team Edition, open ``docker-compose.yaml`` and comment out the following line:
+
+  .. code-block:: text
+
+    dockerfile: Dockerfile-enterprise


### PR DESCRIPTION
Since the enterprise branch and team branch are merged into master, the instruction to switch edition has changed.