### PR TITLE
Clarified the value to use for team name in CLI

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -374,10 +374,9 @@ platform team
 .. note::
     **{team-name} value**
 
-    For the *add*, *delete*, and *remove* commands, the *{team-name}* value comes from the *Name*  column in the *Teams* database, and is not the name that is displayed in the UI.
+    For the *add*, *delete*, and *remove* commands, you can determine the *{team-name}* value from the URLs that you use to access your instance of Mattermost. For example, in the following URL the *{team-name}* value is *myteam*:
 
-    You can usually derive the *{team-name}* from the display name by converting the display name to all lowercase letters and replacing spaces with dashes. For example, *My Team* becomes *my-team*. This works for teams that were created using the UI, but won't work if a custom value for the team name was specified when using the `platform team create`_ command. In that case, you must examine the database to find out the team name.
-
+    ``https://example.com/myteam/channels/mychannel``
 
 platform team add
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -369,16 +369,26 @@ platform team
     -  `platform team delete`_ - Delete a team
     -  `platform team remove`_ - Remove users from a team
 
+.. _team-value-note:
+
+.. note::
+    **{team-name} value**
+
+    For the *add*, *delete*, and *remove* commands, the *{team-name}* value comes from the *Name*  column in the *Teams* database, and is not the name that is displayed in the UI.
+
+    You can usually derive the *{team-name}* from the display name by converting the display name to all lowercase letters and replacing spaces with dashes. For example, *My Team* becomes *my-team*. This works for teams that were created using the UI, but won't work if a custom value for the team name was specified when using the `platform team create`_ command. In that case, you must examine the database to find out the team name.
+
+
 platform team add
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
   Description
-    Add users to a team.
+    Add users to a team. Before running this command, see the :ref:`note about {team-name} <team-value-note>`.
 
   Format
     .. code-block:: none
 
-      platform team add {team} {users}
+      platform team add {team-name} {users}
 
   Example
     .. code-block:: none
@@ -414,12 +424,12 @@ platform team delete
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
   Description
-    Permanently delete a team along with all related information, including posts from the database.
+    Permanently delete a team along with all related information, including posts from the database. Before running this command, see the :ref:`note about {team-name} <team-value-note>`.
 
   Format
     .. code-block:: none
 
-      platform team delete {teams}
+      platform team delete {team-name}
 
   Example
     .. code-block:: none
@@ -435,12 +445,12 @@ platform team remove
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
   Description
-    Remove users from a team.
+    Remove users from a team. Before running this command, see the :ref:`note about {team-name} <team-value-note>`.
 
   Format
     .. code-block:: none
 
-      platform team remove {team} {users}
+      platform team remove {team-name} {users}
 
   Example
     .. code-block:: none


### PR DESCRIPTION
Comes from this forum post: https://forum.mattermost.org/t/solved-how-can-i-delete-teams/220/12

The **platform team** commands require a team name, but they don't work with the value that is displayed in the UI (DisplayName column in the Teams table). Instead, they use the value that is stored in the Name column, which is almost always different.