### PR TITLE
Updated examples for channel CLI commands

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -107,7 +107,7 @@ platform channel add
 
       platform channel add {channel} {users}
 
-  Example
+  Examples
     .. code-block:: none
 
       sudo ./platform channel add 8soyabwthjnf9qibfztje5a36h user@example.com username
@@ -151,7 +151,7 @@ platform channel delete
 
       platform channel delete {channels}
 
-  Example
+  Examples
     .. code-block:: none
 
       sudo ./platform channel delete 8soyabwthjnf9qibfztje5a36h
@@ -184,7 +184,7 @@ platform channel remove
 
       platform channel remove {channel} {users}
 
-  Example
+  Examples
     .. code-block:: none
 
       sudo ./platform channel remove 8soyabwthjnf9qibfztje5a36h user@example.com username
@@ -201,7 +201,7 @@ platform channel restore
 
       platform channel restore {channels}
 
-  Example
+  Examples
     .. code-block:: none
 
       sudo ./platform channel restore 8soyabwthjnf9qibfztje5a36h

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -110,7 +110,8 @@ platform channel add
   Example
     .. code-block:: none
 
-      sudo ./platform channel add mychannel user@example.com username
+      sudo ./platform channel add 8soyabwthjnf9qibfztje5a36h user@example.com username
+      sudo ./platform channel add myteam:mychannel user@example.com username
 
 platform channel create
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -153,6 +154,7 @@ platform channel delete
   Example
     .. code-block:: none
 
+      sudo ./platform channel delete 8soyabwthjnf9qibfztje5a36h
       sudo ./platform channel delete myteam:mychannel
 
 platform channel list
@@ -185,7 +187,8 @@ platform channel remove
   Example
     .. code-block:: none
 
-      sudo ./platform channel remove mychannel user@example.com username
+      sudo ./platform channel remove 8soyabwthjnf9qibfztje5a36h user@example.com username
+      sudo ./platform channel remove myteam:mychannel user@example.com username
 
 platform channel restore
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -201,6 +204,7 @@ platform channel restore
   Example
     .. code-block:: none
 
+      sudo ./platform channel restore 8soyabwthjnf9qibfztje5a36h
       sudo ./platform channel restore myteam:mychannel
 
 platform help


### PR DESCRIPTION
Some of the examples were unclear about how a team name was required with the channel name or that it was possible to use a channel ID.

If it looks cluttered with both, we can take out the channel ID examples, but the others should include the team name still.