### PR TITLE
[BUGFIX] Restore link to API Docs

### DIFF
--- a/source/developer/api-development-version4.rst
+++ b/source/developer/api-development-version4.rst
@@ -7,7 +7,6 @@ channel <https://pre-release.mattermost.com/core/channels/apiv4>`__. The
 project leads are Joram Wilander (@joram) on development and Jason Blais
 (@jason) on product management.
 
-
 Looking for the API reference? That can be found here: https://api.mattermost.com/v4.
 
 Adding an Endpoint

--- a/source/developer/api.md
+++ b/source/developer/api.md
@@ -1,1 +1,0 @@
-Please see [updated API documentation](https://api.mattermost.com).

--- a/source/developer/api.rst
+++ b/source/developer/api.rst
@@ -1,0 +1,4 @@
+API
+===
+
+The API has a separate `Documentation <https://api.mattermost.com>`__.

--- a/source/developer/api.rst
+++ b/source/developer/api.rst
@@ -1,4 +1,4 @@
 API
 ===
 
-The API has a separate `Documentation <https://api.mattermost.com>`__.
+The API has separate `documentation <https://api.mattermost.com>`__.

--- a/source/developer/api4.rst
+++ b/source/developer/api4.rst
@@ -1,0 +1,1 @@
+Please see :doc:`updated APIv4 developer documentation <api-development-version4>`.

--- a/source/guides/developer.rst
+++ b/source/guides/developer.rst
@@ -13,7 +13,7 @@ Development Process
    /developer/contribution*
    /developer/dev-setup.rst
    /developer/mobile-developer-setup.rst
-   /developer/api*
+   /developer/api-development*
    /developer/developer-flow*
    /developer/webapp-to-redux.rst
    /developer/webapp-component.rst

--- a/source/guides/integration.rst
+++ b/source/guides/integration.rst
@@ -1,20 +1,20 @@
 Mattermost Integration Guide
 ----------------------------
 
-Detailed documentation on extending and integrating with the Mattermost server. 
+Detailed documentation on extending and integrating with the Mattermost server.
 
 .. toctree::
    :maxdepth: 2
    :glob:
 
-   /developer/api*
+   /developer/api.rst
    /developer/webhooks*
    /developer/slash*
    /developer/message-attachments*
    /developer/interactive-message-buttons*
    /developer/personal-access-tokens*
    /developer/oauth*
-   /integrations/jira*   
+   /integrations/jira*
    /integrations/zapier*
    /developer/integration*
    /integrations/embedding*


### PR DESCRIPTION
Convert API integration page from Markdown to ReST,
rename the API development page and change includes to both,
in order to restore the correct link to API docs.

Refs #1663