### PR TITLE
Fix relative linking

### DIFF
--- a/source/process/developer.rst
+++ b/source/process/developer.rst
@@ -2,110 +2,110 @@
 Staff Developers
 ====================================
 
-As a core committer at Mattermost you are responsible for one of the world's largest and most popular open source projects. Your work impacts thousands of organizations who depend on Mattermost for daily operations, from high tech (Intel, Samsung, Micron), to healthcare (Medtronic, Epic, Bristol-Myers Squibb) to public sector (U.S. Department of Defense, U.S. Department of Energy), to education (University of California, National University of Singapore), and consumer brands (Urban Outfitters, Wargaming.net). 
+As a core committer at Mattermost you are responsible for one of the world's largest and most popular open source projects. Your work impacts thousands of organizations who depend on Mattermost for daily operations, from high tech (Intel, Samsung, Micron), to healthcare (Medtronic, Epic, Bristol-Myers Squibb) to public sector (U.S. Department of Defense, U.S. Department of Energy), to education (University of California, National University of Singapore), and consumer brands (Urban Outfitters, Wargaming.net).
 
-Working in open source means your work is publicly visible. Your code will receive both credit and critique from the community and with the right mindset and support that can lead to you making the best engineering decisions of your career. 
+Working in open source means your work is publicly visible. Your code will receive both credit and critique from the community and with the right mindset and support that can lead to you making the best engineering decisions of your career.
 
 Core committers include volunteer developers from the community, staff by organizations deploying and investing in Mattermost, as well as staff paid by Mattermost, Inc.
 
-This document summarizes the resposibilities and requirements of core committers employed by Mattermost, Inc., skill level requirements and hiring process. Staff developers work closely with Mattermost product management to envision, design, plan, develop, coordinate, review and merge improvements per our `contribution guidelines <https://docs.mattermost.com/developer/contribution-guide.html>`_ on a regular basis. 
+This document summarizes the responsibilities and requirements of core committers employed by Mattermost, Inc., skill level requirements and hiring process. Staff developers work closely with Mattermost product management to envision, design, plan, develop, coordinate, review and merge improvements per our `contribution guidelines <../developer/contribution-guide.html>`_ on a regular basis.
 
-Ideally, developers are "full stack", and comfortable moving across backend and frontend projects. As part of our `learn, master, teach <https://docs.mattermost.com/process/training.html#learn-master-teach>`_ mindset, our environment has people consistently cross-training, becoming experts and passing on knowledge to new team members rotating into new areas of responsibility. That said, we also welcome engineers who prefer to specialize in backend and frontend, since there's ample projects to find in both areas.  
+Ideally, developers are "full stack", and comfortable moving across backend and frontend projects. As part of our `learn, master, teach <training.html#learn-master-teach>`_ mindset, our environment has people consistently cross-training, becoming experts and passing on knowledge to new team members rotating into new areas of responsibility. That said, we also welcome engineers who prefer to specialize in backend and frontend, since there's ample projects to find in both areas.
 
 Responsibilities
 -------------------------
 
 - Develop features from proposal to polished end result.
-- Support and collaborate with our community service engineers to find the root cause of issues, find, deliver and document effective solutions. 
+- Support and collaborate with our community service engineers to find the root cause of issues, find, deliver and document effective solutions.
 - Engage with the core team and the open source community to collaborate on improving Mattermost.
 - Propose, coordinate, manage, review and merge code contributed by the rest of the community and work with them to get it ready for production.
-- Work with our `documentation team <https://docs.mattermost.com/process/documentation-guidelines.html?>`_ to create and maintain technical information around features, configuration and troubleshooting. 
+- Work with our `documentation team <documentation-guidelines.html>`_ to create and maintain technical information around features, configuration and troubleshooting.
 - Take initiative in improving the software in small or large ways to address pain points in your own experience as a developer.
 - Keep code easy to maintain. Keep it easy for others to contribute code.
-- Help identify, vet and recruit other developers to join our community and, when appropriate, as staff developers. 
+- Help identify, vet and recruit other developers to join our community and, when appropriate, as staff developers.
 
