### PR TITLE
Enhance webhook docs

### DIFF
--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -3,16 +3,17 @@
 Slash Commands
 ==============
 
-Slash commands, like outgoing webhooks, allow users to interact with external applications right from within Mattermost. The user will enter a ``/`` followed by a command, and optionally some arguments, then an HTTP request will be sent to an external application. What occurs next is decided by how the application responds to the HTTP request.
+Slash commands, like :doc:`Outgoing Webhooks <../developer/webhooks-outgoing/>`, allow users to interact with external applications right from within Mattermost. The user will enter a ``/`` followed by a command, and optionally some arguments, then an HTTP request will be sent to an external application. What occurs next is decided by how the application responds to the HTTP request.
 
-A couple key points:
+A couple of key points:
 
-- **Mattermost slash commands are Slack-compatible.** If you've used Slack's slash commands to interact with external applications, you can reuse those same applications with Mattermost. Mattermost will automatically translate Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Custom commands support auto-complete.** When you a create a custom command for your teammates, you have the option to fill in information about how auto-complete should work with that command. This gives your teammates quick and easy access to use your custom slash command
+- **The general concept is the same as for outgoing webhooks.** Read about :doc:`Outgoing Webhooks <../developer/webhooks-outgoing/>` first to understand the basic concept.
+- **Mattermost slash commands are Slack-compatible.** If you have used Slack's slash commands previously to interact with external applications, you can reuse those same applications with Mattermost. Mattermost will automatically translate Slack's proprietary JSON payload format.
+- **Custom commands support auto-complete.** When you create a custom command for your teammates, you have the option to fill in information about how auto-complete should work with that command. This gives your teammates quick and easy access to use your custom slash command.
 
 **Example:**
 
-Suppose you had an external application that had the ability to check the weather for certain cities. By creating a custom slash command, and setting up the application to handle the HTTP POST or GET from the command, you could allow your users to check the weather in their city using your command. For example, a user might be able to type:
+Suppose you have an external application that is able to check the weather for certain cities. By creating a custom slash command, and setting up the application to handle the HTTP POST or GET from the command, you could allow your users to check the weather in their city using your command. For example, a user might be able to type:
 
 ``/weather toronto week``
 
@@ -52,7 +53,7 @@ Each Mattermost installation comes with some built-in slash commands that are re
 Enabling Custom Commands
 ------------------------
 
-Custom slash commands are off by default, and can be enabled by the system administrator. If you are the system administrator you can enable them by doing the following:
+Custom slash commands are off by default. The feature can be enabled by the system administrator only. If you are the system administrator you can enable them by doing the following:
 
 1. Login to your Mattermost team account that has the system administrator role.
 2. Navigate to **System Console > Integrations > Custom Integrations**.

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -3,20 +3,24 @@
 Incoming Webhooks
 =================
 
-Incoming webhooks allow external applications, written in the programming language of your choice--to post messages into Mattermost public channels, private channels, and direct messages by sending a specifically formatted JSON payload via HTTP POST request to a secret Mattermost URL generated specifically for each application.
+Mattermost supports Webhooks to integrate external applications into the platform easily. Webhooks are simple event-notifications via HTTP POST. Incoming Webhooks may post a message to a Mattermost instance into public channels, private channels, and direct messages. The HTTP POST contains a specifically formatted JSON payload and is sent to Mattermost URL generated specifically for each application.
 
-A couple key points:
+A couple of key points:
 
-- **Mattermost incoming webhooks are Slack-compatible.** If you've used Slack's incoming webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost incoming webhooks support full markdown.** A rich range of formatting unavailable in Slack is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown.
+- **The external application may be written in the programming language of your choice.** It only needs to support sending a HTTP POST in the required JSON format to the specific URL.
+- **Webhooks are designed to post a message only.** It is not possible to trigger any other event, like »create new channel« with a Webhook. Use the :doc:`API <../developer/api>`_ for this task.
+- **Mattermost incoming webhooks are Slack-compatible.** If you've used Slack's incoming webhooks previously, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format.
+- **Mattermost incoming webhooks support full markdown.** Unlike in Slack a rich range of formatting is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown.
 
 **Example:**
 
-Suppose you wanted to create a notification of the status of a daily build, with a table of total tests run and total tests failed by component category, with links to failed tests by category. You could create the following JSON payload to post to a Mattermost channel using webhooks:
+Suppose you have an external application which sends notifications, and these notifications should be posted into a Mattermost channel as well. The application may publish a statistic of executed software tests once a day. The application then just needs to send a HTTP request with a defined JSON format to Mattermost.
+
+The JSON payload for this example might be:
 
 .. code-block:: text
 
