### PR TITLE
Updating Example Service file to move working directory up one level

### DIFF
--- a/source/install/install-rhel-71-mattermost.rst
+++ b/source/install/install-rhel-71-mattermost.rst
@@ -73,7 +73,7 @@ Assume that the IP address of this server is 10.10.10.2
 
       [Service]
       Type=simple
-      WorkingDirectory=/opt/mattermost/bin
+      WorkingDirectory=/opt/mattermost
       User=mattermost
       ExecStart=/opt/mattermost/bin/platform
       PIDFile=/var/spool/mattermost/pid/master.pid


### PR DESCRIPTION
In order to prevent an issue where the working directory is too low, preventing the installation of plugins, changing the example service to be in the base mattermost directory. This also brings it inline with the enterprise installation docs.

issue here: https://forum.mattermost.org/t/jira-beta-plugin-not-available-on-4-5-0/4312