### PR TITLE
Changed bash config name for Mac OSX

### DIFF
--- a/source/developer/dev-setup-osx.rst
+++ b/source/developer/dev-setup-osx.rst
@@ -23,7 +23,7 @@ Set up your development environment for building, running, and testing Mattermos
 
   a. ``mkdir ~/go``
 
-  b. Add the following lines to your ``~/.bashprofile`` file:
+  b. Add the following lines to your ``~/.bash_profile`` file:
 
     .. code-block:: bash
 
@@ -34,7 +34,7 @@ Set up your development environment for building, running, and testing Mattermos
 
   c. Reload your bash configuration.
 
-    ``source ~/.bashprofile``
+    ``source ~/.bash_profile``
 
 5. Fork Mattermost server on GitHub from https://github.com/mattermost/mattermost-server.
 


### PR DESCRIPTION
In Mac OSX, bash looks for the file .bash_profile not .bashprofile