### PR TITLE
v4.7 changelog

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -6,11 +6,11 @@ Also see [changelog in progress](http://bit.ly/2nK3cVf) for the next release.
 
 ## Release v4.7
 
-Release date: 2017-02-16
+Release date: 2018-02-16
 
 ## Release v4.6
 
-Release date: 2017-01-16
+Release date: 2018-01-16
 
 ### Highlights
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -35,9 +35,8 @@ Release date: 2018-02-16
 #### Web User Interface
  - Implemented a descriptive error page for browser compatibility.
  - Added a status icon in the channel member list and sorted it by user's status.
- - Disabled pull-to-refresh on Android (Chrome). //XXX Amy Why? What's the user benefit?
- - Added support for image links to be previewed. //XXX Not sure what this means
- - Use transparent pixel while the user profile isn't loaded. //XXX Amy Why? What's the user benefit?
+ - Disabled pull-to-refresh feature on Android (Chrome) to prevent unwanted page refresh.
+ - Added ability to preview image links in a similar way that image links uploaded from Mattermost can be previewed.
  - Added a `Copy Link` option for sidebar channels in the Desktop App.
  - Added focus on the input box after hitting "Edit" for one of the Account Settings options.
  - Custom emojis are now loaded asynchronously in posts for the webapp, for increased performance.
@@ -45,7 +44,7 @@ Release date: 2018-02-16
  - Added a date separator for search results.
 
 #### Notifications
- - Added a post change channel privacy system message. //XXX Amy Why? What's the user benefit?
+ - Added a post change channel privacy system message when a team is changed from public to private.
  - Made system messages always use "User did something" instead of "User has done something" for consistency.
 
 #### Integrations
@@ -57,13 +56,8 @@ Release date: 2018-02-16
  - Added paging and search of custom emojis to webapp emoji picker.
 
 #### Channels
- - Added auto lowercase team and channel names in API requests. //XXX To API changes section
- - Use last channel name for routing on team switch. //XXX Amy Why? What's the user benefit?
- - Updated initial scrolling on post list. //XXX Bug fix
- - Changed URLs of Direct Messages to usernames. //XXX Amy Why? What's the user benefit?
-
-#### Administration
- - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission. //XXX To API changes section
+ - Added a feature where the user will be dericted to the last channel they viewed in another team when switching to the other team.
+ - Changed URLs of Direct Messages to use the form of `https://servername.com/messages/@username`, letting users open a direct message with another user using the URL format.
 
 #### Enterprise Edition
 - Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
@@ -93,17 +87,17 @@ Release date: 2018-02-16
  - Fixed login screen sometimes flashing before Mattermost server loads.
  - Fixed an issue where the current channel wasn't marked as read when the window was on focus.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
- - Fixed redirects with `4XX` status codes.
  - Fixed error code/message and panic when creating post with bad props.
  - Fixed an issue where bot messages from the Zoom plugin ignored the Zoom API URL field for on-prem Zoom servers.
  - Fixed an issue where clicking a direct message channel in left-hand sidebar that displays something other than username redirects to Town Square.
+ - Updated initial scrolling on post list.
  
 ### Compatibility
 
 #### Removed and Deprecated Features
 
 - All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
-- The permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint for permanently deleting a team is scheduled for removal in Mattermost v4.7. // XXX Jason needs update
+- The permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint for permanently deleting a team is scheduled for removal in Mattermost v4.7. // XXX Jason needs to update
 
 #### config.json
 
@@ -119,8 +113,11 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 ### API Changes
 
-- It is required that any new integrations use API v4 endpoints. For more details, and for a complete list of available endpoints, see [https://api.mattermost.com/](https://api.mattermost.com/).
-- All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
+ - It is required that any new integrations use API v4 endpoints. For more details, and for a complete list of available endpoints, see [https://api.mattermost.com/](https://api.mattermost.com/).
+ - All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
+ - Added auto lowercase team and channel names in API requests.
+ - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` API endpoints.
+ - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission.
 
 #### RESTful API v4 Changes
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -4,6 +4,10 @@ This changelog summarizes updates to [Mattermost Team Edition](http://www.matter
 
 Also see [changelog in progress](http://bit.ly/2nK3cVf) for the next release.
 
+## Release v4.7
+
+Release date: 2017-02-16
+
 ## Release v4.6
 
 Release date: 2017-01-16

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -103,12 +103,10 @@ Release date: 2018-02-16
   - RestrictPublicChannelDeletion
   - RestrictPrivateChannelDeletion
   - RestrictPrivateChannelManageMembers
-  - RestrictPostDelete
   - EnableTeamCreation
   - EnableOnlyAdminIntegrations
   - RestrictPostDelete
   - AllowEditPost
-  - EnableOnlyAdminIntegrations
   - RestrictTeamInvite
   - RestrictCustomEmojiCreation
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -53,12 +53,16 @@ Release date: 2018-02-16
  - Users are directed to the last channel they viewed in another team when switching to the other team.
  - Changed URLs of Direct Messages to use the form of `https://servername.com/messages/@username`, letting users open a direct message with another user using the URL format.
  
+#### System Console
+ - Added paging to system console log viewer and set the default value of `per_paging` for logs to 1000.
+ 
 #### Notifications
  - Added a post change channel privacy system message when a team is changed from public to private.
  - Made system messages always use "User did something" instead of "User has done something" for consistency.
 
 #### Enterprise Edition
 - Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
+- Increased OAuth state parameter limit some systems may send a state longer than 128 characters.
 
 ### Bug Fixes
  - Fixed an issue where OAuth account creation error page was unformatted.

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -12,9 +12,10 @@ Release date: 2018-02-16
 
 #### Client-Side Performance
 
- - Added user based rate limiting.
- - Optimized channel autocomplete query.
- - Added paging and server-side search to custom emoji management.
+ - Added user based rate limiting, in addition to rate limiting API access by IP address. // XXX not sure how to quantify perf increase
+ - Decreased page load time by loading custom emojis asynchronously rather than all on first page load.
+ - Optimized channel autocomplete (~) query by returning client-side results immediately.
+ - Decreased the size of most image assets by more than 25% by running `pngquant` to remove unnecessary metadata from PNGs.
 
 #### Image Proxy Support
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -8,6 +8,27 @@ Also see [changelog in progress](http://bit.ly/2nK3cVf) for the next release.
 
 Release date: 2018-02-16
 
+### Highlights
+
+#### Client-Side Performance
+
+-
+
+### Improvements
+
+### Bug Fixes
+
+### Compatibility
+
+### API Changes
+
+### Database Changes
+
+### Known Issues
+
+### Contributors
+
+
 ## Release v4.6
 
 Release date: 2018-01-16

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -30,74 +30,90 @@ Release date: 2018-02-16
 
 ### Improvements
 
+#### Web UI
  - Implemented a descriptive error page for browser compatibility.
- - Added a config property `EnableDefaultChannelLeaveJoinMessages` that allows for leave/join messages to be created in the default channel.
- - Added a post change channel privacy system message.
- - Added auto lowercase team and channel names in API requests.
- - Added a `sampledata` platform command to generate realistic sample data.
- - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission.
- - Added support for Slack attachments in outgoing webhook responses.
- - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` API endpoints.
- - Increased size of position to 128 characters.
  - Migrated file upload to be pure and use Redux.
  - Show status icon in the channel member list and sorted it by user's status.
- - Migrated `SettingItemMin` and `SettingItemMax` to pure component, and replaced anonymous function on props.
- - Use last channel name for routing on team switch.
  - Updated help text for debugging webhooks.
- - Fixed active state for dropdown.
+ - Fixed active state for dropdown for channel header options.
  - Disabled pull-to-refresh on Android(Chrome).
  - Added support for image links to be previewed.
- - Added username and profile picture to webhook set up pages.
  - Use transparent pixel while the user profile isn't loaded.
  - Added a copy link option for the buttons in the desktop app for sidebar channels.
  - Fixed tab and alt-tab keyboard navigation for links on login page.
- - Made system messages always use "User did something" instead of "User has done something.
  - Added the ability to navigate emoji picker with keyboard.
- - Added date separator for search results.
  - Set focus on the input box after hitting "Edit" for one of the account setting options.
- - Updated react-router to version 4.
- - Update initial scrolling on post list.
  - Added async loading of emojis in posts for the webapp.
  - Improved formatting for quotes in channel header.
- - Changed URLs of Direct Messages to usernames.
- - Added paging/search of custom emojis to webapp emoji picker.
  - Handled custom emojis in channel header and login page.
+
+#### Notifications
+ - Added a post change channel privacy system message.
+ - Made system messages always use "User did something" instead of "User has done something.
+
+#### Administration
+ - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission.
+
+#### Integrations
+ - Added support for Slack attachments in outgoing webhook responses.
+
+#### Channels
+ - Added a config property `EnableDefaultChannelLeaveJoinMessages` that allows for leave/join messages to be created in the default channel.
+ - Added auto lowercase team and channel names in API requests.
+ - Use last channel name for routing on team switch.
+ - Updated initial scrolling on post list.
+ - Changed URLs of Direct Messages to usernames.
+
+#### System console
+ - Added username and profile picture to webhook set up pages.
+
+#### Performance
+ - Migrated `SettingItemMin` and `SettingItemMax` to pure component, and replaced anonymous function on props.
+
+#### Emoji picker
+ - Added paging/search of custom emojis to webapp emoji picker.
+
+#### Search
+ - Added date separator for search results.
+
+#### Enterprise Edition
+- Increased max length of User.Position field to 128 characters to meet LDAP max length.
 
 ### Bug Fixes
 
- - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left team.
+ - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left a team.
  - Fixed an issue where plugin slash commands didn't override username or icon.
  - Fixed deleting a team via the API breaks the web UI.
  - Fixed an issue where pagination for team members modal showed a next button when there are no more users to show.
- - Fixed an issue where at-channel in /header should not trigger confirmation modal.
+ - Fixed an issue where at-channel in `/header` should not trigger confirmation modal.
  - Fixed an issue where DM didn't open on clicking user in member icon drop-down list.
  - Fixed an issue where auto-generated SAML Service provider login URL had two slashes instead of one.
  - Fixed an issue where `Add a channel description` should open Edit Header, not Edit Purpose.
  - Fixed an issue where no unread mention appeared on non-mobile platform after receiving push notification.
- - Fixed an issue where there was no warning when mentioning (at)all in RHS.
+ - Fixed an issue where there was no warning when mentioning (at)all in the RHS.
  - Fixed an issue where some iOS emoji using alternate skin tones were rendering incorrectly on Chrome.
  - Fixed an issue where reactions added by clicking another user's reaction should appear in recently Used.
  - Fixed an issue where timestamp was not clickable in desktop mobile view.
  - Ensured that emoji picker search should not be case-sensitive.
  - Fixed unable to type Korean quickly in some dialogs.
  - Fixed an issue where notification preference settings didn't respect case sensitivity for mention highlighting.
- - Fixed after an ephemeral message, cannot use +:emoji: to react to the previous message.
+ - Fixed after an ephemeral message, cannot use `+:emoji:` to react to the previous message.
  - Changed version of webrtc-adapter to 6.0.4 to prevent application crashes due to a webrtc-adapter bug in any version
 previous to 6.0.3 and after 6.0.4.
  - Fixed an issue where empty post menu box displayed sometimes.
  - Fixed login screen flashes before Mattermost server loads.
  - Fixed an issue where the current channel wasn't marked as read when the window was on focus.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
- - Fixed redirects with 4XX status codes.
- - Fixed markdown parsing crash (dos) on empty image url.
+ - Fixed redirects with `4XX` status codes.
  - Fixed error code/message and panic when creating post with bad props.
  - Fixed an issue where bot messages from the Zoom plugin ignore the Zoom API URL field for on-prem Zoom servers.
+ - Fixed an issue where clicking a DM in LHS that displays something other than username redirects to Town Square.
  
 ### Compatibility
 
 #### Removed and Deprecated Features
 
-- All API v3 endpoints are now deprecated, and scheduled for removal in Mattermost v5.0.
+- All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
 - The permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint for permanently deleting a team is scheduled for removal in Mattermost v4.7. // XXX Jason needs update
 
 #### config.json

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -38,8 +38,30 @@ Release date: 2018-02-16
  - Added support for Slack attachments in outgoing webhook responses.
  - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` API endpoints.
  - Increased size of position to 128 characters.
+ - Migrated file upload to be pure and use Redux.
+ - Show status icon in the channel member list and sorted it by user's status.
+ - Migrated `SettingItemMin` and `SettingItemMax` to pure component, and replaced anonymous function on props.
+ - Use last channel name for routing on team switch.
+ - Added paging and server-side search to custom emoji management.
+ - Updated help text for debugging webhooks.
 
 ### Bug Fixes
+
+ - OAuth account creation error page is unformatted.
+ - `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posts in town-square when user leaves team
+ - Plugin slash commands don't override username or icon
+ - Deleting a Team via the API Breaks the Web UI.
+ - Switch to the golang autocert library for let's encrypt.
+ - Pagination for team members modal shows a next button when there are no more users to show.
+ - At-channel in /header should not trigger confirmation modal.
+ - DM doesn't open on clicking user in member icon drop-down list.
+ - Fix dispatch prop warning on popover of profile_popover component.
+ - Auto-generated SAML Service provider login URL has two slashes instead of one.
+ - JavaScript error when trying to switch languages. Setting not saved.
+ - Profile picture uploader accepts images with a size less than 128px x 128px.
+ - `Add a channel description` should open Edit Header, not Edit Purpose.
+ - No unread mention appeared on non-mobile platform after receiving push notification.
+ - CTRL/CMD+UP takes no action in RHS.
 
 ### Compatibility
 
@@ -60,11 +82,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 ### Known Issues
 
- - OAuth account creation error page is unformatted.
- - `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posts in town-square when user leaves team
- - Plugin slash commands don't override username or icon
- - Deleting a Team via the API Breaks the Web UI.
- - Switch to the golang autocert library for let's encrypt.
+ - Refactor sidebar to be pure and use redux.
 
 ### Contributors
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -44,6 +44,11 @@ Release date: 2018-02-16
  - Use last channel name for routing on team switch.
  - Added paging and server-side search to custom emoji management.
  - Updated help text for debugging webhooks.
+ - Fixed active state for dropdown.
+ - Disabled pull-to-refresh on Android(Chrome).
+ - Added support for image links to be previewed.
+ - Added username and profile picture to webhook set up pages.
+ - Use transparent pixel while the user profile isn't loaded.
 
 ### Bug Fixes
 
@@ -62,6 +67,8 @@ Release date: 2018-02-16
  - `Add a channel description` should open Edit Header, not Edit Purpose.
  - No unread mention appeared on non-mobile platform after receiving push notification.
  - CTRL/CMD+UP takes no action in RHS.
+ - No warning when mentioning (at)all in RHS.
+ - Some iOS emoji using alternate skin tones are rendering incorrectly on Chrome.
 
 ### Compatibility
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -42,7 +42,7 @@ Release date: 2018-02-16
  - Added a date separator for search results.
  
  #### Integrations
- - Added username and profile picture to webhook set up pages.
+ - Added username and profile picture to incoming webhook set up pages.
  - Added support for Slack attachments in outgoing webhook responses.
 
 #### Emoji Picker
@@ -130,6 +130,8 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 ### Database Changes
 
 ### WebSocket Event Changes
+
+ - Added `delete_team` web socket event to notify client whenever a team is deleted (e.g. via API call).
 
 ### Known Issues
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -113,7 +113,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
  - Under `ServiceSettings` in `config.json`:
     - Added `"ImageProxyType": ""`, `"ImageProxyOptions": ""`, and `"ImageProxyURL": ""` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
-    - Added `"ExperimentalGroupUnreadChannels": false` setting to show an unread channel section in the webapp sidebar.
+    - Added `"ExperimentalGroupUnreadChannels": true` as `default_on` or `"ExperimentalGroupUnreadChannels": false` as `disabled` settings to show an unread channel section in the webapp sidebar.
     - Added `"VaryByUser": false`, a user based rate limiting, to rate limit on token and on userID. // XXXX This is under `RateLimitingSettings`
     - Added `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows disabling of leave/join messages in the default channel, usually Town Square.
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -122,8 +122,9 @@ Multiple setting options were added to `config.json`. Below is a list of the add
  - Under `ServiceSettings` in `config.json`:
     - Added `"ImageProxyType": ""`, `"ImageProxyOptions": ""`, and `"ImageProxyURL": ""` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
     - Added `"ExperimentalGroupUnreadChannels": true` as `default_on` or `"ExperimentalGroupUnreadChannels": false` as `disabled` settings to show an unread channel section in the webapp sidebar.
-    - Added `"VaryByUser": false`, a user-based rate limiting, to rate limit on token and on userID. // XXXX This is under `RateLimitingSettings`
     - Added `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows disabling of leave/join messages in the default channel, usually Town Square.
+ - Under `RateLimitingSettings` in `config.json`:
+    - Added `"VaryByUser": false`, a user-based rate limiting, to rate limit on token and on userID.
 
 ### API Changes
 
@@ -132,9 +133,9 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 #### RESTful API v4 Changes
 
- - Added auto lowercase team and channel names in API requests. This ensures that the channel name is automatically lowercased for endpoints taking team or channel names as URL parameters.
- - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` API endpoints. These ensure that the benefits of `GET` for important performance related actions such as autocompleting are included.
- - Added a new endpoint called `/users/tokens/search`. This endpoint gets all tokens for all users if one has the `manage_system` permission.
+ - Added `GetChannelByName` and `GetTeamByName` to auto lowercase team and channel names in API requests. This ensures that the channel name is automatically lowercased for endpoints taking team or channel names as URL parameters.
+ - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` to add consistency with user search/autocomplete endpoints. These API endpoints ensure that the benefits of `GET` for important performance related actions such as autocompleting are included.
+ - Added `/users/tokens/search` to allow System Admin to be able to find, manage and revoke personal access tokens as needed. This endpoint gets all tokens for all users if one has the `manage_system` permission.
 
 #### Plugin API Changes (Beta)
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -16,7 +16,7 @@ Release date: 2018-02-16
 
 #### Client-Side Performance
 
- - Added user-based rate limiting, in addition to rate limiting API access by IP address. // XXX not sure how to quantify perf increase
+ - Added user-based rate limiting, in addition to rate limiting API access by IP address.
  - Decreased page load time by loading custom emojis asynchronously rather than all on first page load.
  - Optimized channel autocomplete (~) query by returning client-side results immediately.
  - Decreased the size of most image assets by more than 25% by running `pngquant` to remove unnecessary metadata from PNGs.
@@ -61,6 +61,9 @@ Release date: 2018-02-16
  - Added a post change channel privacy system message when a team is changed from public to private.
  - Made system messages always use "User did something" instead of "User has done something" for consistency.
 
+#### Plugins (Beta)
+ - Zoom plugin now supports an on-premise Zoom server.
+
 #### Enterprise Edition
 - Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
 - Increased OAuth state parameter limit. Some systems may send a state longer than 128 characters.
@@ -97,17 +100,18 @@ Release date: 2018-02-16
  - Fixed an issue where pasting files into a channel didn't work.
  - Fixed an issue where Mattermost crashed when posting a code snippet containing white space.
  - Fixed an issue where a validation error message did not get cleared when switching between creating a private/public channel.
- - Fixed emoji picker search should not be case-sensitive.
- - Fixed timestamp not clickable in desktop mobile view.
- - Fixed deleting a Team via the API breaks the Web UI.
+ - Fixed emoji picker search being case-sensitive.
+ - Fixed timestamp not being clickable in desktop mobile view.
+ - Fixed an issue where deleting a team via the API broke the web user interface.
  
 ### Compatibility
 
 #### Removed and Deprecated Features
 
 - All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
-- The permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint for permanently deleting a team is scheduled for removal in Mattermost v4.7. // XXX Jason needs to update
 - The `mentionKeys` prop in post type plugins is now removed to fix case sensitive mention highlighting. Plugins can retrieve the `mentionKeys` prop from the store as needed.
+
+Note that the permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint is not removed as previously announced, given customer and community feedback.
 
 #### config.json
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -35,19 +35,14 @@ Release date: 2018-02-16
 #### Web User Interface
  - Implemented a descriptive error page for browser compatibility.
  - Added a status icon in the channel member list and sorted it by user's status.
- - Disabled pull-to-refresh feature on Android (Chrome) to prevent unwanted page refresh.
  - Added ability to preview image links in a similar way that image links uploaded from Mattermost can be previewed.
  - Added a `Copy Link` option for sidebar channels in the Desktop App.
  - Added focus on the input box after hitting "Edit" for one of the Account Settings options.
  - Custom emojis are now loaded asynchronously in posts for the webapp, for increased performance.
  - Improved formatting of quotes in the channel header.
  - Added a date separator for search results.
-
-#### Notifications
- - Added a post change channel privacy system message when a team is changed from public to private.
- - Made system messages always use "User did something" instead of "User has done something" for consistency.
-
-#### Integrations
+ 
+ #### Integrations
  - Added username and profile picture to webhook set up pages.
  - Added support for Slack attachments in outgoing webhook responses.
 
@@ -56,8 +51,12 @@ Release date: 2018-02-16
  - Added paging and search of custom emojis to webapp emoji picker.
 
 #### Channels
- - Added a feature where the user will be dericted to the last channel they viewed in another team when switching to the other team.
+ - Users are directed to the last channel they viewed in another team when switching to the other team.
  - Changed URLs of Direct Messages to use the form of `https://servername.com/messages/@username`, letting users open a direct message with another user using the URL format.
+ 
+#### Notifications
+ - Added a post change channel privacy system message when a team is changed from public to private.
+ - Made system messages always use "User did something" instead of "User has done something" for consistency.
 
 #### Enterprise Edition
 - Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
@@ -91,6 +90,7 @@ Release date: 2018-02-16
  - Fixed an issue where bot messages from the Zoom plugin ignored the Zoom API URL field for on-prem Zoom servers.
  - Fixed an issue where clicking a direct message channel in left-hand sidebar that displays something other than username redirects to Town Square.
  - Updated initial scrolling on post list.
+ - Disabled pull-to-refresh feature on Android (Chrome) to prevent unwanted page refresh.
  
 ### Compatibility
 
@@ -115,11 +115,12 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
  - It is required that any new integrations use API v4 endpoints. For more details, and for a complete list of available endpoints, see [https://api.mattermost.com/](https://api.mattermost.com/).
  - All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
- - Added auto lowercase team and channel names in API requests.
- - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` API endpoints.
- - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission.
 
 #### RESTful API v4 Changes
+
+ - Added auto lowercase team and channel names in API requests. This ensures that the channel name is automatically lowercased for endpoints taking team or channel names as URL parameters.
+ - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` API endpoints. These ensure that the benefits of `GET` for important performance related actions such as autocompleting are included.
+ - Added a new endpoint called `/users/tokens/search`. This endpoint gets all tokens for all users if one has the `manage_system` permission.
 
 #### Plugin API Changes (Beta)
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -33,7 +33,6 @@ Release date: 2018-02-16
 ### Improvements
 
 #### Web User Interface
- - Implemented a descriptive error page for browser compatibility.
  - Added a status icon in the channel member list and sorted it by user's status.
  - Added ability to preview image links in a similar way that image links uploaded from Mattermost can be previewed.
  - Added a `Copy Link` option for sidebar channels in the Desktop App.
@@ -80,23 +79,19 @@ Release date: 2018-02-16
  - Fixed where after an ephemeral message, couldn't use `+:emoji:` to react to the previous message.
  - Fixed Mattermost not loading on Firefox if the `media.peerconnection.enabled` setting in Firefox is set to false.
  - Fixed login screen sometimes flashing before Mattermost server loads.
- - Fixed an issue where the current channel wasn't marked as read when the window was on focus.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
  - Fixed error code/message and panic when creating post with bad props.
  - Fixed an issue where bot messages from the Zoom plugin ignored the Zoom API URL field for on-prem Zoom servers.
- - Fixed an issue where clicking a direct message channel in left-hand sidebar that displays something other than username redirects to Town Square.
  - Updated initial scrolling on post list.
+ - Fixed a problem with the last version of webrtc-adapter.
+ - Fixed case sensitive mention highlighting.
+ - Disabled remove button after the first click to prevent multiple request.
  - Disabled pull-to-refresh feature on Android (Chrome) to prevent unwanted page refresh.
  - Fixed an issue with missing validation when an invalid credential was used.
  - Fixed an issue where clicking `Save` in `Rename Channel` modal without changes did nothing.
  - Fixed an issue where pasting files into a channel didn't work.
  - Fixed an issue where Mattermost crashed when posting a code snippet containing white space.
  - Fixed an issue where a validation error message did not get cleared when switching between creating a private/public channel.
- - Fixed an issue where the `Manage Custom Emoji` list didn't scroll to the top when switching pages.
- - Fixed an issue where a channel with no mention was bolded as unread, if "Mark Channel Unread" was set to only for mentions and `ExperimentalGroupUnreadChannels` config.json setting was set to true.
- - Fixed issues with channels staying in the "unreads" section after viewing.
- - Fixed an issue where leaving a team crashed the app.
- - Fixed an issue where the `ALT+SHIFT+UP/DOWN` was broken with the unreads section.
  
 ### Compatibility
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -59,6 +59,9 @@ Release date: 2018-02-16
  - Update initial scrolling on post list.
  - Added async loading of emojis in posts for the webapp.
  - Improved formatting for quotes in channel header.
+ - Changed URLs of Direct Messages to usernames.
+ - Added paging/search of custom emojis to webapp emoji picker.
+ - Handled custom emojis in channel header and login page.
 
 ### Bug Fixes
 
@@ -118,6 +121,10 @@ Release date: 2018-02-16
  - Fixed refactor sidebar to be pure and use redux.
  - Fixed redirects with 4XX status codes.
  - Fixed markdown parsing crash (dos) on empty image url.
+ - Fixed error code/message and panic when creating post with bad props.
+ - Fixed an issue where bot messages from the Zoom plugin ignore the Zoom API URL field for on-prem Zoom servers.
+ - Fixed an issue where current master doesn't load on Win10 Edge or IE11.
+ - Fixed JS warning: (node) warning: possible EventEmitter memory leak detected.
  
 ### Compatibility
 
@@ -133,7 +140,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 #### Changes to Team Edition and Enterprise Edition:
 
  - Under `ServiceSettings` in `config.json`:
-    - Added `"ImageProxyType"` and `"ImageProxyURL"` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
+    - Added `"ImageProxyType": ""`, `"ImageProxyOptions": ""`, and `"ImageProxyURL": ""` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
     - Added `"ExperimentalGroupUnreadChannels": false` setting to show an unread channel section in the webapp sidebar.
     - Added `"VaryByUser": false`, a user based rate limiting, to rate limit on token and on userID.
     - Added a config property `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows for leave/join messages to be created in the default channel.

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -12,7 +12,8 @@ Release date: 2018-02-16
 
 #### Client-Side Performance
 
- -
+ - Added user based rate limiting.
+ - Optimized channel autocomplete query.
 
 #### Image Proxy Support
 
@@ -27,6 +28,16 @@ Release date: 2018-02-16
  - Added an experimental unread channel section in the sidebar to enable or disable the option to display the unread channel section in the sidebar.
 
 ### Improvements
+
+ - Implemented a descriptive error page for browser compatibility.
+ - Added a config property `EnableDefaultChannelLeaveJoinMessages` that allows for leave/join messages to be created in the default channel.
+ - Added a post change channel privacy system message.
+ - Added auto lowercase team and channel names in API requests.
+ - Added a `sampledata` platform command to generate realistic sample data.
+ - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission.
+ - Added support for Slack attachments in outgoing webhook responses.
+ - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` API endpoints.
+ - Increased size of position to 128 characters.
 
 ### Bug Fixes
 
@@ -48,6 +59,12 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 ### Database Changes
 
 ### Known Issues
+
+ - OAuth account creation error page is unformatted.
+ - `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posts in town-square when user leaves team
+ - Plugin slash commands don't override username or icon
+ - Deleting a Team via the API Breaks the Web UI.
+ - Switch to the golang autocert library for let's encrypt.
 
 ### Contributors
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -121,6 +121,11 @@ Release date: 2018-02-16
  
 ### Compatibility
 
+#### Removed and Deprecated Features
+
+- All API v3 endpoints are now deprecated, and scheduled for removal in Mattermost v5.0.
+- The permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint for permanently deleting a team is scheduled for removal in Mattermost v4.7. // XXX Jason needs update
+
 #### config.json
 
 Multiple setting options were added to `config.json`. Below is a list of the additions and their default values on install. The settings can be modified in `config.json`, or the System Console when available.
@@ -129,12 +134,25 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
  - Under `ServiceSettings` in `config.json`:
     - Added `"ImageProxyType"` and `"ImageProxyURL"` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
-    - Added `"ExperimentalGroupUnreadChannels" setting` to show an unread channel section in the webapp sidebar.
-    - Added `"VaryByUser"`, a user based rate limiting, to rate limit on token and on userID.
+    - Added `"ExperimentalGroupUnreadChannels": false` setting to show an unread channel section in the webapp sidebar.
+    - Added `"VaryByUser": false`, a user based rate limiting, to rate limit on token and on userID.
+    - Added a config property `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows for leave/join messages to be created in the default channel.
 
 ### API Changes
 
+- It is required that any new integrations use API v4 endpoints. For more details, and for a complete list of available endpoints, see [https://api.mattermost.com/](https://api.mattermost.com/).
+- All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
+
+#### RESTful API v4 Changes
+
+#### Plugin API Changes (Beta)
+
+#### Plugin Hook Changes (Beta)
+
+
 ### Database Changes
+
+### WebSocket Event Changes
 
 ### Known Issues
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -134,12 +134,6 @@ Multiple setting options were added to `config.json`. Below is a list of the add
  - Added `POST /emoji/search`, `GET /emojis/name/{emoji_name}`, and `GET /emoji/autocomplete` to add consistency with user search/autocomplete endpoints. These API endpoints ensure that the benefits of `GET` for important performance related actions such as autocompleting are included.
  - Added `/users/tokens/search` to allow System Admin to be able to find, manage and revoke personal access tokens as needed. This endpoint gets all tokens for all users if one has the `manage_system` permission.
 
-#### Plugin API Changes (Beta)
-
-#### Plugin Hook Changes (Beta)
-
-### Database Changes
-
 ### WebSocket Event Changes
 
  - Added `delete_team` web socket event to notify client whenever a team is deleted (e.g. via API call).

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -53,9 +53,6 @@ Release date: 2018-02-16
  - Users are directed to the last channel they viewed in another team when switching to the other team.
  - Changed URLs of Direct Messages to use the form of `https://servername.com/messages/@username`, letting users open a direct message with another user using the URL format.
  
-#### System Console
- - Added paging to system console log viewer and set the default value of `per_paging` for logs to 1000.
- 
 #### Notifications
  - Added a post change channel privacy system message when a team is changed from public to private.
  - Made system messages always use "User did something" instead of "User has done something" for consistency.

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -91,6 +91,17 @@ Release date: 2018-02-16
  - Fixed an issue where clicking a direct message channel in left-hand sidebar that displays something other than username redirects to Town Square.
  - Updated initial scrolling on post list.
  - Disabled pull-to-refresh feature on Android (Chrome) to prevent unwanted page refresh.
+ - Fixed an issue where LDAP Sync posted an incorrect log message.
+ - Fixed an issue with missing validation when an invalid credential was used.
+ - Fixed an issue where clicking `Save` in `Rename Channel` modal without changes did nothing.
+ - Fixed an issue where pasting files into a channel didn't work.
+ - Fixed an issue where Mattermost crashed when posting a code snippet containing white space.
+ - Fixed an issue where a validation error message did not get cleared when switching between creating a private/public channel.
+ - Fixed an issue where the `Manage Custom Emoji` list didn't scroll to the top when switching pages.
+ - Fixed an issue where a channel with no mention was bolded as unread, if "Mark Channel Unread" was set to only for mentions and `ExperimentalGroupUnreadChannels` config.json setting was set to true.
+ - Fixed issues with channels staying in the "unreads" section after viewing.
+ - Fixed an issue where leaving a team crashed the app.
+ - Fixed an issue where the `ALT+SHIFT+UP/DOWN` was broken with the unreads section.
  
 ### Compatibility
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -12,7 +12,7 @@ Release date: 2018-02-16
 
 #### Client-Side Performance
 
- - Added user based rate limiting, in addition to rate limiting API access by IP address. // XXX not sure how to quantify perf increase
+ - Added user-based rate limiting, in addition to rate limiting API access by IP address. // XXX not sure how to quantify perf increase
  - Decreased page load time by loading custom emojis asynchronously rather than all on first page load.
  - Optimized channel autocomplete (~) query by returning client-side results immediately.
  - Decreased the size of most image assets by more than 25% by running `pngquant` to remove unnecessary metadata from PNGs.
@@ -59,7 +59,7 @@ Release date: 2018-02-16
 
 #### Enterprise Edition
 - Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
-- Increased OAuth state parameter limit some systems may send a state longer than 128 characters.
+- Increased OAuth state parameter limit. Some systems may send a state longer than 128 characters.
 
 ### Bug Fixes
  - Fixed an issue where OAuth account creation error page was unformatted.
@@ -77,7 +77,7 @@ Release date: 2018-02-16
  - Fixed an issue where reply arrow was on a second line.
  - Fixed not being able to type Korean quickly in some dialogs.
  - Fixed an issue where notification preference settings didn't respect case sensitivity for mention highlighting.
- - Fixed where after an ephemeral message, couldn't use `+:emoji:` to react to the previous message.
+ - Fixed where, after an ephemeral message, couldn't use `+:emoji:` to react to the previous message.
  - Fixed Mattermost not loading on Firefox if the `media.peerconnection.enabled` setting in Firefox is set to false.
  - Fixed login screen sometimes flashing before Mattermost server loads.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -8,6 +8,10 @@ Also see [changelog in progress](http://bit.ly/2nK3cVf) for the next release.
 
 Release date: 2018-02-16
 
+### Security Update
+
+- Mattermost v4.7.0 contains multiple security fixes ranging from low to high severity. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
+
 ### Highlights
 
 #### Client-Side Performance

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -115,6 +115,7 @@ Release date: 2018-02-16
  - Fixed unreads not clearing.
  - Fixed translation string typo and added missing translations.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
+ - Fixed refactor sidebar to be pure and use redux.
  
 ### Compatibility
 
@@ -135,7 +136,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 ### Known Issues
 
- - Refactor sidebar to be pure and use redux.
+
 
 ### Contributors
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -65,7 +65,7 @@ Release date: 2018-02-16
  - Fixed an issue where OAuth account creation error page was unformatted.
  - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left team.
  - Fixed an issue where plugin slash commands didn't override username or icon.
- - Fixed deleting a Team via the API Breaks the Web UI.
+ - Fixed deleting a team via the API breaks the web UI.
  - Switched to the golang autocert library for Let's Encrypt.
  - Fixed an issue where pagination for team members modal showed a next button when there are no more users to show.
  - Fixed an issue where at-channel in /header should not trigger confirmation modal.
@@ -83,7 +83,7 @@ Release date: 2018-02-16
  - Fixed an issue where search box in GitHub theme appeared dark in mobile view.
  - Fixed an issue where some emoji picker search results are unexpected and not selectable.
  - Fixed text of upload button when uploading custom brand image.
- - Fixed an issue where reactions added by clicking another user's reaction should appear in Recently Used.
+ - Fixed an issue where reactions added by clicking another user's reaction should appear in recently Used.
  - Fixed JS warning: (node) warning: possible EventEmitter memory leak detected.
  - Fixed error bar and bad connection state for textbox.
  - Fixed an issue where CTRL/CMD+UP erased text draft from message box.
@@ -156,7 +156,19 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 ### Known Issues
 
-
+- Google login fails on the Classic mobile apps.
+- User can receive a video call from another browser tab while already on a call.
+- Jump link in search results does not always jump to display the expected post.
+- Status may sometimes get stuck as away or offline in High Availability mode with IP Hash turned off.
+- Searching stop words in quotes with Elasticsearch enabled returns more than just the searched terms.
+- Searching with Elasticsearch enabled may not always highlight the searched terms.
+- Team sidebar on desktop app does not update when channels have been read on mobile.
+- Channel scroll position flickers while images and link previews load.
+- CTRL/CMD+U shortcut to upload a file doesn't work on Firefox.
+- Numbered lists can sometimes extend beyond the normal post area.
+- Slack import through the CLI fails if email notifications are enabled.
+- Letters are skipped in a few dialogs when using Korean keyboard in IE11.
+- Push notifications don't always clear on iOS when running Mattermost in High Availability mode.
 
 ### Contributors
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -12,13 +12,36 @@ Release date: 2018-02-16
 
 #### Client-Side Performance
 
--
+ -
+
+#### Image Proxy Support
+
+ - Added three new configuration keys: `ImageProxyType`, `ImageProxyURL`, `ImageProxyOptions` to ensure that posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
+
+#### Updated Image Thumbnails
+
+ - Updated the appearance of image thumbnails in the UI so that single thumbnails will now expand to a larger preview without clicking the image to open the preview window.
+
+#### Experimental Setting for Unreads Sidebar Section
+
+ - Added an experimental unread channel section in the sidebar to enable or disable the option to display the unread channel section in the sidebar.
 
 ### Improvements
 
 ### Bug Fixes
 
 ### Compatibility
+
+#### config.json
+
+Multiple setting options were added to `config.json`. Below is a list of the additions and their default values on install. The settings can be modified in `config.json`, or the System Console when available.
+
+#### Changes to Team Edition and Enterprise Edition:
+
+ - Under `ServiceSettings` in `config.json`:
+    - Added `"ImageProxyType"` and `"ImageProxyURL"` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
+    - Added `"ExperimentalGroupUnreadChannels" setting` to show an unread channel section in the webapp sidebar.
+    - Added `"VaryByUser"`, a user based rate limiting, to rate limit on token and on userID.
 
 ### API Changes
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -19,72 +19,61 @@ Release date: 2018-02-16
 
 #### Image Proxy Support
 
- - Added three new configuration keys: `ImageProxyType`, `ImageProxyURL`, `ImageProxyOptions` to ensure that posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
+ - Image proxy servers increase performance through a layer of caching, and provide custom options to resize images.
+ - Three new configuration keys, `ImageProxyType`, `ImageProxyURL`, `ImageProxyOptions`, ensure that posts served to the client will have their markdown modified such that all images are loaded through a proxy.
 
 #### Updated Image Thumbnails
 
- - Updated the appearance of image thumbnails in the UI so that single thumbnails will now expand to a larger preview without clicking the image to open the preview window.
+ - Updated the appearance of image thumbnails, so that single thumbnails will now expand to a larger preview without clicking the image to open the preview window.
 
 #### Experimental Setting for Unreads Sidebar Section
 
- - Added an experimental unread channel section in the sidebar to enable or disable the option to display the unread channel section in the sidebar.
+ - Added an experimental setting to group unread channels in the channel sidebar.
 
 ### Improvements
 
-#### Web UI
+#### Web User Interface
  - Implemented a descriptive error page for browser compatibility.
- - Migrated file upload to be pure and use Redux.
- - Show status icon in the channel member list and sorted it by user's status.
- - Updated help text for debugging webhooks.
- - Fixed active state for dropdown for channel header options.
- - Disabled pull-to-refresh on Android(Chrome).
- - Added support for image links to be previewed.
- - Use transparent pixel while the user profile isn't loaded.
- - Added a copy link option for the buttons in the desktop app for sidebar channels.
- - Fixed tab and alt-tab keyboard navigation for links on login page.
- - Added the ability to navigate emoji picker with keyboard.
- - Set focus on the input box after hitting "Edit" for one of the account setting options.
- - Added async loading of emojis in posts for the webapp.
- - Improved formatting for quotes in channel header.
- - Handled custom emojis in channel header and login page.
+ - Added a status icon in the channel member list and sorted it by user's status.
+ - Disabled pull-to-refresh on Android (Chrome). //XXX Amy Why? What's the user benefit?
+ - Added support for image links to be previewed. //XXX Not sure what this means
+ - Use transparent pixel while the user profile isn't loaded. //XXX Amy Why? What's the user benefit?
+ - Added a `Copy Link` option for sidebar channels in the Desktop App.
+ - Added focus on the input box after hitting "Edit" for one of the Account Settings options.
+ - Custom emojis are now loaded asynchronously in posts for the webapp, for increased performance.
+ - Improved formatting of quotes in the channel header.
+ - Added a date separator for search results.
 
 #### Notifications
- - Added a post change channel privacy system message.
- - Made system messages always use "User did something" instead of "User has done something.
-
-#### Administration
- - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission.
+ - Added a post change channel privacy system message. //XXX Amy Why? What's the user benefit?
+ - Made system messages always use "User did something" instead of "User has done something" for consistency.
 
 #### Integrations
+ - Added username and profile picture to webhook set up pages.
  - Added support for Slack attachments in outgoing webhook responses.
 
+#### Emoji Picker
+ - Added the ability to navigate emoji picker with the keyboard.
+ - Added paging and search of custom emojis to webapp emoji picker.
+
 #### Channels
- - Added a config property `EnableDefaultChannelLeaveJoinMessages` that allows for leave/join messages to be created in the default channel.
- - Added auto lowercase team and channel names in API requests.
- - Use last channel name for routing on team switch.
- - Updated initial scrolling on post list.
- - Changed URLs of Direct Messages to usernames.
+ - Added auto lowercase team and channel names in API requests. //XXX To API changes section
+ - Use last channel name for routing on team switch. //XXX Amy Why? What's the user benefit?
+ - Updated initial scrolling on post list. //XXX Bug fix
+ - Changed URLs of Direct Messages to usernames. //XXX Amy Why? What's the user benefit?
 
-#### System console
- - Added username and profile picture to webhook set up pages.
-
-#### Performance
- - Migrated `SettingItemMin` and `SettingItemMax` to pure component, and replaced anonymous function on props.
-
-#### Emoji picker
- - Added paging/search of custom emojis to webapp emoji picker.
-
-#### Search
- - Added date separator for search results.
+#### Administration
+ - Added a new endpoint called `/users/tokens/search` which gets all tokens for all users if one has the `manage_system` permission. //XXX To API changes section
 
 #### Enterprise Edition
-- Increased max length of User.Position field to 128 characters to meet LDAP max length.
+- Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
 
 ### Bug Fixes
-
+ - Fixed tab and alt-tab keyboard navigation for links on sign-in page.
+ - Fixed active state for dropdown for channel header options.
  - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left a team.
  - Fixed an issue where plugin slash commands didn't override username or icon.
- - Fixed deleting a team via the API breaks the web UI.
+ - Fixed deleting a team via the API breaking the web UI.
  - Fixed an issue where pagination for team members modal showed a next button when there are no more users to show.
  - Fixed an issue where at-channel in `/header` should not trigger confirmation modal.
  - Fixed an issue where DM didn't open on clicking user in member icon drop-down list.
@@ -95,20 +84,19 @@ Release date: 2018-02-16
  - Fixed an issue where some iOS emoji using alternate skin tones were rendering incorrectly on Chrome.
  - Fixed an issue where reactions added by clicking another user's reaction should appear in recently Used.
  - Fixed an issue where timestamp was not clickable in desktop mobile view.
- - Ensured that emoji picker search should not be case-sensitive.
- - Fixed unable to type Korean quickly in some dialogs.
+ - Fixed emoji picker search being case-sensitive.
+ - Fixed not being able to type Korean quickly in some dialogs.
  - Fixed an issue where notification preference settings didn't respect case sensitivity for mention highlighting.
- - Fixed after an ephemeral message, cannot use `+:emoji:` to react to the previous message.
- - Changed version of webrtc-adapter to 6.0.4 to prevent application crashes due to a webrtc-adapter bug in any version
-previous to 6.0.3 and after 6.0.4.
+ - Fixed where after an ephemeral message, couldn't use `+:emoji:` to react to the previous message.
+ - Fixed Mattermost not loading on Firefox if the `media.peerconnection.enabled` setting in Firefox is set to false.
  - Fixed an issue where empty post menu box displayed sometimes.
- - Fixed login screen flashes before Mattermost server loads.
+ - Fixed login screen sometimes flashing before Mattermost server loads.
  - Fixed an issue where the current channel wasn't marked as read when the window was on focus.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
  - Fixed redirects with `4XX` status codes.
  - Fixed error code/message and panic when creating post with bad props.
- - Fixed an issue where bot messages from the Zoom plugin ignore the Zoom API URL field for on-prem Zoom servers.
- - Fixed an issue where clicking a DM in LHS that displays something other than username redirects to Town Square.
+ - Fixed an issue where bot messages from the Zoom plugin ignored the Zoom API URL field for on-prem Zoom servers.
+ - Fixed an issue where clicking a direct message channel in left-hand sidebar that displays something other than username redirects to Town Square.
  
 ### Compatibility
 
@@ -126,8 +114,8 @@ Multiple setting options were added to `config.json`. Below is a list of the add
  - Under `ServiceSettings` in `config.json`:
     - Added `"ImageProxyType": ""`, `"ImageProxyOptions": ""`, and `"ImageProxyURL": ""` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
     - Added `"ExperimentalGroupUnreadChannels": false` setting to show an unread channel section in the webapp sidebar.
-    - Added `"VaryByUser": false`, a user based rate limiting, to rate limit on token and on userID.
-    - Added a config property `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows for leave/join messages to be created in the default channel.
+    - Added `"VaryByUser": false`, a user based rate limiting, to rate limit on token and on userID. // XXXX This is under `RateLimitingSettings`
+    - Added `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows disabling of leave/join messages in the default channel, usually Town Square.
 
 ### API Changes
 
@@ -139,7 +127,6 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 #### Plugin API Changes (Beta)
 
 #### Plugin Hook Changes (Beta)
-
 
 ### Database Changes
 
@@ -158,7 +145,6 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 - CTRL/CMD+U shortcut to upload a file doesn't work on Firefox.
 - Numbered lists can sometimes extend beyond the normal post area.
 - Slack import through the CLI fails if email notifications are enabled.
-- Letters are skipped in a few dialogs when using Korean keyboard in IE11.
 - Push notifications don't always clear on iOS when running Mattermost in High Availability mode.
 
 ### Contributors

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -37,11 +37,10 @@ Release date: 2018-02-16
 ### Improvements
 
 #### Web User Interface
- - Added a status icon in the channel member list and sorted it by user's status.
- - Added ability to preview image links in a similar way that image links uploaded from Mattermost can be previewed.
+ - Added a status icon in the channel member list and sorted it by user status.
+ - Added ability to preview images found in link previews.
  - Added a `Copy Link` option for sidebar channels in the Desktop App.
- - Added focus on the input box after hitting "Edit" for one of the Account Settings options.
- - Custom emojis are now loaded asynchronously in posts for the webapp, for increased performance.
+ - Added focus on the text box after hitting "Edit" on Account Settings options.
  - Improved formatting of quotes in the channel header.
  - Added a date separator for search results.
  
@@ -54,15 +53,14 @@ Release date: 2018-02-16
  - Added paging and search of custom emojis to webapp emoji picker.
 
 #### Channels
- - Users are directed to the last channel they viewed in another team when switching to the other team.
- - Changed URLs of Direct Messages to use the form of `https://servername.com/messages/@username`, letting users open a direct message with another user using the URL format.
+ - Users are directed to the last channel they viewed in a team when switching to that team.
+ - Changed URLs of Direct Messages to use the form of `https://servername.com/messages/@username`, letting users open a direct message with each other via URL.
  
 #### Notifications
- - Added a post change channel privacy system message when a team is changed from public to private.
- - Made system messages always use "User did something" instead of "User has done something" for consistency.
+ - Added a system message when a team is changed from public to private.
 
 #### Plugins (Beta)
- - Zoom plugin now supports an on-premise Zoom server.
+ - Zoom plugin now supports on-premise Zoom servers.
 
 #### Enterprise Edition
 - Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
@@ -71,35 +69,21 @@ Release date: 2018-02-16
 ### Bug Fixes
  - Fixed an issue where OAuth account creation error page was unformatted.
  - Fixed tab and alt-tab keyboard navigation for links on sign-in page.
- - Fixed active state for dropdown for channel header options.
- - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left a team.
  - Fixed an issue where plugin slash commands didn't override username or icon.
  - Fixed an issue where pagination for team members modal showed a next button when there are no more users to show.
  - Fixed an issue where at-channel in `/header` should not trigger confirmation modal.
  - Fixed an issue where auto-generated SAML Service provider login URL had two slashes instead of one.
  - Fixed an issue where no unread mention appeared on non-mobile platform after receiving push notification.
- - Fixed an issue where emoji posted in center channel doesn't appear in Recently Used in emoji picker.
- - Fixed an issue where the text box was hidden by the keyboard when replying to a post.
+ - Fixed an issue where the text box was hidden by the keyboard when replying to a post in mobile view.
  - Fixed username autocomplete not working with mixed cases.
- - Fixed an issue where reply arrow was on a second line.
  - Fixed not being able to type Korean quickly in some dialogs.
  - Fixed an issue where notification preference settings didn't respect case sensitivity for mention highlighting.
  - Fixed where, after an ephemeral message, couldn't use `+:emoji:` to react to the previous message.
  - Fixed Mattermost not loading on Firefox if the `media.peerconnection.enabled` setting in Firefox is set to false.
  - Fixed login screen sometimes flashing before Mattermost server loads.
- - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
- - Fixed error code/message and panic when creating post with bad props.
  - Fixed an issue where bot messages from the Zoom plugin ignored the Zoom API URL field for on-prem Zoom servers.
- - Updated initial scrolling on post list.
- - Fixed a problem with the last version of webrtc-adapter.
- - Fixed case sensitive mention highlighting.
- - Disabled remove button after the first click to prevent multiple request.
  - Disabled pull-to-refresh feature on Android (Chrome) to prevent unwanted page refresh.
- - Fixed an issue with missing validation when an invalid credential was used.
  - Fixed an issue where clicking `Save` in `Rename Channel` modal without changes did nothing.
- - Fixed an issue where pasting files into a channel didn't work.
- - Fixed an issue where Mattermost crashed when posting a code snippet containing white space.
- - Fixed an issue where a validation error message did not get cleared when switching between creating a private/public channel.
  - Fixed emoji picker search being case-sensitive.
  - Fixed timestamp not being clickable in desktop mobile view.
  - Fixed an issue where deleting a team via the API broke the web user interface.
@@ -110,8 +94,23 @@ Release date: 2018-02-16
 
 - All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
 - The `mentionKeys` prop in post type plugins is now removed to fix case sensitive mention highlighting. Plugins can retrieve the `mentionKeys` prop from the store as needed.
-
-Note that the permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint is not removed as previously announced, given customer and community feedback.
+- The permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint is not removed as previously announced, given customer and community feedback.
+- As Mattermost moves to a role based permissions system in v4.8, a number of configuration settings will be migrated to roles in the database, and changing their `config.json` values will no longer take effect. These permissions can still be modified by their respective System Console settings. The `config.json` settings to be migrated are:
+  - RestrictPublicChannelManagement
+  - RestrictPrivateChannelManagement
+  - RestrictPublicChannelCreation
+  - RestrictPrivateChannelCreation
+  - RestrictPublicChannelDeletion
+  - RestrictPrivateChannelDeletion
+  - RestrictPrivateChannelManageMembers
+  - RestrictPostDelete
+  - EnableTeamCreation
+  - EnableOnlyAdminIntegrations
+  - RestrictPostDelete
+  - AllowEditPost
+  - EnableOnlyAdminIntegrations
+  - RestrictTeamInvite
+  - RestrictCustomEmojiCreation
 
 #### config.json
 
@@ -120,8 +119,8 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 #### Changes to Team Edition and Enterprise Edition:
 
  - Under `ServiceSettings` in `config.json`:
-    - Added `"ImageProxyType": ""`, `"ImageProxyOptions": ""`, and `"ImageProxyURL": ""` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
-    - Added `"ExperimentalGroupUnreadChannels": true` as `default_on` or `"ExperimentalGroupUnreadChannels": false` as `disabled` settings to show an unread channel section in the webapp sidebar.
+    - Added `"ImageProxyType": ""`, `"ImageProxyOptions": ""`, and `"ImageProxyURL": ""` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy.
+    - Added `"ExperimentalGroupUnreadChannels": disabled` to show an unread channel section in the webapp sidebar.
     - Added `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows disabling of leave/join messages in the default channel, usually Town Square.
  - Under `RateLimitingSettings` in `config.json`:
     - Added `"VaryByUser": false`, a user-based rate limiting, to rate limit on token and on userID.

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -114,7 +114,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
  - Under `ServiceSettings` in `config.json`:
     - Added `"ImageProxyType": ""`, `"ImageProxyOptions": ""`, and `"ImageProxyURL": ""` to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy when these keys are configured.
     - Added `"ExperimentalGroupUnreadChannels": true` as `default_on` or `"ExperimentalGroupUnreadChannels": false` as `disabled` settings to show an unread channel section in the webapp sidebar.
-    - Added `"VaryByUser": false`, a user based rate limiting, to rate limit on token and on userID. // XXXX This is under `RateLimitingSettings`
+    - Added `"VaryByUser": false`, a user-based rate limiting, to rate limit on token and on userID. // XXXX This is under `RateLimitingSettings`
     - Added `"ExperimentalEnableDefaultChannelLeaveJoinMessages": true` that allows disabling of leave/join messages in the default channel, usually Town Square.
 
 ### API Changes

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -65,66 +65,33 @@ Release date: 2018-02-16
 
 ### Bug Fixes
 
- - Fixed an issue where OAuth account creation error page was unformatted.
  - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left team.
  - Fixed an issue where plugin slash commands didn't override username or icon.
  - Fixed deleting a team via the API breaks the web UI.
- - Switched to the golang autocert library for Let's Encrypt.
  - Fixed an issue where pagination for team members modal showed a next button when there are no more users to show.
  - Fixed an issue where at-channel in /header should not trigger confirmation modal.
  - Fixed an issue where DM didn't open on clicking user in member icon drop-down list.
- - Fixed dispatch prop warning on popover of profile_popover component.
  - Fixed an issue where auto-generated SAML Service provider login URL had two slashes instead of one.
- - Fixed a JavaScript error when trying to switch languages (setting was not saved).
- - Fixed an issue with profile picture uploader accepting images with a size less than 128px x 128px.
  - Fixed an issue where `Add a channel description` should open Edit Header, not Edit Purpose.
  - Fixed an issue where no unread mention appeared on non-mobile platform after receiving push notification.
- - Fixed an issue where CTRL/CMD+UP took no action in RHS.
  - Fixed an issue where there was no warning when mentioning (at)all in RHS.
  - Fixed an issue where some iOS emoji using alternate skin tones were rendering incorrectly on Chrome.
- - Fixed incorrect channel notification settings when switching teams.
- - Fixed an issue where search box in GitHub theme appeared dark in mobile view.
- - Fixed an issue where some emoji picker search results are unexpected and not selectable.
- - Fixed text of upload button when uploading custom brand image.
  - Fixed an issue where reactions added by clicking another user's reaction should appear in recently Used.
- - Fixed JS warning: (node) warning: possible EventEmitter memory leak detected.
- - Fixed error bar and bad connection state for textbox.
- - Fixed an issue where CTRL/CMD+UP erased text draft from message box.
- - Fixed cannot scroll on team selection page.
- - Fixed an issue where emoji posted in center channel didn't appear in Recently Used in emoji picker.
- - Fixed an issue where the text box was hidden by the keyboard when replying to a post.
- - Fixed username autocomplete not working with mixed cases.
- - Fixed an issue where reply arrow was on a second line.
- - Fixed and issue where status icons in centre channel and RHS were off-centre.
- - Fixed and issue where +-icon in team sidebar had tooltip "Name undefined".
- - Fixed mobile push notifications not saving setting to `Manually enter...` service location.
- - Fixed race condition on persistStore initialization.
- - Fixed JS error on outgoing webhook search.
- - Disabled remove button after the first click to prevent multiple request.
- - Fixed an issue where autocomplete failed to close after typing full command.
- - Fixed a regression where users were not allowed to expand Team Setting's sections.
- - Fixed scroll issue on onboarding.
  - Fixed an issue where timestamp was not clickable in desktop mobile view.
  - Ensured that emoji picker search should not be case-sensitive.
  - Fixed unable to type Korean quickly in some dialogs.
- - Fixed duplicate requests on first page load.
- - Fixed case sensitive mention highlighting.
  - Fixed an issue where notification preference settings didn't respect case sensitivity for mention highlighting.
  - Fixed after an ephemeral message, cannot use +:emoji: to react to the previous message.
- - Fixed JS error after completing MFA setup.
- - Fixed a problem with the last version of webrtc-adapter.
+ - Changed version of webrtc-adapter to 6.0.4 to prevent application crashes due to a webrtc-adapter bug in any version
+previous to 6.0.3 and after 6.0.4.
  - Fixed an issue where empty post menu box displayed sometimes.
- - Fixed login screen flashes before pre-release loads.
- - Fixed unreads not clearing.
- - Fixed translation string typo and added missing translations.
+ - Fixed login screen flashes before Mattermost server loads.
+ - Fixed an issue where the current channel wasn't marked as read when the window was on focus.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
- - Fixed refactor sidebar to be pure and use redux.
  - Fixed redirects with 4XX status codes.
  - Fixed markdown parsing crash (dos) on empty image url.
  - Fixed error code/message and panic when creating post with bad props.
  - Fixed an issue where bot messages from the Zoom plugin ignore the Zoom API URL field for on-prem Zoom servers.
- - Fixed an issue where current master doesn't load on Win10 Edge or IE11.
- - Fixed JS warning: (node) warning: possible EventEmitter memory leak detected.
  
 ### Compatibility
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -102,6 +102,7 @@ Release date: 2018-02-16
 
 - All API v3 endpoints have been deprecated, and scheduled for removal in Mattermost v5.0.
 - The permanent query parameter of the DELETE `/teams/{team_id}` APIv4 endpoint for permanently deleting a team is scheduled for removal in Mattermost v4.7. // XXX Jason needs to update
+- The `mentionKeys` prop in post type plugins is now removed to fix case sensitive mention highlighting. Plugins can retrieve the `mentionKeys` prop from the store as needed.
 
 #### config.json
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -92,6 +92,9 @@ Release date: 2018-02-16
  - Fixed an issue where pasting files into a channel didn't work.
  - Fixed an issue where Mattermost crashed when posting a code snippet containing white space.
  - Fixed an issue where a validation error message did not get cleared when switching between creating a private/public channel.
+ - Fixed emoji picker search should not be case-sensitive.
+ - Fixed timestamp not clickable in desktop mobile view.
+ - Fixed deleting a Team via the API breaks the Web UI.
  
 ### Compatibility
 
@@ -150,6 +153,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 ### Contributors
 
+[amyblais](https://github.com/amyblais), [AndersonWebStudio](https://github.com/AndersonWebStudio), [andruwa13](https://github.com/andruwa13), [asaadmahmood](https://github.com/asaadmahmood), [bbodenmiller](https://github.com/bbodenmiller), [Brunzer](https://github.com/Brunzer), [ccbrown](https://github.com/ccbrown), [chclaus](https://github.com/chclaus), [cherniavskii](https://github.com/cherniavskii), [CometKim](https://github.com/CometKim), [coreyhulen](https://github.com/coreyhulen), [cpanato](https://github.com/cpanato), [crspeller](https://github.com/crspeller), [csduarte](https://github.com/csduarte), [cvitter](https://github.com/cvitter), [darkman](https://github.com/darkman), [der-test](https://github.com/der-test), [dlahn](https://github.com/dlahn), [enahum](https://github.com/enahum), [esethna](https://github.com/esethna), [fermulator](https://github.com/fermulator), [gig177](https://github.com/gig177), [grundleborg](https://github.com/grundleborg), [Hanzei](https://github.com/Hanzei), [hmhealey](https://github.com/hmhealey), [it33](https://github.com/it33), [james-mm](https://github.com/james-mm), [jarredwitt](https://github.com/jarredwitt), [jasonblais](https://github.com/jasonblais), [jespino](https://github.com/jespino), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kemenaran](https://github.com/kemenaran), [knechtionscoding](https://github.com/knechtionscoding), [laginha87](https://github.com/laginha87), [lasley](https://github.com/lasley), [letsila](https://github.com/letsila), [lfbrock](https://github.com/lfbrock), [lieut-data](https://github.com/lieut-data), [lindalumitchell](https://github.com/lindalumitchell), [lindy65](https://github.com/lindy65), [liusy182](https://github.com/liusy182), [Matterchen](https://github.com/Matterchen), [mkraft](https://github.com/mkraft), [MusikPolice](https://github.com/MusikPolice), [phuihock](https://github.com/phuihock), [pichouk](https://github.com/pichouk), [Rohlik](https://github.com/Rohlik), [R-Wang97](https://github.com/R-Wang97), [santos22](https://github.com/santos22), [saturninoabril](https://github.com/saturninoabril), [stephenkiers](https://github.com/stephenkiers), [sudheerDev](https://github.com/sudheerDev), [tayre](https://github.com/tayre), [tejasbubane](https://github.com/tejasbubane), [tkbky](https://github.com/tkbky), [Tristramg](https://github.com/Tristramg), [ulm0](https://github.com/ulm0), [watadarkstar](https://github.com/watadarkstar), [xuxip](https://github.com/xuxip), [yeoji](https://github.com/yeoji), [yuya-oc](https://github.com/yuya-oc)
 
 ## Release v4.6
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -116,6 +116,8 @@ Release date: 2018-02-16
  - Fixed translation string typo and added missing translations.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
  - Fixed refactor sidebar to be pure and use redux.
+ - Fixed redirects with 4XX status codes.
+ - Fixed markdown parsing crash (dos) on empty image url.
  
 ### Compatibility
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -14,6 +14,7 @@ Release date: 2018-02-16
 
  - Added user based rate limiting.
  - Optimized channel autocomplete query.
+ - Added paging and server-side search to custom emoji management.
 
 #### Image Proxy Support
 
@@ -42,34 +43,79 @@ Release date: 2018-02-16
  - Show status icon in the channel member list and sorted it by user's status.
  - Migrated `SettingItemMin` and `SettingItemMax` to pure component, and replaced anonymous function on props.
  - Use last channel name for routing on team switch.
- - Added paging and server-side search to custom emoji management.
  - Updated help text for debugging webhooks.
  - Fixed active state for dropdown.
  - Disabled pull-to-refresh on Android(Chrome).
  - Added support for image links to be previewed.
  - Added username and profile picture to webhook set up pages.
  - Use transparent pixel while the user profile isn't loaded.
+ - Added a copy link option for the buttons in the desktop app for sidebar channels.
+ - Fixed tab and alt-tab keyboard navigation for links on login page.
+ - Made system messages always use "User did something" instead of "User has done something.
+ - Added the ability to navigate emoji picker with keyboard.
+ - Added date separator for search results.
+ - Set focus on the input box after hitting "Edit" for one of the account setting options.
+ - Updated react-router to version 4.
+ - Update initial scrolling on post list.
+ - Added async loading of emojis in posts for the webapp.
+ - Improved formatting for quotes in channel header.
 
 ### Bug Fixes
 
- - OAuth account creation error page is unformatted.
- - `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posts in town-square when user leaves team
- - Plugin slash commands don't override username or icon
- - Deleting a Team via the API Breaks the Web UI.
- - Switch to the golang autocert library for let's encrypt.
- - Pagination for team members modal shows a next button when there are no more users to show.
- - At-channel in /header should not trigger confirmation modal.
- - DM doesn't open on clicking user in member icon drop-down list.
- - Fix dispatch prop warning on popover of profile_popover component.
- - Auto-generated SAML Service provider login URL has two slashes instead of one.
- - JavaScript error when trying to switch languages. Setting not saved.
- - Profile picture uploader accepts images with a size less than 128px x 128px.
- - `Add a channel description` should open Edit Header, not Edit Purpose.
- - No unread mention appeared on non-mobile platform after receiving push notification.
- - CTRL/CMD+UP takes no action in RHS.
- - No warning when mentioning (at)all in RHS.
- - Some iOS emoji using alternate skin tones are rendering incorrectly on Chrome.
-
+ - Fixed an issue where OAuth account creation error page was unformatted.
+ - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left team.
+ - Fixed an issue where plugin slash commands didn't override username or icon.
+ - Fixed deleting a Team via the API Breaks the Web UI.
+ - Switched to the golang autocert library for Let's Encrypt.
+ - Fixed an issue where pagination for team members modal showed a next button when there are no more users to show.
+ - Fixed an issue where at-channel in /header should not trigger confirmation modal.
+ - Fixed an issue where DM didn't open on clicking user in member icon drop-down list.
+ - Fixed dispatch prop warning on popover of profile_popover component.
+ - Fixed an issue where auto-generated SAML Service provider login URL had two slashes instead of one.
+ - Fixed a JavaScript error when trying to switch languages (setting was not saved).
+ - Fixed an issue with profile picture uploader accepting images with a size less than 128px x 128px.
+ - Fixed an issue where `Add a channel description` should open Edit Header, not Edit Purpose.
+ - Fixed an issue where no unread mention appeared on non-mobile platform after receiving push notification.
+ - Fixed an issue where CTRL/CMD+UP took no action in RHS.
+ - Fixed an issue where there was no warning when mentioning (at)all in RHS.
+ - Fixed an issue where some iOS emoji using alternate skin tones were rendering incorrectly on Chrome.
+ - Fixed incorrect channel notification settings when switching teams.
+ - Fixed an issue where search box in GitHub theme appeared dark in mobile view.
+ - Fixed an issue where some emoji picker search results are unexpected and not selectable.
+ - Fixed text of upload button when uploading custom brand image.
+ - Fixed an issue where reactions added by clicking another user's reaction should appear in Recently Used.
+ - Fixed JS warning: (node) warning: possible EventEmitter memory leak detected.
+ - Fixed error bar and bad connection state for textbox.
+ - Fixed an issue where CTRL/CMD+UP erased text draft from message box.
+ - Fixed cannot scroll on team selection page.
+ - Fixed an issue where emoji posted in center channel didn't appear in Recently Used in emoji picker.
+ - Fixed an issue where the text box was hidden by the keyboard when replying to a post.
+ - Fixed username autocomplete not working with mixed cases.
+ - Fixed an issue where reply arrow was on a second line.
+ - Fixed and issue where status icons in centre channel and RHS were off-centre.
+ - Fixed and issue where +-icon in team sidebar had tooltip "Name undefined".
+ - Fixed mobile push notifications not saving setting to `Manually enter...` service location.
+ - Fixed race condition on persistStore initialization.
+ - Fixed JS error on outgoing webhook search.
+ - Disabled remove button after the first click to prevent multiple request.
+ - Fixed an issue where autocomplete failed to close after typing full command.
+ - Fixed a regression where users were not allowed to expand Team Setting's sections.
+ - Fixed scroll issue on onboarding.
+ - Fixed an issue where timestamp was not clickable in desktop mobile view.
+ - Ensured that emoji picker search should not be case-sensitive.
+ - Fixed unable to type Korean quickly in some dialogs.
+ - Fixed duplicate requests on first page load.
+ - Fixed case sensitive mention highlighting.
+ - Fixed an issue where notification preference settings didn't respect case sensitivity for mention highlighting.
+ - Fixed after an ephemeral message, cannot use +:emoji: to react to the previous message.
+ - Fixed JS error after completing MFA setup.
+ - Fixed a problem with the last version of webrtc-adapter.
+ - Fixed an issue where empty post menu box displayed sometimes.
+ - Fixed login screen flashes before pre-release loads.
+ - Fixed unreads not clearing.
+ - Fixed translation string typo and added missing translations.
+ - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
+ 
 ### Compatibility
 
 #### config.json

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -62,27 +62,23 @@ Release date: 2018-02-16
 - Increased max length of `User.Position` field to 128 characters to meet LDAP max length.
 
 ### Bug Fixes
+ - Fixed an issue where OAuth account creation error page was unformatted.
  - Fixed tab and alt-tab keyboard navigation for links on sign-in page.
  - Fixed active state for dropdown for channel header options.
  - Fixed an issue where `ExperimentalEnableDefaultChannelLeaveJoinMessages` set to false still posted in town-square when user left a team.
  - Fixed an issue where plugin slash commands didn't override username or icon.
- - Fixed deleting a team via the API breaking the web UI.
  - Fixed an issue where pagination for team members modal showed a next button when there are no more users to show.
  - Fixed an issue where at-channel in `/header` should not trigger confirmation modal.
- - Fixed an issue where DM didn't open on clicking user in member icon drop-down list.
  - Fixed an issue where auto-generated SAML Service provider login URL had two slashes instead of one.
- - Fixed an issue where `Add a channel description` should open Edit Header, not Edit Purpose.
  - Fixed an issue where no unread mention appeared on non-mobile platform after receiving push notification.
- - Fixed an issue where there was no warning when mentioning (at)all in the RHS.
- - Fixed an issue where some iOS emoji using alternate skin tones were rendering incorrectly on Chrome.
- - Fixed an issue where reactions added by clicking another user's reaction should appear in recently Used.
- - Fixed an issue where timestamp was not clickable in desktop mobile view.
- - Fixed emoji picker search being case-sensitive.
+ - Fixed an issue where emoji posted in center channel doesn't appear in Recently Used in emoji picker.
+ - Fixed an issue where the text box was hidden by the keyboard when replying to a post.
+ - Fixed username autocomplete not working with mixed cases.
+ - Fixed an issue where reply arrow was on a second line.
  - Fixed not being able to type Korean quickly in some dialogs.
  - Fixed an issue where notification preference settings didn't respect case sensitivity for mention highlighting.
  - Fixed where after an ephemeral message, couldn't use `+:emoji:` to react to the previous message.
  - Fixed Mattermost not loading on Firefox if the `media.peerconnection.enabled` setting in Firefox is set to false.
- - Fixed an issue where empty post menu box displayed sometimes.
  - Fixed login screen sometimes flashing before Mattermost server loads.
  - Fixed an issue where the current channel wasn't marked as read when the window was on focus.
  - Fixed an issue where leaving channel in one tab redirected other channels on other tabs to Town Square as well.
@@ -91,7 +87,6 @@ Release date: 2018-02-16
  - Fixed an issue where clicking a direct message channel in left-hand sidebar that displays something other than username redirects to Town Square.
  - Updated initial scrolling on post list.
  - Disabled pull-to-refresh feature on Android (Chrome) to prevent unwanted page refresh.
- - Fixed an issue where LDAP Sync posted an incorrect log message.
  - Fixed an issue with missing validation when an invalid credential was used.
  - Fixed an issue where clicking `Save` in `Rename Channel` modal without changes did nothing.
  - Fixed an issue where pasting files into a channel didn't work.


### PR DESCRIPTION
We should include a note that `Zoom plugin now supports an on-premise Zoom server.`.