### PR TITLE
Note that invite links are invalidated after upgrading to 3.9

### DIFF
--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -19,7 +19,7 @@ To start, select one of the following guides:
       1. Run `platform -version` to check the current version of your Mattermost server
       2. Determine the appropriate next upgrade for your server:
           - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/) considering the conditions below:
-              - Note: Upgrading to `v3.9.x` and later will invalidate existing team invite links, password reset links and email verifications.
+              - Note: Upgrading to `v3.9.x` and later will invalidate existing team invite links, password reset links, and email verification links.
               - Note: Upgrading to `v3.8.x` and later, if you're using NGINX as a proxy for the Mattermost Server, replace the `location /api/v3/users/websocket {` line with `location ~ /api/v[0-9]+/(users/)?websocket$ {` in the `/etc/nginx/sites-available/mattermost` NGINX configuration file. [See documentation to learn more](https://docs.mattermost.com/install/install-ubuntu-1404.html#configuring-nginx-as-a-proxy-for-mattermost-server).
               - Note: Upgrading to `v3.8.x` and later, you must ensure that the **System Console** > **General > Logging** > [**File Log Directory**](https://docs.mattermost.com/administration/config-settings.html#file-log-directory) field is either empty or contains a directory path. It must not have a filename as part of the path. 
               - Note: If public links are enabled, upgrading from `v3.3.x` and earlier to `v3.4.x` and later will invalidate existing public links due to a security upgrade allowing admins to invalidate links by resetting a public link salt from the System Console.
@@ -63,7 +63,7 @@ To start, select one of the following guides:
       1. Run `platform -version` to check the current version of your Mattermost server
       2. Determine the appropriate next upgrade for your server:
           - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/).
-              - Note: Upgrading to `v3.9.x` and later will invalidate existing team invite links, password reset links and email verifications.
+              - Note: Upgrading to `v3.9.x` and later will invalidate existing team invite links, password reset links, and email verification links.
               - Note: Upgrading to `v3.8.x` and later, if you're using NGINX as a proxy for the Mattermost Server, replace the `location /api/v3/users/websocket {` line with `location ~ /api/v[0-9]+/(users/)?websocket$ {` in the `/etc/nginx/sites-available/mattermost` NGINX configuration file. [See documentation to learn more](https://docs.mattermost.com/install/install-ubuntu-1404.html#configuring-nginx-as-a-proxy-for-mattermost-server).
               - Note: If there is are config settings set for `"RestrictPublicChannelManagement"` and `"RestrictPrivateChannelManagement"`, they will be used as the default values for `"RestrictPublicChannelCreation"`, `"RestrictPrivateChannelCreation"`, `"RestrictPublicChannelDeletion"`, and `"RestrictPrivateChannelDeletion"` after upgrade
               - Note: If public links are enabled, upgrading from `v3.3.x` and earlier to `v3.4.x` and later will invalidate existing public links due to a security upgrade allowing admins to invalidate links by resetting a public link salt from the System Console.

--- a/source/administration/upgrade.md
+++ b/source/administration/upgrade.md
@@ -11,19 +11,17 @@ To start, select one of the following guides:
 
 ## Upgrade Team Edition to 3.1.x and later
 
