### PR TITLE
4.6 changelog update about Zoom plugin

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -30,7 +30,6 @@ Release date: 2017-01-16
 #### Plugins (Beta)
 
 - Plugins now support slash commands.
-- Zoom plugin now supports an on-premise Zoom server.
 
 #### Notifications
 
@@ -138,6 +137,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 - Letters are skipped in a few dialogs when using Korean keyboard in IE11.
 - Push notifications don't always clear on iOS when running Mattermost in High Availability mode.
 - Deleting a team via the API breaks the user interface.
+- Bot messages from the Zoom plugin ignore the Zoom API URL field for on-prem Zoom servers.
 
 ### Contributors
 


### PR DESCRIPTION
- Move note about supporting the on-prem version of Zoom to v4.7 and add a known issue to 4.6 changelog. If customers report it as a bug, we'll consider shipping 4.6.1 to fix the bug.