### PR TITLE
Document custom post types for integrations and remove usage of 'payload' in outgoing webhooks and slash commands docs

### DIFF
--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -233,7 +233,7 @@ For example, you can use the following response to override the profile picture 
 Custom post type
 ~~~~~~~~~~~~~~~~~~
 
-You can specify a custom post type `via client plugins <about.mattermost.com/default-plugins>`_ when sending a webhook message. To set the type, use the `type` parameter.
+You can specify a custom post type when sending a webhook message, for use by `plugins <about.mattermost.com/default-plugins>`_. To set the type, use the `type` parameter on the JSON response.
 
 .. code-block:: text
 

--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -230,6 +230,15 @@ For example, you can use the following payload to override the profile picture t
 .. note::
   `Enable integrations to override profile picture icons <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator. If not enabled, the icon of the creator of the webhook URL is used to post messages.
 
+Custom post type
+~~~~~~~~~~~~~~~~~~
+
+You can specify a custom post type when sending the webhook message. To set the type, use the `type` parameter of the JSON payload.
+
+.. code-block:: text
+
+  payload={"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:", "type": "custom_type_here"}
+
 Tips and Best Practices
 ------------------------
 

--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -93,11 +93,11 @@ You can follow these general guidelines to set up a custom Mattermost slash comm
    user_id=c3a4cqe3dfy6dgopqt8ai3hydh&
    user_name=somename
 
-If your integration sends back a JSON payload, make sure it returns the ``application/json`` content-type.
+If your integration sends back a JSON response, make sure it returns the ``application/json`` content-type.
 
 9 - Add a configurable *MATTERMOST_TOKEN* variable to your application and set it to the **Token** value from step 7. This value will be used by your application to confirm the HTTP POST or GET request came from Mattermost.
 
-10 - To have your application post a message back to ``town-square``, it can respond to the HTTP POST request with a JSON response payload such as:
+10 - To have your application post a message back to ``town-square``, it can respond to the HTTP POST request with a JSON response such as:
 
 .. code-block:: text
 
@@ -120,9 +120,9 @@ If your integration sends back a JSON payload, make sure it returns the ``applic
 Which would render in Mattermost as
 
 .. image:: ../images/weatherBot.PNG
-  :alt: Shows what the JSON payload renders as in Mattermost
+  :alt: Shows what the JSON response renders as in Mattermost
 
-11 - You're all set! See below for message formatting options for the JSON payload, as well as tips and best practices for setting up your slash command.
+11 - You're all set! See below for message formatting options for the JSON response, as well as tips and best practices for setting up your slash command.
 
 Parameters and Formatting
 --------------------------
@@ -134,28 +134,28 @@ Message type
 
 You can use the ``response_type`` parameter to set whether the command posts a regular message or an ephemeral message. Ephemeral messages are only displayed temporarily to the user who activated the command.
 
-For example, to send an ephemeral message, use the following payload.
+For example, to send an ephemeral message, use the following response.
 
 .. code-block:: text
 
-  payload={"response_type": "ephemeral", "text": "Hello, this is some text\nThis is more text. :tada:"}
+  {"response_type": "ephemeral", "text": "Hello, this is some text\nThis is more text. :tada:"}
 
-To send the response as a regular message, use the following payload.
+To send the response as a regular message, use the following response.
 
 .. code-block:: text
 
-  payload={"response_type": "in_channel", "text": "Hello, this is some text\nThis is more text. :tada:"}
+  {"response_type": "in_channel", "text": "Hello, this is some text\nThis is more text. :tada:"}
 
 Redirect to an external webpage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use the ``goto_location`` parameter to redirect the user of your command to an external webpage.
 
-If the parameter is present, the user is redirected to the specified URL in a new browser tab. For instance, to redirect the user to `https://about.mattermost.com <https://about.mattermost.com>`_, use the following payload.
+If the parameter is present, the user is redirected to the specified URL in a new browser tab. For instance, to redirect the user to `https://about.mattermost.com <https://about.mattermost.com>`_, use the following response.
 
 .. code-block:: text
 
