### PR TITLE
PLT-6673: Google Analytics Reintegration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To generate the HTML files from markdown in the `/source` directory:
 
 1. Download repo onto a machine with Python installed
 2. `pip install sphinx sphinx-autobuild sphinx_rtd_theme`
-3. `pip install recommonmark sphinxcontrib-googleanalytics`
+3. `pip install recommonmark`
 4. Type `make html`
 
 To contribute to the documentation please fork this repository and create a pull request. If you have not done so already, please complete the [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/). 

--- a/source/conf.py
+++ b/source/conf.py
@@ -40,9 +40,6 @@ def setup(app):
 # ones.
 extensions = []
 
-googleanalytics_id = 'UA-67846571-2'
-googleanalytics_enabled = True
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 templates_path = ['templates']
@@ -51,7 +48,6 @@ templates_path = ['templates']
 # You can specify multiple suffix as a list of string:
 source_suffix = ['.rst', '.md']
 # source_suffix = '.rst'
-
 
 source_parsers = {
     '.md': CommonMarkParser,
@@ -126,13 +122,20 @@ todo_include_todos = False
 
 # Global variables available to all templates
 html_context = {
+
+    # Enable google analytics
+    'googleanalytics_id': 'UA-67846571-2',
+    'googleanalytics_enabled': True,
+    
     # Enable the "Edit in GitHub link within the header of each page.
     'display_github': True,
+
     # Set the following variables to generate the resulting github URL for each page.
     # Format Template: https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}
     'github_user': 'mattermost',
     'github_repo': 'docs',
     'github_version': 'master/source/',
+    
     'css_files': []
 }
 

--- a/source/templates/layout-notoc.html
+++ b/source/templates/layout-notoc.html
@@ -67,7 +67,21 @@
         <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}"/>
     {%- endif %}
   {%- endblock %}
-  {%- block extrahead %} {% endblock %}
+  {%- block extrahead %} 
+    {% if googleanalytics_enabled %}
+      <!-- Google Analytics -->
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{ googleanalytics_id }}', 'auto');
+        ga('send', 'pageview');
+      </script>
+      <!-- End Google Analytics -->
+    {% endif %}
+  {% endblock %}
 
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
   <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>

--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -17,3 +17,19 @@
         }
     </script>
 {% endblock %}
+
+{% block extrahead %}
+	{% if googleanalytics_enabled %}
+		<!-- Google Analytics -->
+		<script>
+			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+			})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+			ga('create', '{{ googleanalytics_id }}', 'auto');
+			ga('send', 'pageview');
+		</script>
+		<!-- End Google Analytics -->
+	{% endif %}
+{% endblock %}


### PR DESCRIPTION
At the request of lindsay, corrected the google analytics build errors by abandoning the usage of the plugin and injecting the GA script directly.  Since the script is very small and hasn't changed in _years_, it seemed simpler and safe to directly inject over fixing the plugin.  

GA can still be configured through the `conf.py` file to disable/enable and specify the GA key.

https://mattermost.atlassian.net/browse/PLT-6673