### PR TITLE
Rhel7 enterprise install

### DIFF
--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -20,7 +20,7 @@ Install Red Hat Enterprise Linux (x64) 7.1+
 2. Make sure the system is up to date with the most recent security
    patches.
 
-   -  ``sudo dnf upgrade``
+   -  ``sudo yum upgrade``
 
 Set up Database Server
 ----------------------
@@ -40,8 +40,8 @@ section.
 
 2.  Install PostgreSQL 9.4+ (or MySQL 5.6+)
 
-    -  ``sudo dnf install http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-1.noarch.rpm``
-    -  ``sudo dnf install postgresql94-server postgresql94-contrib``
+    -  ``sudo yum install http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-1.noarch.rpm``
+    -  ``sudo yum install postgresql94-server postgresql94-contrib``
     -  ``sudo /usr/pgsql-9.4/bin/postgresql94-setup initdb``
     -  ``sudo systemctl enable postgresql.service``
     -  ``sudo systemctl start postgresql.service``
@@ -250,7 +250,7 @@ Set up NGINX Server
           gpgcheck=0
           enabled=1
 
-   -  ``sudo dnf install nginx.x86_64``
+   -  ``sudo yum install nginx.x86_64``
    -  ``sudo service nginx start``
    -  ``sudo chkconfig nginx on``
 
@@ -305,7 +305,7 @@ Set up NGINX with SSL (Recommended)
 1. You can use a free and an open certificate security like `Let's
    Encrypt <https://letsencrypt.org/>`_, this is how to proceed
 
--  ``sudo dnf install git``
+-  ``sudo yum install git``
 -  ``git clone https://github.com/letsencrypt/letsencrypt``
 -  ``cd letsencrypt``
 

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -111,7 +111,7 @@ section.
       ``host all all {mattermost-server-IP}/32 md5``
 12. Reload Postgres database:
 
-    -  ``sudo systemctl reload postgresql.service``
+    -  ``sudo systemctl reload postgresql-9.4.service``
 
 13. Attempt to connect with the new created user to verify everything
     looks good:
@@ -130,7 +130,7 @@ Set up Mattermost Server
 2. Download `any version of Mattermost Enterprise Edition <https://docs.mattermost.com/administration/upgrade.html#version-archive>`_ by typing:
 
    -  ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
-   -  Where ``vX.X.X`` is typically the latest Mattermost release version, which is currently ``v3.3.0``.
+   -  Where ``vX.X.X`` is typically the latest Mattermost release version, which is currently ``v3.10.0``.
 
 3. Install Mattermost under ``/opt``
 
@@ -190,7 +190,7 @@ Set up Mattermost Server
 
           [Unit]
           Description=Mattermost server
-          After=network.target postgresql.service
+          After=network.target postgresql-9.4.service
 
           [Service]
           User=mattermost

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -82,7 +82,7 @@ section.
   
   b. Find the following line:
   
-    ``#listen_addresses = 'localhost'``Uncomment ``
+    ``#listen_addresses = 'localhost'``
     
   c. Uncomment the line and change ``localhost`` to ``*``:
   

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -130,7 +130,7 @@ Set up Mattermost Server
 2. Download `any version of Mattermost Enterprise Edition <https://docs.mattermost.com/administration/upgrade.html#version-archive>`_ by typing:
 
    -  ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
-   -  Where ``vX.X.X`` is typically the latest Mattermost release version, which is currently ``v3.10.0``.
+   -  Where ``vX.X.X`` is typically the latest Mattermost release version, which you can find out from the `download page <https://about.mattermost.com/download/>`_.
 
 3. Install Mattermost under ``/opt``
 

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -20,6 +20,7 @@ Install Red Hat Enterprise Linux (x64) 7.1+
 2. Make sure the system is up to date with the most recent security
    patches.
 
+   -  ``sudo yum update``
    -  ``sudo yum upgrade``
 
 Set up Database Server
@@ -40,11 +41,11 @@ section.
 
 2.  Install PostgreSQL 9.4+ (or MySQL 5.6+)
 
-    -  ``sudo yum install http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-redhat94-9.4-1.noarch.rpm``
+    -  ``sudo yum install http://yum.postgresql.org/9.4/redhat/rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm``
     -  ``sudo yum install postgresql94-server postgresql94-contrib``
     -  ``sudo /usr/pgsql-9.4/bin/postgresql94-setup initdb``
-    -  ``sudo systemctl enable postgresql.service``
-    -  ``sudo systemctl start postgresql.service``
+    -  ``sudo systemctl enable postgresql-9.4.service``
+    -  ``sudo systemctl start postgresql-9.4.service``
 
 3.  PostgreSQL created a user account called ``postgres``. You will need
     to log into that account with:
@@ -75,17 +76,39 @@ section.
 
     -  ``exit``
 
-10. Alter ``/var/lib/pgsql/9.4/data/postgresql.conf`` to allow Postgres to listen
-on all assigned IP Addresses:
+10. Allow Postgres to listen on all assigned IP Addresses:
 
-    -  Uncomment ``listen_addresses`` and change ``localhost`` to ``\*``
+  a. Open ``/var/lib/pgsql/9.4/data/postgresql.conf`` as root in a text editor
+  
+  b. Find the following line:
+  
+    ``#listen_addresses = 'localhost'``Uncomment ``
+    
+  c. Uncomment the line and change ``localhost`` to ``*``:
+  
+    ``listen_addresses = '*'``
 
-11. Alter ``/var/lib/pgsql/9.4/data/pg_hba.conf`` to allow the Mattermost Server to talk to the
-    Postgres database:
+11. Modify the file ``pg_hba.conf`` to allow the Mattermost server to communicate with the database.
 
-    -  Add the following line to the ``IPv4 local connections``:
-    -  ``host all all 10.10.10.2/32 md5``
+  **If the Mattermost server and the database are on the same machine**:
 
+    a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` as root in a text editor.
+
+    b. Find the following line:
+
+      ``local   all             all                        peer``
+
+    c. Change ``peer`` to ``trust``:
+
+      ``local   all             all                        trust``
+
+  **If the Mattermost server and the database are on different machines**:
+
+    a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` as root in a text editor.
+
+    b. Add the following line to the end of the file, where *{mattermost-server-IP}* is the IP address of the machine that contains the Mattermost server.
+
+      ``host all all {mattermost-server-IP}/32 md5``
 12. Reload Postgres database:
 
     -  ``sudo systemctl reload postgresql.service``


### PR DESCRIPTION
I am not sure if the Enterprise documentation is still referenced, but this will make the following changes to Enterprise installation instructions:

 * Change `dnf` to `yum`
 * Change Postgres9.4-3 URL to RHEL7
 * Change the Postgresql service from `postgresql.service` to `postgresql-9.4.service`
 * Change the current version to 3.10.0
 * Update the formatting to the section of PostgreSQL to the current in the Installing on RHEL 7.1