-  payload={"response_type": "ephemeral", "goto_location": "https://about.mattermost.com", "text": "Hello, this is some text\nThis is more text. :tada:"}
+  {"response_type": "ephemeral", "goto_location": "https://about.mattermost.com", "text": "Hello, this is some text\nThis is more text. :tada:"}
 
 The parameter supports any custom protocol including ``http://``, ``https://``, ``ftp://``, ``ssh://`` and ``mailto://``.
 
@@ -175,38 +175,38 @@ Markdown formatting
 
 A rich range of formatting unavailable in Slack is made possible through :doc:`Markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by slash commands.
 
-For example, to create a message with a heading and an italicized text on the next line, use the following payload. 
+For example, to create a message with a heading and an italicized text on the next line, use the following response. 
 
 .. code-block:: text
 
-  payload={"text": "# This is a heading\n_This text is italicized._"}
+  {"text": "# This is a heading\n_This text is italicized._"}
 
 .. image:: ../images/incoming_webhooks_markdown_formatting.png
   :width: 300 px
   
-Messages with advanced formatting can be created by including an :doc:`attachment array <message-attachments>` and :doc:`interactive message buttons <interactive-message-buttons>` in the JSON payload.
+Messages with advanced formatting can be created by including an :doc:`attachment array <message-attachments>` and :doc:`interactive message buttons <interactive-message-buttons>` in the JSON response.
 
 Mention notifications
 ~~~~~~~~~~~~~~~~~~~~~~
 
-You can trigger mention notifications with your message. To trigger a mention, include *@username* or *<userid>* in the `text` parameter of the JSON payload.
+You can trigger mention notifications with your message. To trigger a mention, include *@username* or *<userid>* in the `text` parameter of the JSON response.
 
 Channels can be mentioned by including *@channel* or *<!channel>*. For example:
 
 .. code-block:: text
 
-  payload={"text": "<!channel> this is a notification."}
+  {"text": "<!channel> this is a notification."}
 
 Override the username
 ~~~~~~~~~~~~~~~~~~~~~
 
-In addition to specifying the response username when setting up your slash command, you can also override it by specifying a ``username`` parameter in your JSON payload.
+In addition to specifying the response username when setting up your slash command, you can also override it by specifying a ``username`` parameter in your JSON response.
 
-For example, to send the message as a ``webhook-bot``, use the following payload.
+For example, to send the message as a ``webhook-bot``, use the following response.
 
 .. code-block:: text
 
-  payload={"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:"}
+  {"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:"}
   
 .. image:: ../images/incoming_webhooks_override_username.png
   :width: 400 px
@@ -219,13 +219,13 @@ To prevent malicious users from trying to perform `phishing attacks <https://en.
 Override the profile picture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Similary to the username, you can also override the profile picture by specifying an ``icon_url`` parameter in your JSON payload.
+Similary to the username, you can also override the profile picture by specifying an ``icon_url`` parameter in your JSON response.
 
-For example, you can use the following payload to override the profile picture to use the image located at http://example.com/somecoolimage.jpg.
+For example, you can use the following response to override the profile picture to use the image located at http://example.com/somecoolimage.jpg.
 
 .. code-block:: text
 
-  payload={"icon_url": "http://example.com/somecoolimage.jpg", "text": "Hello, this is some text\nThis is more text. :tada:"}
+  {"icon_url": "http://example.com/somecoolimage.jpg", "text": "Hello, this is some text\nThis is more text. :tada:"}
 
 .. note::
   `Enable integrations to override profile picture icons <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator. If not enabled, the icon of the creator of the webhook URL is used to post messages.
@@ -233,22 +233,22 @@ For example, you can use the following payload to override the profile picture t
 Custom post type
 ~~~~~~~~~~~~~~~~~~
 
-You can specify a custom post type when sending the webhook message. To set the type, use the `type` parameter of the JSON payload.
+You can specify a custom post type `via client plugins <about.mattermost.com/default-plugins>`_ when sending a webhook message. To set the type, use the `type` parameter.
 
 .. code-block:: text
 
-  payload={"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:", "type": "custom_type_here"}
+  {"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:", "type": "custom_type_here"}
 
 Tips and Best Practices
 ------------------------
 
 1. Slash commands are designed to easily allow you to post messages. For other actions such as channel creation, you must also use the `Mattermost APIs <../developer/api.html>`_.
 
-2. If the text in the JSON payload is longer than 4000 characters, the message is split into multiple consecutive posts, each within the 4000 character limit.
+2. If the text in the JSON response is longer than 4000 characters, the message is split into multiple consecutive posts, each within the 4000 character limit.
 
 3. You can restrict who can create slash commands in `System Console > Integrations > Custom Integrations <https://docs.mattermost.com/administration/config-settings.html#restrict-managing-integrations-to-admins>`_.
 
