### PR TITLE
Improve docker deployment documentation

### DIFF
--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -12,7 +12,7 @@ If you have any problems installing, see the `troubleshooting guide <https://www
 Production Docker Setup on Ubuntu
 ----------------------------------------------------
 
-1. **Install Docker Compose** using `the Ubuntu online guide <https://docs.docker.com/installation/ubuntulinux/>`_ or these instructions:
+1. **Install Docker** using `the Ubuntu online guide <https://docs.docker.com/installation/ubuntulinux/>`_ or these instructions:
 
    .. code:: bash
 
@@ -23,7 +23,14 @@ Production Docker Setup on Ubuntu
        sudo service docker start
        newgrp docker
 
-2. **Deploy the Mattermost Production Docker** setup by running:
+2. **Install Docker Compose** using `the online guide <https://docs.docker.com/compose/install/>`_ or these instructions:
+
+   .. code:: bash
+   
+      curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+      sudo chmod +x /usr/local/bin/docker-compose
+
+3. **Deploy the Mattermost Production Docker** setup by running:
 
    .. code:: bash
 
@@ -32,13 +39,13 @@ Production Docker Setup on Ubuntu
        docker-compose build
        docker-compose up -d
 
-3. **Configure TLS** by following `the instructions <https://github.com/mattermost/mattermost-docker#install-with-ssl-certificate>`_
+4. **Configure TLS** by following `the instructions <https://github.com/mattermost/mattermost-docker#install-with-ssl-certificate>`_
 
-4. **Configure Email** by following the `SMTP email setup guide <http://docs.mattermost.com/install/smtp-email-setup.html>`_
+5. **Configure Email** by following the `SMTP email setup guide <http://docs.mattermost.com/install/smtp-email-setup.html>`_
 
-5. (Optional) to enable enterprise features under **System Console** > **Edition and License** upload your `trial license <https://about.mattermost.com/trial/>`_ or `subscription license file <https://about.mattermost.com/pricing/>`_ received via email.
+6. (Optional) to enable enterprise features under **System Console** > **Edition and License** upload your `trial license <https://about.mattermost.com/trial/>`_ or `subscription license file <https://about.mattermost.com/pricing/>`_ received via email.
 
-6. **Configure your server** based on `configuration settings documentation <http://docs.mattermost.com/administration/config-settings.html>`_
+7. **Configure your server** based on `configuration settings documentation <http://docs.mattermost.com/administration/config-settings.html>`_
 
 Additional Guides:
 

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -23,11 +23,11 @@ Production Docker Setup on Ubuntu
        sudo service docker start
        newgrp docker
 
-2. **Install Docker Compose** using `the online guide <https://docs.docker.com/compose/install/>`_ or these instructions:
+2. **Install Docker Compose** using `the online guide <https://docs.docker.com/compose/install/>`_. You have to download the latest release from `Docker Compose Github's page <https://github.com/docker/compose/releases/>`_ and put the binary on your :code:`/usr/local/bin` folder. Usually, you can use the following command, replacing :code:`$dockerComposeVersion` by the Docker Compose version to install :
 
    .. code:: bash
    
-      curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+      curl -L https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
       sudo chmod +x /usr/local/bin/docker-compose
 
 3. **Deploy the Mattermost Production Docker** setup by running:


### PR DESCRIPTION
Thanks to @zeneli, who noticed that the documentation was not explaining how to install `docker-compose`.

The Docker installation is split in two parts : one to install Docker CE, the other to install docker-compose.