-Requirements 
+Requirements
 -------------------------
 
 - You can effectively reason and discuss software, algorithms, and performance at a high level
-- You have a passion for creating open source software 
-- You have previously played a vital role in production-level applications 
+- You have a passion for creating open source software
+- You have previously played a vital role in production-level applications
 - You have strong written communication skills.
 - You're self-motivated with strong organizational skills.
 - You share our values, and work in accordance with those values.
-- You're proficient in Golang, React and/or React Native, or are able to ramp quickly into those languages. 
-- You've either made substantial contributions to the Mattermost open source project or are open to completing a `paid simulation <https://docs.mattermost.com/process/developer.html#paid-simulation>`_ to assess your comfort in working in open source.
-- Ideal, but not required: Experience working in online communities, having made at least one `Help Wanted <https://github.com/search?utf8=%E2%9C%93&q=org%3Amattermost+state%3Aopen+Help+Wanted&type=Issues&ref=searchresults?>`_ pull request to a Mattermost repository, working on other Golang, React or React Native apps. 
+- You're proficient in Golang, React and/or React Native, or are able to ramp quickly into those languages.
+- You've either made substantial contributions to the Mattermost open source project or are open to completing a `paid simulation`_ to assess your comfort in working in open source.
+- Ideal, but not required: Experience working in online communities, having made at least one `Help Wanted <https://github.com/search?utf8=%E2%9C%93&q=org%3Amattermost+state%3Aopen+Help+Wanted&type=Issues&ref=searchresults?>`_ pull request to a Mattermost repository, working on other Golang, React or React Native apps.
 
 Levels
 -------------------------
 
-The below level descriptions are used to categorize core committers based on their capabilities. Regardless of level, all core committers are expected to fulfill the following: 
+The below level descriptions are used to categorize core committers based on their capabilities. Regardless of level, all core committers are expected to fulfill the following:
 
-- Deliver high quality code that represents the best thinking of the open source project and is ready to be scrutinized by hundreds of community members, including commercial customers. 
+- Deliver high quality code that represents the best thinking of the open source project and is ready to be scrutinized by hundreds of community members, including commercial customers.
 - Write complete code that meets all specifications and criteria, has thorough unit tests and typically no defects.
-- Work collaboratively in a high trust, asynchronous environment with strong written communication skills and comfort working with fellow developers, product managers, designers, testers, technical writers, support engineers and other product and business staff. 
+- Work collaboratively in a high trust, asynchronous environment with strong written communication skills and comfort working with fellow developers, product managers, designers, testers, technical writers, support engineers and other product and business staff.
 
 Software Design Engineer I
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Influences and executes defined tasks and features across engineering and test automation. Works effectively in teams to align priorities and manage execution. Learns new skills and establishes goals and context quickly by asking precise questions. Engages, guides and enables open source contributors to deliver high quality pull requests. 
+Influences and executes defined tasks and features across engineering and test automation. Works effectively in teams to align priorities and manage execution. Learns new skills and establishes goals and context quickly by asking precise questions. Engages, guides and enables open source contributors to deliver high quality pull requests.
 
 Software Design Engineer II
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Capabilities of SDE I plus: Designs, leads and delivers high impact features and changes across the product stack and test automation infrastructure. Sets thoughtful, technical vision for areas of ownership, balancing functional and technical trade-offs, while working effectively with PM and UX. Drops fluidly into different projects, ramps quickly and leads features to successful outcomes. Inspires, organizes and enables groups of open source community members to contribute to development campaigns in building significant new functionality. 
+Capabilities of SDE I plus: Designs, leads and delivers high impact features and changes across the product stack and test automation infrastructure. Sets thoughtful, technical vision for areas of ownership, balancing functional and technical trade-offs, while working effectively with PM and UX. Drops fluidly into different projects, ramps quickly and leads features to successful outcomes. Inspires, organizes and enables groups of open source community members to contribute to development campaigns in building significant new functionality.
 
 Senior Software Design Engineer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Capabilities of SDE II plus: Sets and delivers architectural vision for high impact features and changes across multiple products, working in sync with PM, UX, and customer teams. Highly respected by colleagues and community as technical authority, influencing discussions and behavior with input and suggestions. Drops fluidly into customer and community discussions, aligns efforts, and develops superior solutions through discussion and analysis. Attracts, motivates and trains open source community members to lead the coordination and management of development campaigns to create new features and products. 
