### PR TITLE
[XYZ-6] Add sampledata platform command documentation

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -29,6 +29,7 @@ From the directory where the Mattermost server is installed, a
 -  Modifying a channel's public/private type
 -  Migrating sign-in options
 -  Resetting multi-factor authentication for a user
+-  Creating sample data
 
 .. contents::
     :backlinks: top
@@ -112,6 +113,7 @@ platform
     -  `platform user`_ - Management of users
     -  `platform version`_ - Display version information
     -  `platform config`_ - Work with the configuration file
+    -  `platform sampledata`_ - Sample data generation
 
 platform channel
 -----------------
@@ -879,6 +881,43 @@ platform config validate
       .. code-block:: none
 
         sudo ./platform config validate
+
+platform sampledata
+-------------------
+
+  Description
+    .. versionadded:: 4.7
+      Generate sample data and populate the mattermost database.
+
+  Format
+    .. code-block:: none
+
+      platform sampledata
+
+  Example
+    .. code-block:: none
+
+      sudo ./platform sampledata --seed 10 --teams 4 --users 30
+
+  Options
+    .. code-block:: none
+
+          -u, --users int                      The number of sample users. (default 15)
+              --profile-images string          Optional. Path to folder with images to randomly pick as user profile image.
+          -t, --teams int                      The number of sample teams. (default 2)
+              --team-memberships int           The number of sample team memberships per user. (default 2)
+              --channels-per-team int          The number of sample channels per team. (default 10)
+              --channel-memberships int        The number of sample channel memberships per user in a team. (default 5)
+              --posts-per-channel int          The number of sample post per channel. (default 100)
+              --direct-channels int            The number of sample direct channels. (default 30)
+              --group-channels int             The number of sample group channels. (default 15)
+              --posts-per-direct-channel int   The number of sample post per direct channel. (default 15)
+              --posts-per-group-channel int    The number of sample post per group channel. (default 30)
+          -s, --seed int                       Seed used for generate the random data. (default 1)
+          -b, --bulk string                    Optional. Path to write a JSONL bulk file instead of loading into the database.
+          -w, --workers int                    How many workers to run whilst doing the import. (default 2)
+
+
 
 Mattermost 3.5 and earlier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -887,7 +887,7 @@ platform sampledata
 
   Description
     .. versionadded:: 4.7
-      Generate sample data and populate the mattermost database.
+      Generate sample data and populate the Mattermost database.
 
   Format
     .. code-block:: none

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -909,11 +909,11 @@ platform sampledata
               --channels-per-team int          The number of sample channels per team. (default 10)
               --channel-memberships int        The number of sample channel memberships per user in a team. (default 5)
               --posts-per-channel int          The number of sample post per channel. (default 100)
-              --direct-channels int            The number of sample direct message channels per user. (default 30)
-              --group-channels int             The number of sample group message channels per user. (default 15)
+              --direct-channels int            The number of sample direct message channels. (default 30)
+              --group-channels int             The number of sample group message channels. (default 15)
               --posts-per-direct-channel int   The number of sample posts per direct message channel. (default 15)
               --posts-per-group-channel int    The number of sample post per group message channel. (default 30)
-          -s, --seed int                       Seed used for generating the random data. (default 1)
+          -s, --seed int                       Seed used for generating the random data (Different seeds generate different data). (default 1)
           -b, --bulk string                    Optional. Path to write a JSONL bulk file instead of loading into the database.
           -w, --workers int                    How many workers to run during the import. (default 2)
 

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -909,13 +909,13 @@ platform sampledata
               --channels-per-team int          The number of sample channels per team. (default 10)
               --channel-memberships int        The number of sample channel memberships per user in a team. (default 5)
               --posts-per-channel int          The number of sample post per channel. (default 100)
-              --direct-channels int            The number of sample direct channels. (default 30)
-              --group-channels int             The number of sample group channels. (default 15)
-              --posts-per-direct-channel int   The number of sample post per direct channel. (default 15)
-              --posts-per-group-channel int    The number of sample post per group channel. (default 30)
-          -s, --seed int                       Seed used for generate the random data. (default 1)
+              --direct-channels int            The number of sample direct message channels per user. (default 30)
+              --group-channels int             The number of sample group message channels per user. (default 15)
+              --posts-per-direct-channel int   The number of sample posts per direct message channel. (default 15)
+              --posts-per-group-channel int    The number of sample post per group message channel. (default 30)
+          -s, --seed int                       Seed used for generating the random data. (default 1)
           -b, --bulk string                    Optional. Path to write a JSONL bulk file instead of loading into the database.
