### PR TITLE
Documentation for customizing Mattermost

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -2317,6 +2317,7 @@ Restrict Custom Emoji Creation
 
 ________
 
+.. _legal-support-links:
 Legal and Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Legal and Support links will be hidden in the user interface if these fields are left blank.

--- a/source/deployment/customize-mattermost.rst
+++ b/source/deployment/customize-mattermost.rst
@@ -15,11 +15,11 @@ The Mattermost webapp is licensed under the Apache 2.0 license. To modify and us
 1. Install the Mattermost server by following one of our installation guides
 2. Fork the `mattermost-webapp <https://github.com/mattermost/mattermost-webapp>`_ repository
 3. Make your changes 
-4. Run ``make package``. This will create ``mattermost-webapp.tar.gz``. 
-5. Copy ``mattermost-webapp-tar.gz`` to the location Mattermost was installed in Step 1. 
-6. Remove the existing ``client`` folder. 
+4. Run ``make package`` to create ``mattermost-webapp.tar.gz``
+5. Copy ``mattermost-webapp-tar.gz`` to the location Mattermost was installed in Step 1
+6. Remove the existing ``client`` folder
 7. Run ``tar -xvf mattermost-webapp.tar.gz`` to extract your new customized ``client`` folder
-8. Restart your Mattermost server 
+8. Restart your Mattermost server
 
 In Mattermost Enterprise Edition, it is possible to customize certain parts of the webapp without forking using our :doc:`Custom Branding <../administration/branding>` settings. 
 

--- a/source/deployment/customize-mattermost.rst
+++ b/source/deployment/customize-mattermost.rst
@@ -55,5 +55,5 @@ To brand the desktop apps:
 
 1. Fork the `mattermost/desktop <https://github.com/mattermost/desktop>`_ repository
 2. Replace the name, images, and any key text strings
-3. Compile the apps
+3. Refer to `this documentation <https://github.com/mattermost/desktop/blob/master/docs/development.md>`_ for help with compiling the apps
 4. Share the desktop application with your users 

--- a/source/deployment/customize-mattermost.rst
+++ b/source/deployment/customize-mattermost.rst
@@ -23,14 +23,15 @@ The Mattermost webapp is licensed under the Apache 2.0 license. To modify and us
 
 In Mattermost Enterprise Edition, it is possible to customize certain parts of the webapp without forking using our :doc:`Custom Branding <../administration/branding>` settings. 
 
+To replace the logo in email notifications, change the file located in the ``/images`` directory. 
+
 Mattermost Server
 -----------------
 
 There are a few things that can be customized in the Mattermost server without forking. 
 
 1. Modify text in the Mattermost interface by modifying the ``en.json`` file 
-2. Replace the logo in email notifications by changing the file located in the ``/images`` directory 
-3. Customize or hide help and support links by modifying your :ref:`configuration settings <legal-support-links>`
+2. Customize or hide help and support links by modifying your :ref:`configuration settings <legal-support-links>`
 
 Mattermost Mobile Applications
 ------------------------------

--- a/source/deployment/customize-mattermost.rst
+++ b/source/deployment/customize-mattermost.rst
@@ -1,0 +1,59 @@
+Customizing Mattermost
+======================
+
+There are several ways to customize your Mattermost server. 
+
+If customizing Mattermost, please avoid branding that could be confused with the Mattermost brand. For example, it's okay to brand as "Healthcare Central" because it's a completely different brand. "Mattermost Healthcare Central" is not okay, because it can potentially be confused with the Mattermost brand. Please see the `Mattermost trademark guidelines <https://www.mattermost.org/trademark-standards-of-use/>`_ for details.
+
+While you're welcome to add your own copyright notice in the user interface if you feel it is warranted by your changes, we ask that you do not remove the Mattermost, Inc. copyright notice from the login footer or from the About dialog.
+
+Mattermost Webapp
+-----------------
+
+The Mattermost webapp is licensed under the Apache 2.0 license. To modify and use with the Mattermost server, you can:
+
+1. Install the Mattermost server by following one of our installation guides
+2. Fork the `mattermost-webapp <https://github.com/mattermost/mattermost-webapp>`_ repository
+3. Make your changes 
+4. Run ``make package``. This will create ``mattermost-webapp.tar.gz``. 
+5. Copy ``mattermost-webapp-tar.gz`` to the location Mattermost was installed in Step 1. 
+6. Remove the existing ``client`` folder. 
+7. Run ``tar -xvf mattermost-webapp.tar.gz`` to extract your new customized ``client`` folder
+8. Restart your Mattermost server 
+
+In Mattermost Enterprise Edition, it is possible to customize certain parts of the webapp without forking using our :doc:`Custom Branding <../administration/branding>` settings. 
+
+Mattermost Server
+-----------------
+
+There are a few things that can be customized in the Mattermost server without forking. 
+
+1. Modify text in the Mattermost interface by modifying the ``en.json`` file 
+2. Replace the logo in email notifications by changing the file located in the ``/images`` directory 
+3. Customize or hide help and support links by modifying your :ref:`configuration settings <legal-support-links>`
+
+Mattermost Mobile Applications
+------------------------------
+
+The Mattermost mobile applications can be customized if you choose to build the apps yourself. 
+
+To brand the mobile apps: 
+
+1. Fork the `mattermost-mobile <https://github.com/mattermost/mattermost-mobile>`_ repository
+2. Replace the name, images, and any key text strings
+3. Compile the apps
+4. Deploy the apps to an app store
+
+While most organizations deploy to internal enterprise app stores, you are welcome to deploy to iTunes and Google Play as long as the branding is not confusable with official Mattermost products.
+
+Mattermost Desktop Applications
+-------------------------------
+
+The Mattermost desktop applications can be customized if you choose to build the apps yourself. 
+
+To brand the desktop apps: 
+
+1. Fork the `mattermost/desktop <https://github.com/mattermost/desktop>`_ repository
+2. Replace the name, images, and any key text strings
+3. Compile the apps
+4. Share the desktop application with your users 

--- a/source/deployment/customize-mattermost.rst
+++ b/source/deployment/customize-mattermost.rst
@@ -42,7 +42,7 @@ To brand the mobile apps:
 
 1. Fork the `mattermost-mobile <https://github.com/mattermost/mattermost-mobile>`_ repository
 2. Replace the name, images, and any key text strings
-3. Compile the apps
+3. :doc:`Compile the apps <../mobile/mobile-compile-yourself>`
 4. Deploy the apps to an app store
 
 While most organizations deploy to internal enterprise app stores, you are welcome to deploy to iTunes and Google Play as long as the branding is not confusable with official Mattermost products.

--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -48,6 +48,7 @@ Deployment
    /deployment/sso-google*
    /deployment/sso-office*
    /deployment/metrics*
+   /deployment/customize-mattermost.rst
    /deployment/client-side-data.rst
 
 Administration


### PR DESCRIPTION
Can probably close https://github.com/mattermost/docs/issues/1006 after merging. 

If so, we may want to update the link under re-branding here to point to this page https://docs.mattermost.com/overview/faq.html#how-can-i-create-an-open-source-derivative-work-of-mattermost

@jasonblais - we may also want to mention plugins as a way to customize without forking if there's documentation to link to 