### PR TITLE
Mention Docker as a supported server platform

### DIFF
--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -58,7 +58,7 @@ Mattermost Server Operating System
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  Ubuntu 14.04, Ubuntu 16.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux 6.6+, Oracle Linux 7.1+
-- Using an Alpine-based `Docker image <https://docs.mattermost.com/install/prod-docker.html>`_ on a Docker compatible Operatin System (Linux-based OS is still recommended)
+- Using Mattermost `Docker image <https://docs.mattermost.com/install/prod-docker.html>`_ on a Docker-compatible operating system (Linux-based OS is still recommended)
 
 While community support exists for Fedora, FreeBSD and Arch Linux, Mattermost does not currently include production support for these platforms.
 

--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -58,6 +58,7 @@ Mattermost Server Operating System
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  Ubuntu 14.04, Ubuntu 16.04, Debian Jessie, CentOS 6.6+, CentOS 7.1+, RedHat Enterprise Linux 6.6+, RedHat Enterprise Linux 7.1+, Oracle Linux 6.6+, Oracle Linux 7.1+
+- Using an Alpine-based `Docker image <https://docs.mattermost.com/install/prod-docker.html>`_ on a Docker compatible Operatin System (Linux-based OS is still recommended)
 
 While community support exists for Fedora, FreeBSD and Arch Linux, Mattermost does not currently include production support for these platforms.
 


### PR DESCRIPTION
As we are moving to [Alpine-based Docker image for Mattermost server](https://github.com/mattermost/mattermost-docker/pull/208) I noticed that the documentation didn't mentioned that Docker is a supported server platform to deploy Mattermost.