### PR TITLE
Add a note that Firefox ESR 45 is no longer supported

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -124,6 +124,7 @@ Release Date: May 16, 2017
 
 - If you're using NGINX as a proxy for the Mattermost Server, replace the `location /api/v3/users/websocket {` line with `location ~ /api/v[0-9]+/(users/)?websocket$ {` in the `/etc/nginx/sites-available/mattermost` NGINX configuration file. [See documentation to learn more](https://docs.mattermost.com/install/install-ubuntu-1404.html#configuring-nginx-as-a-proxy-for-mattermost-server).
 - Existing team invite links, password reset links and email verification links will be invalidated after upgrading to v3.9.0.
+- Firefox ESR 45 has an [end-of-life scheduled for June 13](https://en.wikipedia.org/wiki/Firefox_version_history) and is therefore no longer supported. We recommend upgrading to [Firefox ESR 52](https://www.mozilla.org/en-US/firefox/organizations/all/).
 
 #### Removed and deprecated features
 - System Console settings in **Files > Images** scheduled for removal in July 2017 release. This includes:


### PR DESCRIPTION
Firefox ESR 45 had it's end of life on June 13: https://en.wikipedia.org/wiki/Firefox_version_history