### PR TITLE
Fix old version description

### DIFF
--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -37,12 +37,12 @@ Owner and group of the install directory - *{owner}* and *{group}*
 
   ``cd ~``
 
-3. Download the latest version of Mattermost Server.
+3. Download `the latest version of Mattermost Server <https://about.mattermost.com/download/>`_. In the following command, replace ``X.X.X`` with the version that you want to download:
 
   Enterprise Edition
-    ``wget https://releases.mattermost.com/4.2.0/mattermost-4.2.0-linux-amd64.tar.gz``
+    ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
   Team Edition
-    ``wget https://releases.mattermost.com/4.2.0/mattermost-team-4.2.0-linux-amd64.tar.gz``
+    ``wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz``
 
 4. Extract the Mattermost Server files.
 


### PR DESCRIPTION
The description of old version remains in [Upgrade Instruction](https://docs.mattermost.com/administration/upgrade.html).

```
3. Download the latest version of Mattermost Server.

  Enterprise Edition
    `wget https://releases.mattermost.com/4.2.0/mattermost-4.2.0-linux-amd64.tar.gz`

  Team Edition
    `wget https://releases.mattermost.com/4.2.0/mattermost-team-4.2.0-linux-amd64.tar.gz`
```


As with [other page descriptions](https://docs.mattermost.com/install/install-ubuntu-1604.html#installing-mattermost-server), fixing the description not to be dependent on version change.