### PR TITLE
Update instructions for configuring systemd service

### DIFF
--- a/source/install/install-debian-88-mattermost.rst
+++ b/source/install/install-debian-88-mattermost.rst
@@ -74,8 +74,9 @@ Assume that the IP address of this server is 10.10.10.2.
     Requires=postgresql.service
 
     [Service]
-    Type=simple
+    Type=notify
     ExecStart=/opt/mattermost/bin/platform
+    TimeoutStartSec=90
     Restart=always
     RestartSec=10
     WorkingDirectory=/opt/mattermost

--- a/source/install/install-debian-88-mattermost.rst
+++ b/source/install/install-debian-88-mattermost.rst
@@ -76,7 +76,7 @@ Assume that the IP address of this server is 10.10.10.2.
     [Service]
     Type=notify
     ExecStart=/opt/mattermost/bin/platform
-    TimeoutStartSec=90
+    TimeoutStartSec=3600
     Restart=always
     RestartSec=10
     WorkingDirectory=/opt/mattermost

--- a/source/install/install-rhel-71-mattermost.rst
+++ b/source/install/install-rhel-71-mattermost.rst
@@ -77,7 +77,7 @@ Assume that the IP address of this server is 10.10.10.2
       User=mattermost
       ExecStart=/opt/mattermost/bin/platform
       PIDFile=/var/spool/mattermost/pid/master.pid
-      TimeoutStartSec=90
+      TimeoutStartSec=3600
       LimitNOFILE=49152
 
       [Install]

--- a/source/install/install-rhel-71-mattermost.rst
+++ b/source/install/install-rhel-71-mattermost.rst
@@ -72,11 +72,12 @@ Assume that the IP address of this server is 10.10.10.2
       After=syslog.target network.target postgresql-9.4.service
 
       [Service]
-      Type=simple
+      Type=notify
       WorkingDirectory=/opt/mattermost
       User=mattermost
       ExecStart=/opt/mattermost/bin/platform
       PIDFile=/var/spool/mattermost/pid/master.pid
+      TimeoutStartSec=90
       LimitNOFILE=49152
 
       [Install]

--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -74,8 +74,9 @@ Assume that the IP address of this server is 10.10.10.2.
     Requires=postgresql.service
 
     [Service]
-    Type=simple
+    Type=notify
     ExecStart=/opt/mattermost/bin/platform
+    TimeoutStartSec=90
     Restart=always
     RestartSec=10
     WorkingDirectory=/opt/mattermost

--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -76,7 +76,7 @@ Assume that the IP address of this server is 10.10.10.2.
     [Service]
     Type=notify
     ExecStart=/opt/mattermost/bin/platform
-    TimeoutStartSec=90
+    TimeoutStartSec=3600
     Restart=always
     RestartSec=10
     WorkingDirectory=/opt/mattermost


### PR DESCRIPTION
Starting from Mattermost 4.8, the platform server can notify systemd when it is actually started up and ready to accept network connections.

This makes the service status more reliable: systemd will now report the server as going from "stopped" to "activating" and finally "running". If the server exits before signaling it is ready, this will be correctly reported as an error to systemd. And executing `systemctl mattermost start` will return control to the shell when the server is actually ready–or return with an error exit code in case of startup failure.

(More details in https://github.com/mattermost/mattermost-server/pull/8296)

### To be merged only after Mattermost 4.8 is released