### PR TITLE
Update the build instructions to use Go 1.9.2

### DIFF
--- a/source/developer/dev-setup-centos-7.rst
+++ b/source/developer/dev-setup-centos-7.rst
@@ -35,11 +35,11 @@ Set up your development environment for building, running, and testing Mattermos
 
     a. Download the Go binary.
 
-       ``wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz``
+       ``wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz``
 
     b. Install the Go binary.
 
-       ``sudo tar -C /usr/local -xzf go1.9.linux-amd64.tar.gz``
+       ``sudo tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz``
 
 4. Set up your Go workspace:
 

--- a/source/developer/dev-setup-centos-7.rst
+++ b/source/developer/dev-setup-centos-7.rst
@@ -35,11 +35,11 @@ Set up your development environment for building, running, and testing Mattermos
 
     a. Download the Go binary.
 
-       ``wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz``
+       ``wget https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz``
 
     b. Install the Go binary.
 
-       ``sudo tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz``
+       ``sudo tar -C /usr/local -xzf go1.9.4.linux-amd64.tar.gz``
 
 4. Set up your Go workspace:
 

--- a/source/developer/dev-setup-ubuntu-1604.rst
+++ b/source/developer/dev-setup-ubuntu-1604.rst
@@ -33,11 +33,11 @@ Set up your development environment for building, running, and testing Mattermos
 
     a. Download the Go binary.
 
-       ``wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz``
+       ``wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz``
 
     b. Install the Go binary.
 
-       ``sudo tar -C /usr/local -xzf go1.9.linux-amd64.tar.gz``
+       ``sudo tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz``
 
 4. Set up your Go workspace:
 

--- a/source/developer/dev-setup-ubuntu-1604.rst
+++ b/source/developer/dev-setup-ubuntu-1604.rst
@@ -33,11 +33,11 @@ Set up your development environment for building, running, and testing Mattermos
 
     a. Download the Go binary.
 
-       ``wget https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz``
+       ``wget https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz``
 
     b. Install the Go binary.
 
-       ``sudo tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz``
+       ``sudo tar -C /usr/local -xzf go1.9.4.linux-amd64.tar.gz``
 
 4. Set up your Go workspace:
 


### PR DESCRIPTION
Mattermost now strongly recommends using Go 1.9.2—and warns if the 1.9.0 version is used.

Update the docs to reflect this.