### PR TITLE
Updates the Apache proxy deployment guide

### DIFF
--- a/source/install/config-proxy-apache2.rst
+++ b/source/install/config-proxy-apache2.rst
@@ -1,71 +1,72 @@
 .. _config-proxy-apache2:
 
 Configuring Apache2 as a proxy for Mattermost Server (Unofficial)
-==================================================================
+=================================================================
 
-.. important:: This unofficial guide is maintained by the Mattermost community and this deployment configuration is not yet officially supported by Mattermost, Inc. Community testing, feedback and improvements are welcome and greatly appreciated. You can `edit this page on GitHub <https://github.com/mattermost/docs/blob/master/source/install/config-proxy-apache2.rst>`_.
+.. important::
 
-The Apache2 proxy configuration is done through the ``/etc/apache2/sites-available`` directory. If you're setting up Mattermost on a subdomain you'll want to create a new configuration along the lines of ``mysubdomain.mydomain.com.conf``.
+    This unofficial guide is maintained by the Mattermost community and this
+    deployment configuration is not yet officially supported by Mattermost, Inc.
+    Community testing, feedback and improvements are welcome and greatly
+    appreciated. You can `edit this page on GitHub <https://github.com/mattermost/docs/blob/master/source/install/config-proxy-apache2.rst>`_.
 
-Copy the `default` configuration file found in the same directory.
+The following is an exemplary description how to setup Apache ``httpd`` 2 as
+proxy serving requests to the domain ``mattermost.mydomain.net`` from a
+Mattermost instance that runs on the same host, listening on port ``8065``.
+The Apache2 proxy configuration in this guide is done through a configuration
+file for a *virtual host* ``/etc/apache2/sites-available`` directory. If you're
+setting up Mattermost on a subdomain you'll want to create a new configuration,
+e.g. ``mattermost.mydomain.net.conf``.
 
-**To configure Apache2 as a proxy**
+1. Login to your server.
+2. If necessary, create a new configuration file.
+3. Edit your configuration using the example below, replacing values to match
+   your environment.
 
-1. SSH into your server
-2. Create/open the above mentioned, correct file (000-default or a new subdomain configuration).
-3. Edit your configuration using the guide below.
+   .. code-block:: apacheconf
 
-	1. If you're not setting up a subdomain your ``ServerName`` will simply be set to ``mydomain.com``.
-	2. ``ServerAlias`` can been added too if you want to capture ``www.mydomain.com``.
-	3. Remember to change the values to match your server's name etc.
-	4. Save once finished
+        <VirtualHost *:80>
+          ServerName mattermost.mydomain.net
+          ServerAdmin hostmaster@mydomain.net
+          ProxyPreserveHost On
 
-.. code-block:: apacheconf
+          # setup the proxy
+          <Proxy "mattermost.mydomain.net">
+            Order allow,deny
+            Allow from all
+          </Proxy>
 
-		<VirtualHost *:80>
-		  # If you're not using a subdomain you may need to set a ServerAlias to:
-		  # ServerAlias www.mydomain.com
-		  ServerName mysubdomain.mydomain.com
-		  ServerAdmin hostmaster@mydomain.com
-		  ProxyPreserveHost On
+          # Set web sockets
+          RewriteEngine On
+          RewriteCond %{REQUEST_URI} ^/api/v3/users/websocket [NC,OR]
+          RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC,OR]
+          RewriteCond %{HTTP:CONNECTION} ^Upgrade$ [NC]
+          RewriteRule .* wss://127.0.0.1:8065%{REQUEST_URI} [P,QSA,L]
+          RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
 
-		  # setup the proxy
-		  <Proxy *>
-			 Order allow,deny
-			 Allow from all
-		  </Proxy>
+          <Location /api/v3/users/websocket>
+            Require all granted
+            ProxyPass ws://127.0.0.1:8065/api/v3/users/websocket
+            ProxyPassReverse ws://127.0.0.1:8065/api/v3/users/websocket
+            ProxyPassReverseCookieDomain 127.0.0.1 mattermost.mydomain.net
+          </Location>
 
-		  # Set web sockets
-		  RewriteEngine On
-		  RewriteCond %{REQUEST_URI} ^/api/v3/users/websocket [NC,OR]
-		  RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC,OR]
-		  RewriteCond %{HTTP:CONNECTION} ^Upgrade$ [NC]
-		  RewriteRule .* wss://127.0.0.1:8065%{REQUEST_URI} [P,QSA,L]
-		  RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
-			# This line simply forces HTTPS
-		  RewriteRule (.*) https://%{SERVER_NAME}%{REQUEST_URI} [END,QSA,R=permanent]
+          <Location />
+            Require all granted
+            ProxyPass http://127.0.0.1:8065/
+            ProxyPassReverse http://127.0.0.1:8065/
+            ProxyPassReverseCookieDomain 127.0.0.1 mattermost.mydomain.net
+          </Location>
+        </VirtualHost>
 
-		  <Location /api/v3/users/websocket>
-			Require all granted
-			ProxyPass ws://127.0.0.1:8065/api/v3/users/websocket
-			ProxyPassReverse ws://127.0.0.1:8065/api/v3/users/websocket
-			ProxyPassReverseCookieDomain 127.0.0.1 mysubdomain.mydomain.com
-		  </Location>
+4. If you created a new configuration file, enable its configuration, ensure
+   necessary Apache modules are enabled, test the overall configuration and
+   restart Apache::
 
-		  <Location />
-			Require all granted
-			ProxyPass http://127.0.0.1:8065/
-			ProxyPassReverse http://127.0.0.1:8065/
-			ProxyPassReverseCookieDomain 127.0.0.1 mysubdomain.mydomain.com
-		  </Location>
+       a2ensite mattermost.mydomain.net.conf
+      a2enmod proxy_http proxy_wstunnel rewrite
+      apachectl configtest
+      apachectl restart
 
-		</VirtualHost>
-
-4. Because you'll likely have not set up the subdomain before now on Apache2, run ``a2ensite mysubdomain.mydomain.com`` to enable the site (do not run ``a2ensite mysubdomain.mydomain.com.conf``)
-
-5. Restart Apache2
-
-	- On Ubuntu 14.04 and RHEL 6: ``sudo service apache2 restart``
-	- On Ubuntu 16.04 and RHEL 7: ``sudo systemctl restart apache2``
-
-You should be all set! Ensure that your Mattermost config file is pointing to the correct URL and then ensure that once deployed your socket connection is not dropping.
+You should be all set! Ensure that your Mattermost configuration has the
+``ServiceSettings.SiteURL`` set according to the configured ``ServerName``.


### PR DESCRIPTION
- strips unnecessary Apache specifics
- adds note about needed modules
- restructuredtext polishing

i deliberatley did not touch the guide with additional information how to setup an encrypted transport as it is imo a different concern and maintaining documents that are mostly redundant always results in a mess.