-4. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates Slack's proprietary JSON payload format <../developer/slash-commands#translate-slacks-proprietary-data-format-to-mattermost>`_.
+4. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates Slack's proprietary JSON format <../developer/slash-commands#translate-slacks-proprietary-data-format-to-mattermost>`_.
 
 5. The external application may be written in any programming language. It needs to provide a URL which receives the request sent by your Mattermost server and responds with in the required JSON format.
 
@@ -269,10 +269,10 @@ Translate Slack's proprietary data format to Mattermost
 
 Mattermost automatically translates the data coming from Slack:
 
-1. JSON payloads written for Slack, that contain the following, are translated to Mattermost Markdown and rendered equivalently to Slack:
+1. JSON responses written for Slack, that contain the following, are translated to Mattermost Markdown and rendered equivalently to Slack:
    
-   - *<>* to denote a URL link, such as ``payload={"text": "<http://www.mattermost.com/>"}``
-   - *|* within a *<>* to define linked text, such as ``payload={"text": "Click <http://www.mattermost.com/|here> for a link."}``
+   - *<>* to denote a URL link, such as ``{"text": "<http://www.mattermost.com/>"}``
+   - *|* within a *<>* to define linked text, such as ``{"text": "Click <http://www.mattermost.com/|here> for a link."}``
 
 2. Both the HTTP POST and GET request bodies sent to a web service are formatted the same as Slack's. This means your Slack integration's receiving function does not need change to be compatible with Mattermost.
   
@@ -298,9 +298,9 @@ If you are using a slash command that previously worked in Slack, try specifying
 
 Slack assumes the ``response_type`` is ``ephemeral`` while Mattermost does not, so the `response_type must be specified <https://docs.mattermost.com/developer/slash-commands.html#message-type>`_ before the command works.
 
-My integration prints the JSON payload data in a Mattermost channel
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+My integration prints the JSON data in a Mattermost channel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mattermost handles multiple content types for integrations, including plain text content type. 
 
-If your integration prints the JSON payload data instead of rendering the generated message, make sure your integration is returning the ``application/json`` content-type.
+If your integration prints the JSON data instead of rendering the generated message, make sure your integration is returning the ``application/json`` content-type.

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -152,7 +152,7 @@ Messages with advanced formatting can be created by including an :doc:`attachmen
 Custom post type
 ~~~~~~~~~~~~~~~~~~
 
-You can specify a custom post type `via client plugins <about.mattermost.com/default-plugins>`_ when sending a webhook message. To set the type, use the `type` parameter on the JSON payload.
+You can specify a custom post type when sending a webhook message, for use by `plugins <about.mattermost.com/default-plugins>`_. To set the type, use the `type` parameter on the JSON payload.
 
 .. code-block:: text
 

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -105,8 +105,8 @@ For example, to send the message as a ``webhook-bot``, use the following payload
 
 To prevent malicious users from trying to perform `phishing attacks <https://en.wikipedia.org/wiki/Phishing>`_ a *BOT* indicator appears next to posts coming from webhooks regardless of what username is specified.
 
-  .. note::
-    `Enable integrations to override usernames <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-usernames>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator to do so. If not enabled, the username is set to `webhook`.
+.. note::
+  `Enable integrations to override usernames <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-usernames>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator to do so. If not enabled, the username is set to `webhook`.
 
 Override the profile picture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -119,8 +119,8 @@ For example, you can use the following payload to override the profile picture t
 
   payload={"icon_url": "http://example.com/somecoolimage.jpg", "text": "Hello, this is some text\nThis is more text. :tada:"}
 
