### PR TITLE
Style Guide: Added plural form of emoji

### DIFF
--- a/source/process/sg_general-guidelines.rst
+++ b/source/process/sg_general-guidelines.rst
@@ -61,6 +61,15 @@ Word Usage Guidelines
 
 To promote consistency and clarity, follow the word usage and spelling guidelines in the following list.
 
+can, might, may
+  The word *may* can have several meanings. To avoid ambiguity, use *can* or *might* instead of *may*. Use *can* to mean *capable of* and *might* to mean that something is possible. Use *may* only to give permission to do something.
+
+downtime
+  Use as one word *downtime*, not *down time*.
+
+emoji, emojis
+  Use *emojis* as the plural form of *emoji*.
+
 login, log in, log into
   Use *login* as a noun or adjective, and *log in* and *log into* as verbs. For example: *Log into the Mattermost server using your System Admin login credentials.*
 
@@ -72,12 +81,6 @@ sign-in, sign in, and sign into
 
 single sign-on
   Single sign-on is abbreviated as SSO. When using the long form in a heading with title case, it's *Single Sign-on*.
-
-can, might, may
-  The word *may* can have several meanings. To avoid ambiguity, use *can* or *might* instead of *may*. Use *can* to mean *capable of* and *might* to mean that something is possible. Use *may* only to give permission to do something.
-
-downtime
-  Use as one word *downtime*, not *down time*.
 
 Gender-neutral Text
 -------------------


### PR DESCRIPTION
The Internet is up in arms about which is the correct form of emoji: Is it *emoji* or *emojis*. Personally, I like *emojii* but that's not an option :)

Until the dust settles, we should use *emojis* for the following reasons:

1. Because *emojis* is unambiguously plural, sentences are easier to mentally parse, especially for those whose English is not perfect.
1. If *emoji* turns out to be the accepted form, then a simple regex can replace all occurrences in our docs. However, if we use *emoji*, and *emojis* turns out to be accepted, the regex is somewhat more complicated because it'll have to know when *emoji* is singular and should be ignored and when *emoji* is plural and should be changed.
1. If *emoji* turns out to be the accepted form, then people will still know what *emojis* means.

I also re-ordered the word list so that it's alphabetical.


