### PR TITLE
Update RHEL7 Documentation

### DIFF
--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -19,7 +19,7 @@ Installing PostgreSQL Database
 
 5. Initialize the database.
 
-  ``sudo service postgresql initdb``
+  ``sudo /usr/pgsql-9.4/bin/postgresql94-setup initdb``
 
 6. Set PostgreSQL to start on boot.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -7,7 +7,14 @@ Installing PostgreSQL Database
 
 2. Download the PostgreSQL 9.4 Yum repository.
 
-  ``curl -O https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm``
+  For RHEL 7
+    ``curl -O https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm``
+  For CentOS 7
+    ``curl -O https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-centos94-9.4-3.noarch.rpm``
+  For Scientific Linux
+    ``curl -O https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-sl94-9.4-3.noarch.rpm``
+  For Oracle
+    ``curl -O https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-oraclelinux-9.4-3.noarch.rpm``
 
 3. Install the Yum repository from the file that you downloaded.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -31,7 +31,7 @@ Installing PostgreSQL Database
 
 8. Switch to the *postgres* Linux user account that was created during the installation.
 
-  ``sudo --login --user postgres``
+  ``sudo su postgres``
 
 9. Start the PostgreSQL interactive terminal.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -31,7 +31,7 @@ Installing PostgreSQL Database
 
 8. Switch to the *postgres* Linux user account that was created during the installation.
 
-  ``sudo su postgres``
+  ``sudo -ui postgres``
 
 9. Start the PostgreSQL interactive terminal.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -76,7 +76,7 @@ Installing PostgreSQL Database
 
   If the Mattermost server and the database are on the same machine, then you can skip this step.
 
-  a. Open ``/var/lib/pgsql/9/4/data/pg_hba.conf`` in a text editor.
+  a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` in a text editor.
 
   b. Add the following line to the end of the file, where *<mm-server-IP>* is the IP address of the machine that contains the Mattermost server.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -72,7 +72,7 @@ Installing PostgreSQL Database
   
     ``listen_addresses = '*'``
 
-16. If the Mattermost server is on a separate machine, modify the file ``pg_hbe.conf`` to allow the Mattermost server to communicate with the database.
+16. If the Mattermost server is on a separate machine, modify the file ``pg_hba.conf`` to allow the Mattermost server to communicate with the database.
 
   If the Mattermost server and the database are on the same machine, then you can skip this step.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -38,7 +38,7 @@ Installing PostgreSQL Database
 
 8. Switch to the *postgres* Linux user account that was created during the installation.
 
-  ``sudo -ui postgres``
+  ``sudo -iu postgres``
 
 9. Start the PostgreSQL interactive terminal.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -7,7 +7,7 @@ Installing PostgreSQL Database
 
 2. Download the PostgreSQL 9.4 Yum repository.
 
-  ``wget https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm``
+  ``curl -O https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm``
 
 3. Install the Yum repository from the file that you downloaded.
 

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -23,11 +23,11 @@ Installing PostgreSQL Database
 
 6. Set PostgreSQL to start on boot.
 
-  ``sudo systemctl enable postgresql``
+  ``sudo systemctl enable postgresql-9.4``
 
 7. Start the PostgreSQL server.
 
-  ``sudo systemctl start postgresql``
+  ``sudo systemctl start postgresql-9.4``
 
 8. Switch to the *postgres* Linux user account that was created during the installation.
 
@@ -84,7 +84,7 @@ Installing PostgreSQL Database
 
 17. Reload Postgres database
 
-  ``sudo systemctl reload postgresql``
+  ``sudo systemctl reload postgresql-9.4``
 
 18. Verify that you can connect with the user *mmuser*.
   

--- a/source/install/install-rhel-71-postgresql.rst
+++ b/source/install/install-rhel-71-postgresql.rst
@@ -62,7 +62,7 @@ Installing PostgreSQL Database
 
 15. Allow Postgres to listen on all assigned IP Addresses.
 
-  a. Open ``/etc/postgresql/9.4/main/postgresql.conf`` as root in a text editor.
+  a. Open ``/var/lib/pgsql/9.4/data/postgresql.conf`` as root in a text editor.
 
   b. Find the following line:
   
@@ -76,7 +76,7 @@ Installing PostgreSQL Database
 
   If the Mattermost server and the database are on the same machine, then you can skip this step.
 
-  a. Open ``/etc/postgresql/9.4/main/pg_hba.conf`` in a text editor.
+  a. Open ``/var/lib/pgsql/9/4/data/pg_hba.conf`` in a text editor.
 
   b. Add the following line to the end of the file, where *<mm-server-IP>* is the IP address of the machine that contains the Mattermost server.
 


### PR DESCRIPTION
The command `sudo service postgresql initdb` doesn't work within CentOS 7.1, you receive the following error

`The service command supports only basic LSB actions (start, stop, restart, try-restart, reload, force-reload, status). For other actions, please try to use systemctl.`

 I have updated this to `/usr/pgsql-9.4/bin/postgresql94-setup initdb`