+Capabilities of SDE II plus: Sets and delivers architectural vision for high impact features and changes across multiple products, working in sync with PM, UX, and customer teams. Highly respected by colleagues and community as technical authority, influencing discussions and behavior with input and suggestions. Drops fluidly into customer and community discussions, aligns efforts, and develops superior solutions through discussion and analysis. Attracts, motivates and trains open source community members to lead the coordination and management of development campaigns to create new features and products.
 
 Architect
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Capabilities of Senior SDE plus: Sets and delivers architectural vision for entire products and systems spanning multiple products. Engages with peers in customer and partner organizations to shape joint development plans. Works fluidly with PM, UX and sales leadership to set organizational objectives and direction. Sought out as a technical authority in industry in developing, disseminating, reviewing, evaluating key patterns and reference architectures. Influences, shapes and can redirect customer and community technical discussions, rapidly understanding disparate viewpoints and leading discussions that align thinking and efforts to influence the direction of large scale technical projects. 
+Capabilities of Senior SDE plus: Sets and delivers architectural vision for entire products and systems spanning multiple products. Engages with peers in customer and partner organizations to shape joint development plans. Works fluidly with PM, UX and sales leadership to set organizational objectives and direction. Sought out as a technical authority in industry in developing, disseminating, reviewing, evaluating key patterns and reference architectures. Influences, shapes and can redirect customer and community technical discussions, rapidly understanding disparate viewpoints and leading discussions that align thinking and efforts to influence the direction of large scale technical projects.
 
 Hiring Process
 -------------------------
 
-Candidates for developer roles on the Mattermost staff can expect the hiring process to follow the order below. Please keep in mind that applicants can be declined from the position at any stage of the process. 
+Candidates for developer roles on the Mattermost staff can expect the hiring process to follow the order below. Please keep in mind that applicants can be declined from the position at any stage of the process.
 
-Both declined and accepted candidates will be invited to share feedback on their hiring experience so we can continually improve our process. 
+Both declined and accepted candidates will be invited to share feedback on their hiring experience so we can continually improve our process.
 
-- **Application/Email - Review of code samples** - In `your application <https://jobs.lever.co/mattermost/>`_ we welcome you to include links to any public open source work you've done, including GitHub, GitLab or BitBucket profiles. If you'd like to share privately we can send you our ID for GitHub, GitLab or BitBucket, or we can review code you send in via email. If you really want to impress us, `make a contribution to our open source project by completing a Help Wanted ticket. <https://docs.mattermost.com/developer/contribution-guide.html>`_
-- **Email - Follow-up questions** - If your code samples look good, we'll email you some questions specific to the role. 
-- **Video call - Screening interview** - Selected candidates will be invited for a 25-minute screening call with a recruiter. 
-- **Video call - Soft-skills discussion** - Next, candidates will be invited to schedule a 25-minute interview with a core committer to assess soft skills and for the candidate to learn more about the role. 
-- **Paid Simulation** - Successful candidates with limited experience contributing to Mattermost are offered a paid project to simulate the experience of working as a core committer. See below for description for *Paid Simulation* for details. 
-- **Reference Checks** - You'll be sent an email request by `SkillSurvey <http://www.skillsurvey.com/>`_ to list 3 references who can verify your past achievements.  
-- **Video call - CTO interview** - Candidates are invited to a 45-minute interview with our CTO and co-creator of the Mattermost open source project. The interview may include technical questions along with a discussion of either past work or results of the simulation, the candidate's interests, their career aspirations, and how being a core committer at Mattermost could align with those interests and aspirations. 
+- **Application/Email - Review of code samples** - In `your application <https://jobs.lever.co/mattermost/>`_ we welcome you to include links to any public open source work you've done, including GitHub, GitLab or BitBucket profiles. If you'd like to share privately we can send you our ID for GitHub, GitLab or BitBucket, or we can review code you send in via email. If you really want to impress us, `make a contribution to our open source project by completing a Help Wanted ticket. <../developer/contribution-guide.html>`_
+- **Email - Follow-up questions** - If your code samples look good, we'll email you some questions specific to the role.
+- **Video call - Screening interview** - Selected candidates will be invited for a 25-minute screening call with a recruiter.
+- **Video call - Soft-skills discussion** - Next, candidates will be invited to schedule a 25-minute interview with a core committer to assess soft skills and for the candidate to learn more about the role.
+- **Paid Simulation** - Successful candidates with limited experience contributing to Mattermost are offered a paid project to simulate the experience of working as a core committer. See below for description for *Paid Simulation* for details.
+- **Reference Checks** - You'll be sent an email request by `SkillSurvey <http://www.skillsurvey.com/>`_ to list 3 references who can verify your past achievements.
+- **Video call - CTO interview** - Candidates are invited to a 45-minute interview with our CTO and co-creator of the Mattermost open source project. The interview may include technical questions along with a discussion of either past work or results of the simulation, the candidate's interests, their career aspirations, and how being a core committer at Mattermost could align with those interests and aspirations.
 - **Video call - CEO interview** - Finally, candidates will have a 45-minute interview with our CEO.