-  payload={"text": "
+  {"text": "
   | Component  | Tests Run   | Tests Failed                                   |
   |:-----------|:------------|:-----------------------------------------------|
   | Server     | 948         | :white_check_mark: 0                           |

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -3,17 +3,19 @@
 Outgoing Webhooks
 =================
 
-Outgoing webhooks allow external applications, written in the programming language of your choice--to receive HTTP POST requests whenever a user posts to a certain channel, with a trigger word at the beginning of the message, or a combination of both. If the external application responds appropriately to the HTTP request, as response post can be made in the channel where the original post occurred.
+In addition to :doc:`Incoming Webhooks <../developer/webhooks-incoming/>` Mattermost also supports outgoing webhooks. This allows Mattermost to send a request to a web service and process the response. The outgoing webhook is triggered whenever a user posts to a certain channel, with a trigger word at the beginning of a message, or a combination of both. If the application responds appropriately to the HTTP request, a response message can be posted in the channel where the original post occurred.
 
-A couple key points:
+A couple of key points:
 
-- **Mattermost outgoing webhooks are Slack-compatible.** If you've used Slack's outgoing webhooks to create integrations, you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format into markdown to render in Mattermost messages
-- **Mattermost outgoing webhooks support full markdown.** When an integration responds with a message to post, it will have access to a rich range of formatting unavailable in Slack that is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown.
-- **Outgoing webhooks are only supported in public channels.** If you need something that works in a private channel, consider using a :doc:`Slash Command <slash-commands>`.
+- **The outgoing webhook is similar to the incoming webhook.** As described in the chapter :doc:`Incoming Webhooks <../developer/webhooks-incoming/>` the application may be written in the programming language of your choice. It needs to provide a URL which reacts to the request send by your Mattermost instance, and may be able to send a HTTP POST in the required JSON format as a response.
+- **Mattermost outgoing webhooks are Slack-compatible.** If you've used Slack's outgoing webhooks before, than you can copy and paste that code to create Mattermost integrations. Mattermost automatically translates Slack's proprietary JSON payload format.
+- **Outgoing webhooks are supported in public channels only.** If you need a trigger that works in a private channel, consider using a :doc:`Slash Command <slash-commands>` instead.
 
 **Example:**
 
-Suppose you had an external application that received a post event whenever a message started with *#build*. If a user posted the message *#build Let's see the status*, then the external application would receive an HTTP POST with data about that message. The application could then respond with a table of total tests run and total tests failed by component category, with links to failed tests by category. An example response might be:
+Suppose you have an external application that should be triggered whenever a message in Mattermost starts with *#build*. If a user posted the message *#build Let's see the status*, then the external application would receive an HTTP POST with data about that message. The application could then calculate all necessary data, such as a statistic of executed software tests. The application then builds the required JSON payload format and sends it as response to Mattermost. Mattermost reads the response and posts a new message.
+
+An example response of such an application might be:
 
 .. code-block:: text
 
@@ -33,7 +35,7 @@ Which would render in a Mattermost message as follows:
 Enabling Outgoing Webhooks
 --------------------------
 
-Outgoing webhooks are off by default, and can be enabled by the system administrator. If you are the system administrator you can enable them by doing the following:
+Outgoing webhooks are off by default. They need to be enabled by the system administrator. If you are the system administrator you can enable them by doing the following:
 
 1. Login to your Mattermost team account that has the system administrator role.
 2. Enable outgoing webhooks from **System Console > Integrations > Custom Integrations**.
@@ -44,13 +46,13 @@ Outgoing webhooks are off by default, and can be enabled by the system administr
 Set Up an Outgoing Webhook
 --------------------------
 
-Once outgoing webhooks are enabled, you will be able to set one up through the Mattermost UI. You will need to know the following
+Once outgoing webhooks are enabled in general, you will be able to set individual webhooks through the Mattermost UI. You will need to know the following:
 
 1. The channel you want to listen to post events from (you can leave the channel field blank if you would like to set up the webhook for all channels).
 2. The trigger words (if any) that will trigger a post event if they are the **first word** of the post.
 3. The URL you want Mattermost to report the events to.
 
-Once you have those, you can follow these steps to set up your webhook:
+Once you have this information, you can follow these steps to set up your new webhook:
 
 1. Login to your Mattermost team site and go to **Main Menu > Integrations > Outgoing Webhooks**.
 2. Click **Add outgoing webhook**, and select your options.
@@ -64,9 +66,9 @@ Once you have those, you can follow these steps to set up your webhook:
 Creating Integrations using Outgoing Webhooks
 ---------------------------------------------
 
-If you'd like to build your own integration that uses outgoing webhooks, you can follow these general guidelines:
+If you'd like to build your own application that uses outgoing webhooks, you can follow these general guidelines:
 
-1. In the programming language of your choice, write your integration to perform what you had in mind.
+1. In the programming language of your choice, write your application to perform what you had in mind.
   1. Your integration should have a function for receiving HTTP POSTs from Mattermost that look like this example:
 
     .. code-block:: text


### PR DESCRIPTION
Since I stumpled upon the webhooks (and slash command) and did not understand the basic concept at first, I wanted to share my insights with others. Personally I have the feeling that the docs were written for people who are used to the integrations in Slack and already know the basic concepts of hooks, payloads and so on. But for newbies like me it was a bit confusing. So I hope I can help to improve the situation.

PS: I did not find any documentation of how the JSON payload is supposed to look like. The docs currently only refer to Slack at several points. But there seems to be no page which describes all available fields in the JSON payload. I created a [feature request](https://mattermost.uservoice.com/forums/306457-general/suggestions/19787740-documentation-of-json-payload-format-for-integrati) for this as well.