### PR TITLE
improve verbosity for how to "code block"

### DIFF
--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -125,7 +125,9 @@ Renders as:
 Code Block
 ----------
 
-Create a code block by indenting each line by four spaces, or by placing ``````` on the line above and below your code.
+Create a fixed width code block by indenting each line by four spaces, or by placing ``````` on the line above and below your code.
+ - This is best described as: three backticks, shift-enter, type stuff, shift-enter, three backticks, enter
+ - Or by key code structures: 3x<`>, <SHIFT>+<ENTER>, **TYPE_OR_PASTE_CODE_AND_STUFF**, <SHIFT>+<ENTER>, 3x<`>, <ENTER>
 
 Example:
 

--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -125,7 +125,9 @@ Renders as:
 Code Block
 ----------
 
-Creating a fixed width code block is recommended for pasting multi-line blocks of code or other text output that is easier to read with fixed width font alignment.
+Creating a fixed width code block is recommended for pasting multi-line blocks of code or other text output that is easier to read with fixed width font alignment. Examples include block text snippets, ASCII tables, log files, etc.
+
+Renders as:
 
 .. code-block:: none
 
@@ -141,19 +143,20 @@ Example:
 
 .. code-block:: none
 
-    this is my
-    code block
+      this is my
+      code block
+
+  ^^^^ 4x spaces
 
 
 or,
 
- 2. Placing 3x backtics (```) on the line directly above and directly below your code.
+ 2. Placing 3x backtics (\`\`\`) on the line directly above and directly below your code
 
 
 Example:
 
 .. code-block:: none
-
 
   ```
   this is my
@@ -161,7 +164,7 @@ Example:
   ```
 
 
- * **TIP**! - If you're having trouble as a first-timer, assuming default keyboard shortcuts for most clients, this can be accomplished by entering: 3x backticks \<\`\`\`\>, \<SHIFT\>+\<ENTER\>, \<type_your_code\>, \<SHIFT\>+\<ENTER\>, and finally 3x backtacs \<\`\`\`\>
+* **TIP**! - If you're having trouble as a first-timer, assuming default keyboard shortcuts for most clients, this can be accomplished by entering: 3x backticks <\`\`\`>, <SHIFT>+<ENTER>, <type_your_code>, <SHIFT>+<ENTER>, and finally 3x backtacs <\`\`\`>.
 
 **Syntax Highlighting**
 

--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -125,9 +125,30 @@ Renders as:
 Code Block
 ----------
 
-Create a fixed width code block by indenting each line by four spaces, or by placing ``````` on the line above and below your code.
- - This is best described as: three backticks, shift-enter, type stuff, shift-enter, three backticks, enter
- - Or by key code structures: 3x<`>, <SHIFT>+<ENTER>, **TYPE_OR_PASTE_CODE_AND_STUFF**, <SHIFT>+<ENTER>, 3x<`>, <ENTER>
+Creating a fixed width code block is recommended for pasting multi-line blocks of code or other text output that is easier to read with fixed width font alignment.
+
+.. code-block:: none
+
+  this is my code
+  123 alignment
+  alignment 456
+  fixed width!
+
+This can be accomplished in one of two ways:
+ 1. Indenting each line by four spaces
+
+Example:
+
+.. code-block:: none
+
+    this is my
+    code block
+
+
+or,
+
+ 2. Placing 3x backtics (```) on the line directly above and directly below your code.
+
 
 Example:
 
@@ -135,15 +156,12 @@ Example:
 
 
   ```
+  this is my
   code block
   ```
 
-Renders as:
 
-.. code-block:: none
-
-
-  code block
+ * **TIP**! - If you're having trouble as a first-timer, assuming default keyboard shortcuts for most clients, this can be accomplished by entering: 3x backticks \<\`\`\`\>, \<SHIFT\>+\<ENTER\>, \<type_your_code\>, \<SHIFT\>+\<ENTER\>, and finally 3x backtacs \<\`\`\`\>
 
 **Syntax Highlighting**
 


### PR DESCRIPTION
increase verbosity and explanation for how to create a fixed width code block
numerous users were getting it wrong, and I want to provide clarity upstream into the documentation

this is a reboot from https://github.com/mattermost/docs/pull/1317, after feedback there, significantly changed delivery with improvements to address concerns and make the section even better!