-- **Email - Offer** - Successful candidates will receive an offer via email. Mattermost offers compensation competitive with a candidate's local market opportunities. 
+- **Email - Offer** - Successful candidates will receive an offer via email. Mattermost offers compensation competitive with a candidate's local market opportunities.
 
 Notes:
- 
-- Staff developers in Canada are typically offered full-time employment through a Canadian co-employer, with local payroll via ADP, benefits and T4 tax reporting. 
-- Staff developers in the US are typically offered full-time employment through a U.S. co-employer, with local payroll via TriNet, benefits and W2 tax reporting. 
+
+- Staff developers in Canada are typically offered full-time employment through a Canadian co-employer, with local payroll via ADP, benefits and T4 tax reporting.
+- Staff developers in the US are typically offered full-time employment through a U.S. co-employer, with local payroll via TriNet, benefits and W2 tax reporting.
 - Staff developers outside the U.S. and Canada are offered full-time consulting paperwork very similar to the click-sign agreement for the paid simulation.
 
-Paid Simulation 
+Paid Simulation
 ----------------------------
 
-Similar to other open source companies, for candidates who successfully complete technical and soft-skills reviews, and who have limited experience contributing to Mattermost, we offer a paid simulation.  
+Similar to other open source companies, for candidates who successfully complete technical and soft-skills reviews, and who have limited experience contributing to Mattermost, we offer a paid simulation.
 
 The simulation helps candidates experience working on one of the world's largest open source projects to understand how they would enjoy such a role should they decide to join the company. Your code will be reviewed and used by hundreds of other contributing developers. After a vetting process, successful projects are merged and the results of your simulation will be deployed by thousands of companies around in the world.
 
-Your work will become a permanent part of the open source project that you can reference for the rest of your career. You're also eligible to receive a `Mattermost Mug <https://twitter.com/search?q=%23mattermug&src=typd>`_ in appreciation of your first contribution. 
+Your work will become a permanent part of the open source project that you can reference for the rest of your career. You're also eligible to receive a `Mattermost Mug <https://twitter.com/search?q=%23mattermug&src=typd>`_ in appreciation of your first contribution.
 
-The simulation project reflects an investment from the core committers to work with the candidate through a series of significant contributions, answering questions, providing input and reviewing code as needed. It also reflects an investment from the candidate to explore the experience of working at Mattermost. 
+The simulation project reflects an investment from the core committers to work with the candidate through a series of significant contributions, answering questions, providing input and reviewing code as needed. It also reflects an investment from the candidate to explore the experience of working at Mattermost.
 