-          -w, --workers int                    How many workers to run whilst doing the import. (default 2)
+          -w, --workers int                    How many workers to run during the import. (default 2)
 
 
 

--- a/source/deployment/bulk-loading-data-format.rst
+++ b/source/deployment/bulk-loading-data-format.rst
@@ -35,6 +35,8 @@ The identifiers for each object are listed in the following table:
   UserTeamMembership, "*team*, *username*"
   UserChannelMembership, "*team*, *channel*, *username*"
   Post, "*channel*, *message*, *create_at*"
+  Reply, "*post*, *message*, *create_at*"
+  Reaction, "*post*, *emoji_name*, *create_at*"
   DirectChannel, *members*
   DirectPost,  "*channel_members*, *user*, *message*, *create_at* "
 
@@ -289,6 +291,7 @@ For clarity, the object is shown using regular JSON formatting, but in the data 
   {
     "type": "user",
     "user": {
+      "profile_image": "avatar.png",
       "username": "username",
       "email": "email@example.com",
       "auth_service": "",
@@ -331,6 +334,13 @@ Fields of the User object
       <th class="head">Description</th>
       <th class="head">Validated</th>
       <th class="head">Mandatory</th>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">profile_image</td>
+      <td valign="middle">string</td>
+      <td>The user’s profile image. This must be an existing file path.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">No</td>
     </tr>
     <tr class="row-odd">
       <td valign="middle">username</td>
@@ -723,7 +733,7 @@ This object is a member of the ChannelMembership object.
 Post object
 -----------
 
- If present, Post objects must occur after the last User object in the file, but before any DirectChannel objects.
+If present, Post objects must occur after the last User object in the file, but before any DirectChannel objects.
 
 Example Post object
 ~~~~~~~~~~~~~~~~~~~
@@ -744,7 +754,25 @@ For clarity, the object is shown using regular JSON formatting, but in the data 
         "username1",
         "username2",
         "username3"
-      ]
+      ],
+      "replies": [{
+        "user": "username4",
+        "message": "The reply message",
+        "create_at": 140012352049,
+      }, {
+        "user": "username5",
+        "message": "Other reply message",
+        "create_at": 140012353057,
+      }],
+      "reactions": [{
+        "user": "username6",
+        "emoji_name": "+1",
+        "create_at": 140012356032,
+      }, {
+        "user": "username7",
+        "emoji_name": "heart",
+        "create_at": 140012359034,
+      }]
     }
   }
 
@@ -811,6 +839,96 @@ Fields of the Post object
       <td>Must contain a list of members who have flagged the post.</td>
       <td align="center" valign="middle">No</td>
       <td align="center" valign="middle">No</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">replies</td>
+      <td valign="middle">array</td>
+      <td>The posts in reply to this post. Must be an array of <a href="#fields-of-the-reply-object">Reply</a> objects.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">No</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">reactions</td>
+      <td valign="middle">array</td>
+      <td>The emoji reactions to this post. Must be an array of <a href="#fields-of-the-reaction-object">Reaction</a> objects.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">No</td>
+    </tr>
+  </table>
+
+Fields of the Reply object
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This object is a member of the Post/DirectPost object.
+
+.. raw:: html
+
+  <table width="100%" border="1" cellpadding="5px" style="margin-bottom:20px;">
+    <tr class="row-odd">
+      <th class="head">Field name</th>
+      <th class="head">Type</th>
+      <th class="head">Description</th>
+      <th class="head">Validated</th>
+      <th class="head">Mandatory</th>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">user</td>
+      <td valign="middle">string</td>
+      <td>The username of the user for this reply.</td>
+      <td align="center" valign="middle">No [3]</td>
+      <td align="center" valign="middle">Yes</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">message</td>
+      <td valign="middle">string</td>
+      <td>The message that the reply contains.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">Yes</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">create_at</td>
+      <td valign="middle">int</td>
+      <td>The timestamp for the reply, in milliseconds since the Unix epoch.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">Yes</td>
+    </tr>
+  </table>
+
+Fields of the Reaction object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This object is a member of the Post/DirectPost object.
+
+.. raw:: html
+
+  <table width="100%" border="1" cellpadding="5px" style="margin-bottom:20px;">
+    <tr class="row-odd">
+      <th class="head">Field name</th>
+      <th class="head">Type</th>
+      <th class="head">Description</th>
+      <th class="head">Validated</th>
+      <th class="head">Mandatory</th>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">user</td>
+      <td valign="middle">string</td>
+      <td>The username of the user for this reply.</td>
+      <td align="center" valign="middle">No [3]</td>
+      <td align="center" valign="middle">Yes</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">emoji_name</td>
+      <td valign="middle">string</td>
+      <td>The emoji of the reaction.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">Yes</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">create_at</td>
+      <td valign="middle">int</td>
+      <td>The timestamp for the reply, in milliseconds since the Unix epoch.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">Yes</td>
     </tr>
   </table>
 