-  .. note::
-    `Enable integrations to override profile picture icons <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator to do so. If not enabled, the icon of the creator of the webhook URL is used to post messages.
+.. note::
+  `Enable integrations to override profile picture icons <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator to do so. If not enabled, the icon of the creator of the webhook URL is used to post messages.
 
 Mention notifications
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -148,6 +148,15 @@ For example, to create a message with a heading, and an italicized text on the n
   :width: 300 px
 
 Messages with advanced formatting can be created by including an :doc:`attachment array <message-attachments>` and :doc:`interactive message buttons <interactive-message-buttons>` in the JSON payload.
+
+Custom post type
+~~~~~~~~~~~~~~~~~~
+
+You can specify a custom post type when sending the webhook message. To set the type, use the `type` parameter of the JSON payload.
+
+.. code-block:: text
+
+  payload={"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:", "type": "custom_type_here"}
 
 Tips and Best Practices
 ------------------------

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -120,7 +120,7 @@ For example, you can use the following payload to override the profile picture t
   payload={"icon_url": "http://example.com/somecoolimage.jpg", "text": "Hello, this is some text\nThis is more text. :tada:"}
 
 .. note::
-  `Enable integrations to override profile picture icons <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator to do so. If not enabled, the icon of the creator of the webhook URL is used to post messages.
+  `Enable integrations to override profile picture icons <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons>`_ must be set to `true` in `config.json` to override profile picture icons. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator to do so. If not enabled, the icon of the creator of the webhook URL is used to post messages.
 
 Mention notifications
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -152,7 +152,7 @@ Messages with advanced formatting can be created by including an :doc:`attachmen
 Custom post type
 ~~~~~~~~~~~~~~~~~~
 
-You can specify a custom post type when sending the webhook message. To set the type, use the `type` parameter of the JSON payload.
+You can specify a custom post type `via client plugins <about.mattermost.com/default-plugins>`_ when sending a webhook message. To set the type, use the `type` parameter on the JSON payload.
 
 .. code-block:: text
 

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -173,6 +173,15 @@ For example, to create a message with a heading, and an italicized text on the n
 
 Messages with advanced formatting can be created by including an :doc:`attachment array <message-attachments>` and :doc:`interactive message buttons <interactive-message-buttons>` in the JSON payload.
 
+Custom post type
+~~~~~~~~~~~~~~~~~~
+
+You can specify a custom post type when sending the webhook message. To set the type, use the `type` parameter of the JSON payload.
+
+.. code-block:: text
+
+  payload={"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:", "type": "custom_type_here"}
+
 Tips and Best Practices
 ------------------------
 

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -32,7 +32,7 @@ You can follow these general guidelines to set up a Mattermost outgoing webhook 
  - If ``application/x-www-form-urlencoded`` is chosen, the Mattermost server assumes you will be encoding the parameters in a URL format.
  - If ``application/json`` is chosen, the Mattermost server assumes you will posting JSON data.
 
-4 - Select the public channel to receive webhook payloads, or specify one or more trigger words that send an HTTP POST request to your application. You may configure either the channel or the trigger words for the outgoing webhook, or both. If both are specified, then the message must match both values.
+4 - Select the public channel to receive webhook responses, or specify one or more trigger words that send an HTTP POST request to your application. You may configure either the channel or the trigger words for the outgoing webhook, or both. If both are specified, then the message must match both values.
 
 In our example, we would set the channel to ``town-square`` and specify ``#build`` as the trigger word.
 
@@ -75,11 +75,11 @@ In our example, we would set the channel to ``town-square`` and specify ``#build
       user_id=rnina9994bde8mua79zqcg5hmo&
       user_name=somename
 
-If your integration sends back a JSON payload, make sure it returns the ``application/json`` content-type.
+If your integration sends back a JSON response, make sure it returns the ``application/json`` content-type.
 
 9 - Add a configurable *MATTERMOST_TOKEN* variable to your application and set it to the **Token** value from step 7. This value will be used by your application to confirm the HTTP POST request came from Mattermost.
 
-10 - To have your application post a message back to ``town-square``, it can respond to the HTTP POST request with a JSON response payload such as:
+10 - To have your application post a message back to ``town-square``, it can respond to the HTTP POST request with a JSON response such as:
 
 .. code-block:: text
 
@@ -95,7 +95,7 @@ which would render in Mattermost as:
 
 .. image:: ../images/webhooksTable.PNG
 
