### PR TITLE
Update smtp-email-setup.rst

### DIFF
--- a/source/install/smtp-email-setup.rst
+++ b/source/install/smtp-email-setup.rst
@@ -100,7 +100,7 @@ Gmail
 -  Set **SMTP Password** to **your\_password**
 -  Set **SMTP Server** to **smtp.gmail.com**
 -  Set **SMTP Port** to **587**
--  Set **Connection Security** to **TLS**
+-  Set **Connection Security** to **STARTTLS**
 
 Hotmail
 ^^^^^^^


### PR DESCRIPTION
TLS Connection Security for gmail doesn't work for me, but STARTTLS does. Maybe this is particular to the fact I'm using Google Apps and therefore my email addresses aren't @gmail.com, but my own domain. I suspect that STARTTLS is actually what everyone's going to need to use gmail's SMTP at this point. I tried TLS many times and it failed every time until I switched to STARTTLS.