### PR TITLE
Update telemetry.rst

### DIFF
--- a/source/administration/telemetry.rst
+++ b/source/administration/telemetry.rst
@@ -60,7 +60,13 @@ The following information is sent when the specified event occurs:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Non-personally Identifiable Error Information
-  Boolean when the following events occur: Email login error, AD/LDAP login error, SAML login error
+  Boolean when the following events occur:
+  
+  - *Sign-in Error*: Email login error, AD/LDAP login error, SAML login error
+  
+  Boolean when the following events occur, including the error message, recently dispatched Redux actions, and non-identifiable information of the device, operating system and the app:
+
+  - *Mobile App Errors*: App crashes caused by type errors, exceptions and failed logins
 
 Non-personally Identifiable Diagnostic Information
   Boolean when the following events occur:


### PR DESCRIPTION
Included a summarized version of the Sentry data collection. Can be opted out by disabling the `EnableDiagnostics` server config.json setting, similar to our other error and diagnostics reporting.