### PR TITLE
Minor change about docker image CLI

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -64,7 +64,7 @@ On GitLab Omnibus, you must be in the following directory when you run CLI comma
 Using the CLI on Docker Install
 -------------------------------
 
-On Docker install, the default working directory is ``/mattermost/bin``, so you can use the CLI directly with the ``docker exec`` command. Note that the container name may be ``mattermostdocker_app_1`` if you installed Mattermost with ``docker-compose.yml``.
+On Docker install, the ``/mattermost/bin`` directory was added to ``PATH``, so you can use the CLI directly with the ``docker exec`` command. Note that the container name may be ``mattermostdocker_app_1`` if you installed Mattermost with ``docker-compose.yml``.
 
 **For example, to get the Mattermost version on a Docker install:**
 


### PR DESCRIPTION
Minor change introduced by  [`mattermost-docker` PR#218](https://github.com/mattermost/mattermost-docker/pull/218). It didn't change anything for users, the explanation is just different.