-**Important Note:** Security-related changes were made in 3.8 that require you to verify settings in the System Console before upgrading from version 3.7.x and earlier to any version greater than 3.8.0.
-
-**To prepare your system when upgrading from 3.7.x and earlier**:
-
-  1. In the System Console, go to **General > Configuration** and make sure that the **Site URL** is specified. It must not be empty.
-  2. In the System Console, go to **General > Logging** and make sure that the **File Log Directory** field is either empty or has a directory path only. It must not have a filename as part of the path.
+**Important Note:** Security-related changes require you to specify the Site URL setting when upgrading to `v3.6.x` and later. The Site URL can be set in the `config.json` or in **System Console** > **General > Configuration** > [**Site URL**](https://docs.mattermost.com/administration/config-settings.html#site-url). If you are using GitLab Mattermost, you must set the Site URL in the `gitlab.rb` file.
 
 **To upgrade your system**:
 
 1. Download the **appropriate next upgrade** of your Team Edition server and note any compatibility procedures:
       1. Run `platform -version` to check the current version of your Mattermost server
       2. Determine the appropriate next upgrade for your server:
-          - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/), but see the previous note about upgrading from 3.7.x and earlier.
+          - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/) considering the conditions below:
+              - Note: Upgrading to `v3.9.x` and later will invalidate existing team invite links, password reset links and email verifications.
+              - Note: Upgrading to `v3.8.x` and later, if you're using NGINX as a proxy for the Mattermost Server, replace the `location /api/v3/users/websocket {` line with `location ~ /api/v[0-9]+/(users/)?websocket$ {` in the `/etc/nginx/sites-available/mattermost` NGINX configuration file. [See documentation to learn more](https://docs.mattermost.com/install/install-ubuntu-1404.html#configuring-nginx-as-a-proxy-for-mattermost-server).
+              - Note: Upgrading to `v3.8.x` and later, you must ensure that the **System Console** > **General > Logging** > [**File Log Directory**](https://docs.mattermost.com/administration/config-settings.html#file-log-directory) field is either empty or contains a directory path. It must not have a filename as part of the path. 
               - Note: If public links are enabled, upgrading from `v3.3.x` and earlier to `v3.4.x` and later will invalidate existing public links due to a security upgrade allowing admins to invalidate links by resetting a public link salt from the System Console.
               - Note: RHEL6 and Ubuntu installations must verify the line `limit nofile 50000 50000` is included in `/etc/init/mattermost.conf` file. See the [installation guide](https://docs.mattermost.com/guides/administrator.html#install-guides) for your operating system for more details.
               - Note: RHEL7 and Debian installations must verify the line `LimitNOFILE=49152` is included in the `/etc/systemd/system/mattermost.service` file. See the [installation guide](https://docs.mattermost.com/guides/administrator.html#install-guides) for your operating system for more details.
@@ -65,6 +63,8 @@ To start, select one of the following guides:
       1. Run `platform -version` to check the current version of your Mattermost server
       2. Determine the appropriate next upgrade for your server:
           - Mattermost `v3.0.x` and later can upgrade directly to the [latest release of Mattermost](https://about.mattermost.com/download/).
+              - Note: Upgrading to `v3.9.x` and later will invalidate existing team invite links, password reset links and email verifications.
+              - Note: Upgrading to `v3.8.x` and later, if you're using NGINX as a proxy for the Mattermost Server, replace the `location /api/v3/users/websocket {` line with `location ~ /api/v[0-9]+/(users/)?websocket$ {` in the `/etc/nginx/sites-available/mattermost` NGINX configuration file. [See documentation to learn more](https://docs.mattermost.com/install/install-ubuntu-1404.html#configuring-nginx-as-a-proxy-for-mattermost-server).
               - Note: If there is are config settings set for `"RestrictPublicChannelManagement"` and `"RestrictPrivateChannelManagement"`, they will be used as the default values for `"RestrictPublicChannelCreation"`, `"RestrictPrivateChannelCreation"`, `"RestrictPublicChannelDeletion"`, and `"RestrictPrivateChannelDeletion"` after upgrade
               - Note: If public links are enabled, upgrading from `v3.3.x` and earlier to `v3.4.x` and later will invalidate existing public links due to a security upgrade allowing admins to invalidate links by resetting a public link salt from the System Console.
               - Note: RHEL6 and Ubuntu installations must verify the line `limit nofile 50000 50000` is included in `/etc/init/mattermost.conf` file. See the [installation guide](https://docs.mattermost.com/guides/administrator.html#install-guides) for your operating system for more details.
@@ -122,15 +122,15 @@ Private cloud enterprise communications server.
 -------
 
 
-- Mattermost Enterprise Edition v3.8.0 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-8-0) - [Download](https://releases.mattermost.com/3.8.0/mattermost-3.8.0-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.8.0/mattermost-3.8.0-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `bc61e98f795b48739541839d7259ee57896f4c0f1e155cc43b59bd18c114ff0b`
-- Mattermost Enterprise Edition v3.7.4 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-4) - [Download](https://releases.mattermost.com/3.7.4/mattermost-3.7.4-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.7.4/mattermost-3.7.4-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `adc84d61e14812ff5bfd788be7e49f2e8b8d7803909fa83ce7e6b0f27cee2394`
-- Mattermost Enterprise Edition v3.6.6 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-6) - [Download](https://releases.mattermost.com/3.6.6/mattermost-3.6.6-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.6.6/mattermost-3.6.6-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `257400926c3a20212a210fdeec2b0ef60f6845ed4075598b374c64e224a08b9f`
+- Mattermost Enterprise Edition v3.8.2 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-8-2) - [Download](https://releases.mattermost.com/3.8.2/mattermost-3.8.2-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.8.2/mattermost-3.8.2-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `b99c86a2667f636eaee26331aa61a71a51b2d3d412eaa83fdebf8b53cddc6aeb`
+- Mattermost Enterprise Edition v3.7.5 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-5) - [Download](https://releases.mattermost.com/3.7.5/mattermost-3.7.5-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.7.5/mattermost-3.7.5-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `65e65da661edbc7b7b2b02411f13dbe498fd704d5ae1289789feca79fe00b58a`
+- Mattermost Enterprise Edition v3.6.7 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-7) - [Download](https://releases.mattermost.com/3.6.7/mattermost-3.6.7-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.6.7/mattermost-3.6.7-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `8e666708fead5fbfcf1f20617b07fda21cc8cbc85f9690321cbf4a41bfc1dd89`
 - Mattermost Enterprise Edition v3.5.1 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-5-1) - [Download](https://releases.mattermost.com/3.5.1/mattermost-3.5.1-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.5.1/mattermost-3.5.1-linux-amd64.tar.gz`
   - SHA-256 Checksum: `b972ac6f38f8b4c4f364e40a7c0e7819511315a81cb38c8a51c0622d7c5b14a1`
@@ -165,15 +165,15 @@ Open source self-hosted team communication server compiled by Mattermost, Inc, a
 
 -------
 
-- Mattermost Team Edition v3.8.0 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-8-0) - [Download](https://releases.mattermost.com/3.8.0/mattermost-team-3.8.0-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.8.0/mattermost-team-3.8.0-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `eb17c2688eb253e36404287c2bf880d8e99cb17c53e1b23ff7223a3c559a68d2`
-- Mattermost Team Edition v3.7.4 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-4) - [Download](https://releases.mattermost.com/3.7.4/mattermost-team-3.7.4-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.7.4/mattermost-team-3.7.4-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `17ec3c85d7c210aa4d856aea437e7a23bb9e7c3e68031ba458a029d032730d01`
-- Mattermost Team Edition v3.6.6 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-6) - [Download](https://releases.mattermost.com/3.6.6/mattermost-team-3.6.6-linux-amd64.tar.gz)
-  - `https://releases.mattermost.com/3.6.6/mattermost-team-3.6.6-linux-amd64.tar.gz`
-  - SHA-256 Checksum: `6e501390c11f74b88d0992f9fd25d53dd7e30016c692cefb6f4bcdde29575dd7`
+- Mattermost Team Edition v3.8.2 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-8-2) - [Download](https://releases.mattermost.com/3.8.2/mattermost-team-3.8.2-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.8.2/mattermost-team-3.8.2-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `82cc85557dc21b3871ec89326769c11d3a89c9c41362fb3945247f8fba562ce7`
+- Mattermost Team Edition v3.7.5 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-7-5) - [Download](https://releases.mattermost.com/3.7.5/mattermost-team-3.7.5-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.7.5/mattermost-team-3.7.5-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `eaee6a57ab9e2924f71853cbebf465d63f7dbf1112716c0e4768984de39f83a2`
+- Mattermost Team Edition v3.6.7 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-6-7) - [Download](https://releases.mattermost.com/3.6.7/mattermost-team-3.6.7-linux-amd64.tar.gz)
+  - `https://releases.mattermost.com/3.6.7/mattermost-team-3.6.7-linux-amd64.tar.gz`
+  - SHA-256 Checksum: `8378f15a6bd070386077798f36d8e521b63844bc838f6553915c6fd4fba3b01d`
 - Mattermost Team Edition v3.5.1 - [View Changelog](https://docs.mattermost.com/administration/changelog.html#release-v3-5-1) - [Download](https://releases.mattermost.com/3.5.1/mattermost-team-3.5.1-linux-amd64.tar.gz)
   - `https://releases.mattermost.com/3.5.1/mattermost-team-3.5.1-linux-amd64.tar.gz`
   - SHA-256 Checksum: `2c6bc8b1c25e48d1ac887cd6cbef77df1f80542127b4d98c4d7c0dfbfade04d5`


### PR DESCRIPTION
Already noted in the 3.9 changelog.

It also takes upstream changes from the `master` branch, hence the larger diff file.