-11 - You're all set! See below for message formatting options for the JSON payload, as well as tips and best practices for setting up your outgoing webhook.
+11 - You're all set! See below for message formatting options for the JSON response, as well as tips and best practices for setting up your outgoing webhook.
 
 Parameters and Formatting
 --------------------------
@@ -105,13 +105,13 @@ Below we give a brief description of additional parameters that help you customi
 Override the username
 ~~~~~~~~~~~~~~~~~~~~~
 
-You can override the username the messages posts as by specifying a ``username`` parameter in your JSON payload.
+You can override the username the messages posts as by specifying a ``username`` parameter in your JSON response.
 
-For example, to send the message as a ``webhook-bot``, use the following payload.
+For example, to send the message as a ``webhook-bot``, use the following response.
 
 .. code-block:: text
 
-  payload={"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:"}
+  {"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:"}
   
 .. image:: ../images/incoming_webhooks_override_username.png
   :width: 400 px
@@ -124,13 +124,13 @@ To prevent malicious users from trying to perform `phishing attacks <https://en.
 Override the profile picture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also override the profile picture the messages post with by specifying an ``icon_url`` parameter in your JSON payload.
+You can also override the profile picture the messages post with by specifying an ``icon_url`` parameter in your JSON response.
 
-For example, you can use the following payload to override the profile picture to use the image located at http://example.com/somecoolimage.jpg.
+For example, you can use the following response to override the profile picture to use the image located at http://example.com/somecoolimage.jpg.
 
 .. code-block:: text
 
-  payload={"icon_url": "http://example.com/somecoolimage.jpg", "text": "Hello, this is some text\nThis is more text. :tada:"}
+  {"icon_url": "http://example.com/somecoolimage.jpg", "text": "Hello, this is some text\nThis is more text. :tada:"}
 
 .. note::
   `Enable integrations to override profile picture icons <https://docs.mattermost.com/administration/config-settings.html#enable-integrations-to-override-profile-picture-icons>`_ must be set to `true` in `config.json` to override usernames. Enable them from **System Console > Integrations > Custom Integrations** or ask your System Administrator. If not enabled, the icon of the creator of the webhook URL is used to post messages.
@@ -142,58 +142,58 @@ You can have the outgoing webhook post a reply to the message that triggered it.
 
 .. code-block:: text
 
-  payload={"text": "<!channel> this is a notification.", "response_type": "comment"}
+  {"text": "<!channel> this is a notification.", "response_type": "comment"}
 
 When the ``response_type`` is set to ``post``, or not set, the webhook message is made as a regular post.
 
 Mention notifications
 ~~~~~~~~~~~~~~~~~~~~~~
 
-You can trigger mention notifications with your outgoing webhook message. To trigger a mention, include *@username* or *<userid>* in the ``text`` parameter of the JSON payload.
+You can trigger mention notifications with your outgoing webhook message. To trigger a mention, include *@username* or *<userid>* in the ``text`` parameter of the JSON response.
 
 Channels can be mentioned by including *@channel* or *<!channel>*. For example:
 
 .. code-block:: text
 
-  payload={"text": "<!channel> this is a notification."}
+  {"text": "<!channel> this is a notification."}
 
 Markdown formatting
 ~~~~~~~~~~~~~~~~~~~~
 
 A rich range of formatting unavailable in Slack is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by outgoing webhooks.
 
-For example, to create a message with a heading, and an italicized text on the next line, use the following payload. 
+For example, to create a message with a heading, and an italicized text on the next line, use the following response. 
 
 .. code-block:: text
 
-  payload={"text": "# This is a heading\n_This text is italicized._"}
+  {"text": "# This is a heading\n_This text is italicized._"}
 
 .. image:: ../images/incoming_webhooks_markdown_formatting.png
   :width: 300 px
 
-Messages with advanced formatting can be created by including an :doc:`attachment array <message-attachments>` and :doc:`interactive message buttons <interactive-message-buttons>` in the JSON payload.
+Messages with advanced formatting can be created by including an :doc:`attachment array <message-attachments>` and :doc:`interactive message buttons <interactive-message-buttons>` in the JSON response.
 
 Custom post type
 ~~~~~~~~~~~~~~~~~~
 