@@ -912,7 +1030,25 @@ For clarity, the object is shown using regular JSON formatting, but in the data 
         "username1",
         "username2",
         "username3"
-      ]
+      ],
+      "replies": [{
+        "user": "username4",
+        "message": "The reply message",
+        "create_at": 140012352049,
+      }, {
+        "user": "username5",
+        "message": "Other reply message",
+        "create_at": 140012353057,
+      }],
+      "reactions": [{
+        "user": "username6",
+        "emoji_name": "+1",
+        "create_at": 140012356032,
+      }, {
+        "user": "username7",
+        "emoji_name": "heart",
+        "create_at": 140012359034,
+      }]
     }
   }
 
@@ -968,6 +1104,20 @@ Fields of the DirectPost object
       <td valign="middle">array</td>
       <td>Must contain a list of members who have flagged the post.</td>
       <td align="center" valign="middle">No</td>
+      <td align="center" valign="middle">No</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">replies</td>
+      <td valign="middle">array</td>
+      <td>The posts in reply to this direct post. Must be an array of <a href="#fields-of-the-reply-object">Reply</a> objects.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">No</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">reactions</td>
+      <td valign="middle">array</td>
+      <td>The emoji reactions to this direct post. Must be an array of <a href="#fields-of-the-reaction-object">Reaction</a> objects.</td>
+      <td align="center" valign="middle">Yes</td>
       <td align="center" valign="middle">No</td>
     </tr>
   </table>

--- a/source/deployment/bulk-loading.rst
+++ b/source/deployment/bulk-loading.rst
@@ -15,6 +15,8 @@ You can import the following data types:
 - Users' Channel memberships
 - Users' notification preferences
 - Posts (regular, non-reply posts)
+- Posts' Replies
+- Posts' Reactions
 - Direct Message and Group Message channels
 - Direct Messages and Group Messages
 

--- a/source/developer/developer-flow.md
+++ b/source/developer/developer-flow.md
@@ -39,16 +39,14 @@ go test -v -run='TestPostUpdate' ./api
 
 ### Useful platform commands ###
 
-During the development sometimes you'll want to clean up your data o generate
-random data for manually testing your changes, for this porpose Mattermost
-comes with the following commands in the platform CLI.
+During development, you'll want to clean up your data to generate random data for manually testing your changes. For this purpose, Mattermost has the following commands in the platform CLI:
 
 You can reset your database to the initial state using:
 ```
 platform reset
 ```
 
-After that, you can generate random data to prepopulate the mattermost database using:
+After that, you can generate random data to prepopulate the Mattermost database using:
 ```
 platform sampledata
 ```

--- a/source/developer/developer-flow.md
+++ b/source/developer/developer-flow.md
@@ -37,6 +37,22 @@ For example, if you wanted to run `TestPostUpdate` in `api/post_test.go`, you wo
 go test -v -run='TestPostUpdate' ./api
 ```
 
+### Useful platform commands ###
+
+During the development sometimes you'll want to clean up your data o generate
+random data for manually testing your changes, for this porpose Mattermost
+comes with the following commands in the platform CLI.
+
+You can reset your database to the initial state using:
+```
+platform reset
+```
+
+After that, you can generate random data to prepopulate the mattermost database using:
+```
+platform sampledata
+```
+
 ### Repository structure ###
 
 For server work, you'll be working in the [server repository](https://github.com/mattermost/mattermost-server).

--- a/source/developer/developer-flow.md
+++ b/source/developer/developer-flow.md
@@ -39,14 +39,14 @@ go test -v -run='TestPostUpdate' ./api
 
 ### Useful platform commands ###
 
-During development, you'll want to clean up your data to generate random data for manually testing your changes. For this purpose, Mattermost has the following commands in the platform CLI:
+During development you may want to reset the database and generate random data for testing your changes. For this purpose, Mattermost has the following commands in the platform CLI:
 
 You can reset your database to the initial state using:
 ```
 platform reset
 ```
 
-After that, you can generate random data to prepopulate the Mattermost database using:
+After that, you can generate random data to populate the Mattermost database using:
 ```
 platform sampledata
 ```


### PR DESCRIPTION
This PR contains the documentation related to the new `platform sampledata` command.

It must be merged after the mattermost/mattermost-server#8027.