### PR TITLE
Simplify CLI command on Docker install

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -64,15 +64,13 @@ On GitLab Omnibus, you must be in the following directory when you run CLI comma
 Using the CLI on Docker Install
 -------------------------------
 
-On Docker install, you must be in the ``/mattermost`` directory within your Docker container when you run CLI commands.  Note that the container name may be ``mattermostdocker_app_1`` if you installed Mattermost with ``docker-compose.yml``.
+On Docker install, the default working directory is ``/mattermost/bin``, so you can use the CLI directly through ``docker exec`` command. Note that the container name may be ``mattermostdocker_app_1`` if you installed Mattermost with ``docker-compose.yml``.
 
 **For example, to get the Mattermost version on a Docker install:**
 
   .. code-block:: bash
 
-    docker exec -it <your-mattermost-container-name> /bin/bash
-    cd /mattermost
-    bin/platform version
+    docker exec -it <your-mattermost-container-name> platform version
 
 Mattermost 3.6 and later
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -64,7 +64,7 @@ On GitLab Omnibus, you must be in the following directory when you run CLI comma
 Using the CLI on Docker Install
 -------------------------------
 
-On Docker install, the default working directory is ``/mattermost/bin``, so you can use the CLI directly through ``docker exec`` command. Note that the container name may be ``mattermostdocker_app_1`` if you installed Mattermost with ``docker-compose.yml``.
+On Docker install, the default working directory is ``/mattermost/bin``, so you can use the CLI directly with the ``docker exec`` command. Note that the container name may be ``mattermostdocker_app_1`` if you installed Mattermost with ``docker-compose.yml``.
 
 **For example, to get the Mattermost version on a Docker install:**
 


### PR DESCRIPTION
The working directory of Mattermost docker image is ``/mattermost/bin``, so you can run directly ``platform`` commands.