-You can specify a custom post type when sending the webhook message. To set the type, use the `type` parameter of the JSON payload.
+You can specify a custom post type `via client plugins <about.mattermost.com/default-plugins>`_ when sending a webhook message. To set the type, use the `type` parameter.
 
 .. code-block:: text
 
-  payload={"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:", "type": "custom_type_here"}
+  {"username": "webhook-bot", "text": "Hello, this is some text\nThis is more text. :tada:", "type": "custom_type_here"}
 
 Tips and Best Practices
 ------------------------
 
 1. Webhooks are designed to easily allow you to post messages. For other actions such as channel creation, you must also use the `Mattermost APIs <../developer/api.html>`_.
 
-2. If the text in the JSON payload is longer than 4000 characters, the message is split into multiple consecutive posts, each within the 4000 character limit.
+2. If the text in the JSON response is longer than 4000 characters, the message is split into multiple consecutive posts, each within the 4000 character limit.
 
 3. Outgoing webhooks are supported in public channels only. If you need a trigger that works in a private channel or a direct message, consider using a `slash command <https://docs.mattermost.com/developer/slash-commands.html>`_ instead.
 
 4. You can restrict who can create outgoing webhooks in `System Console > Integrations > Custom Integrations <https://docs.mattermost.com/administration/config-settings.html#restrict-managing-integrations-to-admins>`_.
 
-5. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates the Slack's proprietary JSON payload format <../developer/webhooks-outgoing#translate-slacks-proprietary-data-format-to-mattermost>`_.
+5. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates the Slack's proprietary JSON response format <../developer/webhooks-outgoing#translate-slacks-proprietary-data-format-to-mattermost>`_.
 
 6. The external application may be written in any programming language. It needs to provide a URL which reacts to the request sent by your Mattermost server, and send an HTTP POST in the required JSON format as a response.
  
@@ -214,10 +214,10 @@ Translate Slack's proprietary data format to Mattermost
 
 Mattermost automatically translates the data coming from Slack:
 
-1. JSON payloads written for Slack, that contain the following, are translated to Mattermost markdown and rendered equivalently to Slack:
+1. JSON responses written for Slack, that contain the following, are translated to Mattermost markdown and rendered equivalently to Slack:
    
-   - *<>* to denote a URL link, such as ``payload={"text": "<http://www.mattermost.com/>"}``
-   - *|* within a *<>* to define linked text, such as ``payload={"text": "Click <http://www.mattermost.com/|here> for a link."}``
+   - *<>* to denote a URL link, such as ``{"text": "<http://www.mattermost.com/>"}``
+   - *|* within a *<>* to define linked text, such as ``{"text": "Click <http://www.mattermost.com/|here> for a link."}``
 
 2. The HTTP POST request body sent to a web service is formatted the same as Slack's. This means your Slack integration's receiving function does not need change to be compatible with Mattermost.
   
@@ -236,9 +236,9 @@ Troubleshooting
 
 To debug outgoing webhooks in **System Console > Logs**, set **System Console > Logging > Enable Webhook Debugging** to ``true`` and set **System Console > Logging > Console Log Level** to ``DEBUG``.
 
-My integration prints the JSON payload data in a Mattermost channel
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+My integration prints the JSON data in a Mattermost channel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mattermost handles multiple content types for integrations, including plain text content type. 
 
-If your integration prints the JSON payload data instead of rendering the generated message, make sure your integration is returning the ``application/json`` content-type.
+If your integration prints the JSON data instead of rendering the generated message, make sure your integration is returning the ``application/json`` content-type.

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -176,7 +176,7 @@ Messages with advanced formatting can be created by including an :doc:`attachmen
 Custom post type
 ~~~~~~~~~~~~~~~~~~
 
-You can specify a custom post type `via client plugins <about.mattermost.com/default-plugins>`_ when sending a webhook message. To set the type, use the `type` parameter.
+You can specify a custom post type when sending a webhook message, for use by `plugins <about.mattermost.com/default-plugins>`_. To set the type, use the `type` parameter on the JSON response.
 
 .. code-block:: text
 


### PR DESCRIPTION
@jwilander Wondering if we have a list of post types that can be used?