### PR TITLE
Correct what `platform channel delete` actually does

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -143,7 +143,7 @@ platform channel delete
 ~~~~~~~~~~~~~~~~~~~~~~~
 
   Description
-    Permanently delete a channel along with all related information, including posts from the database. Channels can be specified by {team}:{channel} using the team and channel names or IDs.
+    Archives a channel with all related information, including posts. The channels are not deleted from the database. Channels can be specified by {team}:{channel} using the team and channel names or IDs.
 
   Format
     .. code-block:: none


### PR DESCRIPTION
Correct what `platform channel delete` actually does.

There's a Help Wanted ticket (https://github.com/mattermost/platform/issues/6201) to update CLI so that
 - `platform channel archive` archives a channel
 - `platform channel delete` permanently deletes a channel (consistent with CLI command for users and teams)