### PR TITLE
Replace documentation by links to the official Arch Linux doc

### DIFF
--- a/source/install/desktop.rst
+++ b/source/install/desktop.rst
@@ -85,6 +85,11 @@ Unofficial, community-driven .deb packages are available.
 
 3. To run Mattermost, open **Dash** (located at top left corner) and input ``mattermost``, then click the Mattermost icon.
 
+Arch Linux-based systems
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To install the desktop client on Arch Linux, see the `Mattermost page <https://wiki.archlinux.org/index.php/Mattermost>`_ on the Arch Linux wiki.
+
 Snapcraft package
 ~~~~~~~~~~~~~~~~~
 

--- a/source/install/docker-local-machine.rst
+++ b/source/install/docker-local-machine.rst
@@ -95,27 +95,10 @@ Fedora
        
 3. When Docker is done fetching the image, open http://localhost:8065/ in your browser.
 
-Arch
-^^^^
+Arch Linux
+^^^^^^^^^^
 
-1. Install Docker using the following commands:
-
-   .. code:: bash
-
-       pacman -S docker
-       systemctl enable docker.service
-       systemctl start docker.service
-       gpasswd -a <username> docker
-       newgrp docker
-
-2. Start Docker container:
-
-   .. code:: bash
-
-       docker run --name mattermost-preview -d --publish 8065:8065 mattermost/mattermost-preview
-
-3. When Docker is done fetching the image, open ``http://localhost:8065/``
-   in your browser.
+To install the preview on Arch Linux, see the `installation guide <https://wiki.archlinux.org/index.php/Mattermost#With_Docker>`_ on the Arch Linux wiki.
 
 Setting up SMTP Email (Recommended) 
 -----------------------------------

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -46,6 +46,13 @@ Additional Guides:
 
 - **Setup Database Backup** following the `database backup instructions. <https://github.com/mattermost/mattermost-docker/#database-backup>`_
 
+
+Production Docker Setup on Arch Linux
+------------------------------------------------------------
+
+To install on Arch Linux, see the `installation guide <https://wiki.archlinux.org/index.php/Mattermost>`_ on the Arch Linux wiki.
+
+
 Production Docker Setup on Mac OS X
 ------------------------------------------------------------
 

--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -59,7 +59,7 @@ Mattermost Server Operating System
 
 -  Ubuntu 14.04, Ubuntu 16.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux 6.6+, Oracle Linux 7.1+
 
-While community support exists for Fedora, FreeBSD and Arch Linux, Mattermost Inc does not currently include production support for these platforms.
+While community support exists for Fedora, FreeBSD and Arch Linux, Mattermost does not currently include production support for these platforms.
 
 Database Software
 ^^^^^^^^^^^^^^^^^

--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -59,7 +59,7 @@ Mattermost Server Operating System
 
 -  Ubuntu 14.04, Ubuntu 16.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux 6.6+, Oracle Linux 7.1+
 
-The Mattermost roadmap does not currently include production support for Fedora, FreeBSD or Arch Linux.
+While community support exists for Fedora, FreeBSD and Arch Linux, Mattermost Inc does not currently include production support for these platforms.
 
 Database Software
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The documentation related to Mattermost has been moved (and been reviewed) to the Arch Linux wiki (the location where all the docs related to Arch Linux should be).