### PR TITLE
Update instructions in step 8 on testing

### DIFF
--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -53,9 +53,9 @@ Assume that the IP address of this server is 10.10.10.2.
 8. Test the Mattermost server to make sure everything works.
 
     a. Change to the ``bin`` directory:
-      ``cd /opt/mattermost/bin``
+      ``cd /opt/mattermost``
     b. Start the Mattermost server as the user mattermost:
-      ``sudo -u mattermost ./platform``
+      ``sudo -u mattermost ./bin/platform``
 
   When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 


### PR DESCRIPTION
Revise the path to test from (/opt/mattermost) and the command to test with (sudo -u mattermost ./bin/platform) based on change in 4.4.5 related to creating the client/plugin folder