-The paid simulation project typically consists of a collection of challenging `Help Wanted tickets <https://github.com/mattermost/platform/issues?q=is%3Aissue+%5BHelp+Wanted%5D+is%3Aopen>`_ to be completed per the `Mattermost contribution guidelines <https://docs.mattermost.com/developer/contribution-guide.html>`_ in a mutually agreed timeline reflecting 30-40 hours of development at the estimated skill level of the candidate. 
+The paid simulation project typically consists of a collection of challenging `Help Wanted tickets <https://github.com/mattermost/platform/issues?q=is%3Aissue+%5BHelp+Wanted%5D+is%3Aopen>`_ to be completed per the `Mattermost contribution guidelines <..developer/contribution-guide.html>`_ in a mutually agreed timeline reflecting 30-40 hours of development at the estimated skill level of the candidate.
 
-A flat rate of $750 USD is offered to attempt the simulation project. This amount is a standard fee for simulations and not an indicator of the final offer that would be extended to a successful candidate. A `standard click-sign services agreement <https://docs.google.com/document/d/1G4wFLq_wHHEDJ-hrv5Kmu022mFJgh3rJ4-glM0W6riI/edit#heading=h.u3m8fmn6xapr>`_ is used to accept the fee. The fee is paid regardless of whether the project is completed. 
+A flat rate of $750 USD is offered to attempt the simulation project. This amount is a standard fee for simulations and not an indicator of the final offer that would be extended to a successful candidate. A `standard click-sign services agreement <https://docs.google.com/document/d/1G4wFLq_wHHEDJ-hrv5Kmu022mFJgh3rJ4-glM0W6riI/edit#heading=h.u3m8fmn6xapr>`_ is used to accept the fee. The fee is paid regardless of whether the project is completed.
 
-While you're working on the project, you can join the Mattermost community site at https://pre-release.mattermost.com/core/. 
+While you're working on the project, you can join the Mattermost community site at https://pre-release.mattermost.com/core/.
 
-Once signed-in, the following channels are recommended for observing how the core committers work with the community to ship new releases: 
+Once signed-in, the following channels are recommended for observing how the core committers work with the community to ship new releases:
 
 - https://pre-release.mattermost.com/core/channels/developers
 - https://pre-release.mattermost.com/core/channels/bugs
@@ -113,12 +113,12 @@ Once signed-in, the following channels are recommended for observing how the cor
 - https://pre-release.mattermost.com/core/channels/release-discussion
 - https://pre-release.mattermost.com/core/channels/peer-to-peer-help
 
-Observing these public channels as you work will give you a good sense of what it is like to work at Mattermost in a full time capacity to ensure joining the company aligns to your interests and desired career direction. 
+Observing these public channels as you work will give you a good sense of what it is like to work at Mattermost in a full time capacity to ensure joining the company aligns to your interests and desired career direction.
 
-Frequently Asked Questions 
+Frequently Asked Questions
 --------------------------------------------------
 
-Do you have internships? 
+Do you have internships?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 While we no longer offer internships for developers, if you get a couple of `Help Wanted <https://github.com/search?utf8=%E2%9C%93&q=org%3Amattermost+state%3Aopen+Help+Wanted&type=Issues&ref=searchresults?>`_ pull requests accepted, we'll interview you for one. This will be a remote internship without supervision; you'll only get feedback on your merge requests. If you want to work on open source and qualify `please submit an application <https://jobs.lever.co/mattermost/>`_. In the cover letter field, please note that you want an internship and link to the accepted pull requests. The pull requests should be of significant value and difficulty, which is at the discretion of the hiring manager. For example, fixing 10 typos isn't as valuable as shipping 2 new features.

--- a/source/process/developer.rst
+++ b/source/process/developer.rst
@@ -40,7 +40,7 @@ Requirements
 Levels
 -------------------------
 
-The below level descriptions are used to categorize core committers based on their capabilities. Regardless of level, all core committers are expected to fulfill the following:
+The level descriptions below are used to categorize core committers based on their capabilities. Regardless of level, all core committers are expected to fulfill the following:
 
 - Deliver high quality code that represents the best thinking of the open source project and is ready to be scrutinized by hundreds of community members, including commercial customers.
 - Write complete code that meets all specifications and criteria, has thorough unit tests and typically no defects.


### PR DESCRIPTION
Converted links to targets that are within the docset into relative links. Resolves [broken link or missing information #1268](https://github.com/mattermost/docs/issues/1268)