### PR TITLE
Updated rhel7 docs 

### DIFF
--- a/source/install/config-mattermost-server.rst
+++ b/source/install/config-mattermost-server.rst
@@ -30,4 +30,6 @@ Configuring Mattermost Server
 7. Feel free to modify other settings.
 8. Restart the Mattermost Service.
 
-  ``sudo restart mattermost``
+  On Ubuntu 14.04 and RHEL 6.6: ``sudo service mattermost restart``
+  
+  On Ubuntu 16.04 and RHEL 7.1: ``sudo systemctl restart mattermost``

--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -357,4 +357,4 @@ Test setup and configure Mattermost Server
 8. Feel free to modify other settings
 9. Restart the Mattermost Service by typing:
 
-   -  ``sudo restart mattermost``
+   -  ``sudo service mattermost restart``

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -161,7 +161,7 @@ Set up Mattermost Server
 8. Set up Mattermost to use the systemd init daemon which handles
    supervision of the Mattermost process. 
 
-   * Create and edit ``/etc/systemd/system/mattermost.service``
+   * Create and edit ``/usr/lib/systemd/system/mattermost.service``
 
       ::
 
@@ -181,11 +181,10 @@ Set up Mattermost Server
           [Install]
           WantedBy=multi-user.target
 
-   - Make sure the service is executable with ``sudo chmod 664 /etc/systemd/system/mattermost.service``
+   - Make sure the service is executable with ``sudo chmod 664 /usr/lib/systemd/system/mattermost.service``
    * Reload the services with ``sudo systemctl daemon-reload``
-   * Start Mattermost service with``\ sudo systemctl start mattermost.service``
-   * ``sudo chkconfig mattermost on``
    * Start server on reboot ``sudo systemctl enable mattermost.service``
+   * Start Mattermost service with``sudo systemctl start mattermost.service``
 
 Unix-domain socket connection
 -----------------------------
@@ -380,7 +379,7 @@ You should see a congratulation message if successful.
 Then, add a cron job or use systemd timer capability to run twice a day the renewal
 process.
 
-- write the ``/etc/systemd/system/letsencrypt.renewal.service`` file
+- write the ``/usr/lib/systemd/system/letsencrypt.renewal.service`` file
 
 ::
 
@@ -390,7 +389,7 @@ process.
      [Service]
      ExecStart=/usr/bin/certbot renew --quiet
 
-- write the ``/etc/systemd/system/letsencrypt.timer`` file
+- write the ``/usr/lib/systemd/system/letsencrypt.timer`` file
 
 ::
 
@@ -444,4 +443,4 @@ Test setup and configure Mattermost Server
 8. Feel free to modify other settings
 9. Restart the Mattermost Service by typing:
 
-   -  ``sudo restart mattermost``
+   -  ``sudo systemctl restart mattermost``

--- a/source/install/ee-prod-ubuntu.rst
+++ b/source/install/ee-prod-ubuntu.rst
@@ -352,4 +352,4 @@ Test setup and configure Mattermost Server
 8. Feel free to modify other settings.
 9. Restart the Mattermost Service by typing:
 
-   -  ``sudo restart mattermost``
+   -  ``sudo service mattermost restart``

--- a/source/install/install-rhel-71-mattermost.rst
+++ b/source/install/install-rhel-71-mattermost.rst
@@ -61,7 +61,7 @@ Assume that the IP address of this server is 10.10.10.2
 
   a. Create the Mattermost configuration file:
 
-    ``sudo touch /etc/systemd/system/mattermost.service``
+    ``sudo touch /usr/lib/systemd/system/mattermost.service``
 
   b. Open the configuration file in your favorite text editor, and copy the following lines into the file:
 
@@ -84,17 +84,13 @@ Assume that the IP address of this server is 10.10.10.2
 
   c. Make the service executable.
 
-    ``sudo chmod 664 /etc/systemd/system/mattermost.service``
+    ``sudo chmod 664 /usr/lib/systemd/system/mattermost.service``
 
   d. Reload the systemd services.
 
     ``sudo systemctl daemon-reload``
 
   f. Enable the Mattermost service.
-
-    ``sudo chkconfig mattermost on``
-
-  g. Set Mattermost to start on boot.
 
     ``sudo systemctl enable mattermost``
 


### PR DESCRIPTION
- [x] added `service` and `systemctl` commands for starting mattermost
- [x] changed the location of the systemd services from `/etc/systemd` to `/usr/lib/systemd/`