### PR TITLE
updated Apache example for post-4.x

### DIFF
--- a/source/install/config-proxy-apache2.rst
+++ b/source/install/config-proxy-apache2.rst
@@ -37,7 +37,7 @@ Copy the `default` configuration file found in the same directory.
 
 		  # Set web sockets
 		  RewriteEngine On
-		  RewriteCond %{REQUEST_URI} ^/api/v3/users/websocket [NC,OR]
+		  RewriteCond %{REQUEST_URI} /api/v[0-9]+/(users/)?websocket [NC,OR]
 		  RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC,OR]
 		  RewriteCond %{HTTP:CONNECTION} ^Upgrade$ [NC]
 		  RewriteRule .* wss://127.0.0.1:8065%{REQUEST_URI} [P,QSA,L]
@@ -45,10 +45,10 @@ Copy the `default` configuration file found in the same directory.
 			# This line simply forces HTTPS
 		  RewriteRule (.*) https://%{SERVER_NAME}%{REQUEST_URI} [END,QSA,R=permanent]
 
-		  <Location /api/v3/users/websocket>
+		  <LocationMatch "^/api/v(?<apiversion>[0-9]+)/(?<apiusers>users/)?websocket">
 			Require all granted
-			ProxyPass ws://127.0.0.1:8065/api/v3/users/websocket
-			ProxyPassReverse ws://127.0.0.1:8065/api/v3/users/websocket
+			ProxyPass ws://127.0.0.1:8065/api/v%{env:MATCH_APIVERSION}/%{env:MATCH_APIUSERS}websocket
+			ProxyPassReverse ws://127.0.0.1:8065/api/v%{env:MATCH_APIVERSION}/%{env:MATCH_APIUSERS}websocket
 			ProxyPassReverseCookieDomain 127.0.0.1 mysubdomain.mydomain.com
 		  </Location>
 


### PR DESCRIPTION
updated the apache example to match the post-4.x NGINX reccommendations

config submitted by user prixone on the forums...
https://forum.mattermost.org/t/apache-reverse-proxy-with-mm-4-0