### PR TITLE
Version archive for 4.0.0 + changelog updates for 4.0.0/4.0.1

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -6,7 +6,14 @@ Also see [changelog in progress](http://bit.ly/2nK3cVf) for the next release.
 
 ## Release v4.0.0
 
-Release Date: July 16, 2017
+ - **v4.0.1, TBD**
+   - Release date planned for 2017-07-18 with the following fixes:
+     -  If `AllowTimeLimit` config setting is set to `Never`, pinning and un-pinning messages fails.
+     - If you upload or remove the **Service Provider Public Certificate** file in **System Console > SAML**, the page refreshes and clears changed settings.
+     - Deactivated users are listed in channel member lists.
+     - If you remove Site URL in High Availability mode, your Mattermost instance might refresh repeatedly.
+ - **v4.0.0, released 2017-07-16**
+   - Original 4.0.0 release
 
 ### Security Update
 
@@ -261,9 +268,9 @@ Many thanks to all our contributors. In alphabetical order:
 
 ## Release v3.10.2
 
- - **v3.10.2, released 2017-07-16**
+ - **v3.10.2, released 2017-07-18**
    - Mattermost v3.10.2 contains low severity security fixes. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
- - **v3.10.1, released 2017-07-13**
+ - **v3.10.1, released 2017-07-16**
    - Mattermost v3.10.1 contains a high severity security fix for an OAuth SSO vulnerability and two additional fixes for low severity security issues. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
  - **v3.10.0, released 2017-06-16**
    - Original 3.10 release
@@ -463,9 +470,9 @@ Many thanks to all our contributors. In alphabetical order:
 
 ## Release v3.9.2
 
- - **v3.9.2, released 2017-07-16**
+ - **v3.9.2, released 2017-07-18**
    - Mattermost v3.9.2 contains low severity security fixes. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
- - **v3.9.1, released 2017-07-13**
+ - **v3.9.1, released 2017-07-16**
    - Mattermost v3.10.1 contains a high severity security fix for an OAuth SSO vulnerability and two additional fixes for low severity security issues. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
  - **v3.9.0, released 2017-05-16**
    - Original 3.10 release
@@ -707,7 +714,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ### Notes on Patch Release
 
- - **v3.8.3, released 2017-07-13**
+ - **v3.8.3, released 2017-07-16**
    - Mattermost v3.8.3 contains a high severity security fix for an OAuth SSO vulnerability and two additional fixes for low severity security issues. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
  - **v3.8.2, released 2017-04-21**
    - Changed the client to use `window.location.origin` instead of siteURL, fixing WebSocket connection issues with Mattermost 3.8 upgrade.

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -121,20 +121,20 @@ Mattermost Enterprise Edition - Supported Versions
 
 Mattermost Enterprise Edition v4.0.0 - `View Changelog <./changelog.html#release-v4-0-0>`_ - `Download <https://releases.mattermost.com/4.0.0/mattermost-4.0.0-linux-amd64.tar.gz>`_
   - ``https://releases.mattermost.com/4.0.0/mattermost-4.0.0-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``TBA``
-Mattermost Enterprise Edition v3.10.0 - `View Changelog <./changelog.html#release-v3-10-0>`_ - `Download <https://releases.mattermost.com/3.10.0/mattermost-3.10.0-linux-amd64.tar.gz>`_
-  - ``https://releases.mattermost.com/3.10.0/mattermost-3.10.0-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``3977cb70b88a6def7009176bf23880fe5ad864cead05a1f2cae7792c8ac9148c``
-Mattermost Enterprise Edition v3.9.0 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-9-0>`_ - `Download <https://releases.mattermost.com/3.9.0/mattermost-3.9.0-linux-amd64.tar.gz>`_
-  - ``https://releases.mattermost.com/3.9.0/mattermost-3.9.0-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``6e88c8a89c1320804960d215b8d5e6914075ad156f4590bbcd763252597e506c``
+  - SHA-256 Checksum: ``ff81595ac82679f208709cd0a4367396f0f49fbb4bb2c439a3fced8ab020731e``
+Mattermost Enterprise Edition v3.10.1 - `View Changelog <./changelog.html#release-v3-10-1>`_ - `Download <https://releases.mattermost.com/3.10.1/mattermost-3.10.1-linux-amd64.tar.gz>`_
+  - ``https://releases.mattermost.com/3.10.1/mattermost-3.10.1-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``1cef548b916972a2a932bc9c819a3928162e3a6aaee8762259174d8cdc003b00``
+Mattermost Enterprise Edition v3.9.1 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-9-1>`_ - `Download <https://releases.mattermost.com/3.9.1/mattermost-3.9.1-linux-amd64.tar.gz>`_
+  - ``https://releases.mattermost.com/3.9.1/mattermost-3.9.1-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``2c7419a768ac0ae1eb58fd4c578849670ecc226568efc3f76ac21f7f9147470a``
 
 Mattermost Enterprise Edition - Unsupported Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost Enterprise Edition v3.8.2 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-8-2>`_ - `Download <https://releases.mattermost.com/3.8.2/mattermost-3.8.2-linux-amd64.tar.gz>`_
-  - ``https://releases.mattermost.com/3.8.2/mattermost-3.8.2-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``b99c86a2667f636eaee26331aa61a71a51b2d3d412eaa83fdebf8b53cddc6aeb``
+Mattermost Enterprise Edition v3.8.3 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-8-3>`_ - `Download <https://releases.mattermost.com/3.8.3/mattermost-3.8.3-linux-amd64.tar.gz>`_
+  - ``https://releases.mattermost.com/3.8.3/mattermost-3.8.3-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``c223320a82222ebff002071633c6331dce0da6ff6ac8e22d0ab0d7055356ff9c``
 Mattermost Enterprise Edition v3.7.5 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-7-5>`_ - `Download <https://releases.mattermost.com/3.7.5/mattermost-3.7.5-linux-amd64.tar.gz>`_
   - ``https://releases.mattermost.com/3.7.5/mattermost-3.7.5-linux-amd64.tar.gz``
   - SHA-256 Checksum: ``65e65da661edbc7b7b2b02411f13dbe498fd704d5ae1289789feca79fe00b58a``
@@ -171,20 +171,20 @@ Mattermost Team Edition Server Archive - Supported Versions
 
 Mattermost Team Edition v4.0.0 - `View Changelog <./changelog.html#release-v4-0-0>`_ - `Download <https://releases.mattermost.com/4.0.0/mattermost-team-4.0.0-linux-amd64.tar.gz>`_
   - ``https://releases.mattermost.com/4.0.0/mattermost-team-4.0.0-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``TBA``
-Mattermost Team Edition v3.10.0 - `View Changelog <./changelog.html#release-v3-10-0>`_ - `Download <https://releases.mattermost.com/3.10.0/mattermost-team-3.10.0-linux-amd64.tar.gz>`_
-  - ``https://releases.mattermost.com/3.10.0/mattermost-team-3.10.0-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``ed64cb5357a8a3669386fd73b9a3f4934a10f0a9da02dc4be085e3d2e36886ed``
-Mattermost Team Edition v3.9.0 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-9-0>`_ - `Download <https://releases.mattermost.com/3.9.0/mattermost-team-3.9.0-linux-amd64.tar.gz>`_
-  - ``https://releases.mattermost.com/3.9.0/mattermost-team-3.9.0-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``c6179f7b2282cfbc8f0a691a90b41b554b62726f1dfb036fc59eed635556c8d9``
+  - SHA-256 Checksum: ``23cd9b44af336443260016dfbd6d6dfd95226cb0aaedbfef0681183150ad5996``
+Mattermost Team Edition v3.10.1 - `View Changelog <./changelog.html#release-v3-10-1>`_ - `Download <https://releases.mattermost.com/3.10.1/mattermost-team-3.10.1-linux-amd64.tar.gz>`_
+  - ``https://releases.mattermost.com/3.10.1/mattermost-team-3.10.1-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``6e4976e500e9e31358256a8a169378fb99bed643c8ad10005f3695cfb3041de4``
+Mattermost Team Edition v3.9.1 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-9-1>`_ - `Download <https://releases.mattermost.com/3.9.1/mattermost-team-3.9.1-linux-amd64.tar.gz>`_
+  - ``https://releases.mattermost.com/3.9.1/mattermost-team-3.9.1-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``f7f878c7d195e1f336b7025fbb4063c1796fa16296ac2d7437d2a5067750966e``
 
 Mattermost Team Edition Server Archive - Unsupported Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost Team Edition v3.8.2 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-8-2>`_ - `Download <https://releases.mattermost.com/3.8.2/mattermost-team-3.8.2-linux-amd64.tar.gz>`_
-  - ``https://releases.mattermost.com/3.8.2/mattermost-team-3.8.2-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``82cc85557dc21b3871ec89326769c11d3a89c9c41362fb3945247f8fba562ce7``
+Mattermost Team Edition v3.8.3 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-8-3>`_ - `Download <https://releases.mattermost.com/3.8.3/mattermost-team-3.8.3-linux-amd64.tar.gz>`_
+  - ``https://releases.mattermost.com/3.8.3/mattermost-team-3.8.3-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``1a5de4052c007c54fce6cd844ab3e89aabc8d1a05b8bac72ef58f6896760c4e1``
 Mattermost Team Edition v3.7.5 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v3-7-5>`_ - `Download <https://releases.mattermost.com/3.7.5/mattermost-team-3.7.5-linux-amd64.tar.gz>`_
   - ``https://releases.mattermost.com/3.7.5/mattermost-team-3.7.5-linux-amd64.tar.gz``
   - SHA-256 Checksum: ``eaee6a57ab9e2924f71853cbebf465d63f7dbf1112716c0e4768984de39f83a2``


### PR DESCRIPTION
@JeffSchering @lindy65 I'll merge this for the July 16th release, but it wouldn't hurt to have one of you review.

If you search for `in:release-discussion download links` in pre-release, you'll find posts with download links and SHA-256 hashes for 4.0.0/3.10.1/3.9.1/3.8.3