### PR TITLE
Add information about the telemetry endpoint

### DIFF
--- a/source/administration/telemetry.rst
+++ b/source/administration/telemetry.rst
@@ -14,8 +14,6 @@ We use the data for the following purposes:
   - to help improve the quality of Mattermost software and related services
   - to make design decisions for future releases
 
-Telemetry data is sent by the client to the endpoint `api.segment.io`.
-
 Security Update Check Feature
 -----------------------------
 
@@ -85,4 +83,4 @@ Non-personally Identifiable Diagnostic Information
   - *Commercial License Diagnostics (Enterprise Edition Only):* Uploaded an Enterprise license key to the server
   - *Mobile Performance Diagnostics:* Load times for starting the app, switching channels, and switching teams 
 
-  To opt out of error and diagnostic reporting, disable the feature in **System Console > General > Logging > Enable Error and Diagnostics Reporting**.
+Error and diagnostic reporting is sent by the client to the endpoint `api.segment.io`. To opt out, disable the feature in **System Console > General > Logging > Enable Error and Diagnostics Reporting**.

--- a/source/administration/telemetry.rst
+++ b/source/administration/telemetry.rst
@@ -14,6 +14,8 @@ We use the data for the following purposes:
   - to help improve the quality of Mattermost software and related services
   - to make design decisions for future releases
 
+Telemetry data is sent by the client to the endpoint `api.segment.io`.
+
 Security Update Check Feature
 -----------------------------
 


### PR DESCRIPTION
Users have observed that the client sends information to segment.io if the telemetry is activated.

Some can react very suspiciously, as it is documented nowhere that the information is gathered from the client and to a third party provider.