### PR TITLE
Make upgrades more backup-friendly

### DIFF
--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -35,66 +35,95 @@ Owner and group of the install directory - *{owner}* and *{group}*
 
 2. In a terminal window on the server that hosts Mattermost Server, change to your home directory. If any, delete files and directories that might still exist from a previous download.
 
-  ``cd ~``
+  .. code-block:: sh
+
+    cd ~
 
 3. Download `the latest version of Mattermost Server <https://about.mattermost.com/download/>`_. In the following command, replace ``X.X.X`` with the version that you want to download:
 
   Enterprise Edition
-    ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
+
+  .. code-block:: sh
+
+    wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz
   Team Edition
-    ``wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz``
+
+  .. code-block:: sh
+
+    wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz
 
 4. Extract the Mattermost Server files.
 
-  ``tar -x --transform='s,^[^/]\+,\0-upgrade,' -f mattermost*.gz``
+  .. code-block:: sh
+
+    tar -x --transform='s,^[^/]\+,\0-upgrade,' -f mattermost*.gz
   
   The ``transform`` option adds a suffix to the topmost extracted directory so it does not conflict with the usual install directory.
 
 5. Stop Mattermost Server.
 
-  On Ubuntu 14.04 and RHEL 6.6: ``sudo service mattermost stop``
+  On Ubuntu 14.04 and RHEL 6.6:
 
-  On Ubuntu 16.04 and RHEL 7.1: ``sudo systemctl stop mattermost``
+  .. code-block:: sh
+
+    sudo service mattermost stop
+
+  On Ubuntu 16.04 and RHEL 7.1:
+
+  .. code-block:: sh
+
+    sudo systemctl stop mattermost
 
 6. Back up your data and application.
   a. Back up your database using your organization’s standard procedures for backing up MySQL or PostgreSQL.
   b. Back up your application by copying into an archive folder (e.g. ``mattermost-back-YYYY-MM-DD-HH-mm``).
 
-  .. code-block:: text
+  .. code-block:: sh
 
     cd {install-path}
     sudo cp -ra mattermost/ mattermost-back-$(date +'%F-%H-%M')/
 
-7. Remove all files *except special directories* from within the current install directory.
+7. Remove all files *except special directories* from within the current mattermost directory.
 
-  You should first test that you'll be deleting the correct files by modifying the second part of the command to ``xargs echo rm -r`` to see exactly what will be executed.
+  The special directories within mattermost are ``config``, ``logs``, and ``data`` (unless you have a different value configured for local storage, as per *Before you begin*). The following command clears the contents of mattermost, preserving only those directories and their contents.
+  You should first modify the second part of the command to ``xargs echo rm -r`` to verify what will be executed.
 
-  .. code-block:: text
+  .. code-block:: sh
 
-    sudo find mattermost/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path 'mattermost/config' -o -path 'mattermost/data' -o -path 'mattermost/logs' \) -prune \) | sudo xargs rm -r
+    sudo find mattermost/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/config -o -path mattermost/data -o -path mattermost/logs \) -prune \) | sudo xargs rm -r
     
 8. Change ownership of the new files before copying them.
 
-  ``sudo chown -hR {owner}:{group} {path-to}/mattermost-upgrade/``
+  .. code-block:: sh
+
+    sudo chown -hR {owner}:{group} {path-to}/mattermost-upgrade/
 
 9. Copy the new files to your install directory and remove the temporary files.
 
   Note that the ``n`` (no-clobber) flag and trailing ``.`` on source are very important.
 
-  .. code-block:: text
+  .. code-block:: sh
 
     sudo cp -rn {path-to}/mattermost-upgrade/. mattermost/
     sudo rm -r {path-to}/mattermost-upgrade/
 
 10. Start Mattermost server.
 
-  On Ubuntu 14.04 and RHEL 6.6: ``sudo service mattermost start``
+  On Ubuntu 14.04 and RHEL 6.6:
 
-  On Ubuntu 16.04 and RHEL 7.1: ``sudo systemctl start mattermost``
+  .. code-block:: sh
+
+    sudo service mattermost start
+
+  On Ubuntu 16.04 and RHEL 7.1:
+
+  .. code-block:: sh
+
+    sudo systemctl start mattermost
 
 11. If you have TLS set up on your Mattermost server, you must activate the CAP_NET_BIND_SERVICE capability to allow the new Mattermost binary to bind to low ports.
 
-  .. code-block:: text
+  .. code-block:: sh
 
     cd {install-path}/mattermost
     sudo setcap cap_net_bind_service=+ep ./bin/platform

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -6,7 +6,7 @@ In most cases you can upgrade Mattermost Server in a few minutes, but the upgrad
 Upgrading to the Latest Version
 -------------------------------
 
-If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version earlier than 3.0.0, you must first `upgrade to version 3.0.3 <https://docs.mattermost.com/administration/upgrading-to-3.0.html?highlight=upgrading>`_.
+If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version earlier than 3.0.0, you must first `upgrade to version 3.0.3 <../administration/upgrading-to-3.0.html>`_.
 
 .. _before-you-begin:
 
@@ -15,7 +15,7 @@ If you are upgrading from version 3.0 or later, these instructions apply to you.
 Read these instructions carefully from start to finish. Make sure that you understand each step before starting the upgrade. If you have questions or concerns, you can ask on the Mattermost forum at https://forum.mattermost.org/.
 
 .. important::
-  Review `important-upgrade-notes <https://docs.mattermost.com/administration/important-upgrade-notes.html?highlight=important%20upgrade>`_ to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
+  Review the :doc:`important-upgrade-notes` to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
 
 You should gather the following information before starting the upgrade:
 
@@ -31,7 +31,7 @@ Owner and group of the install directory - *{owner}* and *{group}*
 .. note::
   If you are upgrading an HA cluster, `review these upgrade notes instead <https://docs.mattermost.com/deployment/cluster.html#upgrade-guide>`_.
 
-#. Review `important-upgrade-notes <https://docs.mattermost.com/administration/important-upgrade-notes.html?highlight=important%20upgrade>`_ to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
+#. Review the :doc:`important-upgrade-notes` to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
 
 #. In a terminal window on the server that hosts Mattermost Server, change to your home directory. If any, delete files and directories that might still exist from a previous download.
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -31,110 +31,113 @@ Owner and group of the install directory - *{owner}* and *{group}*
 .. note::
   If you are upgrading an HA cluster, `review these upgrade notes instead <https://docs.mattermost.com/deployment/cluster.html#upgrade-guide>`_.
 
-1. Review the :doc:`important-upgrade-notes` to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
+#. Review the :doc:`important-upgrade-notes` to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
 
-2. In a terminal window on the server that hosts Mattermost Server, change to your home directory. If any, delete files and directories that might still exist from a previous download.
+#. In a terminal window on the server that hosts Mattermost Server, change to your home directory. If any, delete files and directories that might still exist from a previous download.
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    cd ~
+     cd ~
 
-3. Download `the latest version of Mattermost Server <https://about.mattermost.com/download/>`_. In the following command, replace ``X.X.X`` with the version that you want to download:
+#. Download `the latest version of Mattermost Server <https://about.mattermost.com/download/>`_. In the following command, replace ``X.X.X`` with the version that you want to download:
 
-  Enterprise Edition
+   *Enterprise Edition*
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz
-  Team Edition
+     wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz
 
-  .. code-block:: sh
+   *Team Edition*
+
+   .. code-block:: sh
 
     wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz
 
-4. Extract the Mattermost Server files.
+#. Extract the Mattermost Server files.
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    tar -x --transform='s,^[^/]\+,\0-upgrade,' -f mattermost*.gz
+     tar -x --transform='s,^[^/]\+,\0-upgrade,' -f mattermost*.gz
   
-  The ``transform`` option adds a suffix to the topmost extracted directory so it does not conflict with the usual install directory.
+   The ``transform`` option adds a suffix to the topmost extracted directory so it does not conflict with the usual install directory.
 
-5. Stop Mattermost Server.
+#. Stop Mattermost Server.
 
-  On Ubuntu 14.04 and RHEL 6.6:
+   On Ubuntu 14.04 and RHEL 6.6:
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    sudo service mattermost stop
+     sudo service mattermost stop
 
-  On Ubuntu 16.04 and RHEL 7.1:
+   On Ubuntu 16.04 and RHEL 7.1:
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    sudo systemctl stop mattermost
+     sudo systemctl stop mattermost
 
-6. Back up your data and application.
-  a. Back up your database using your organization’s standard procedures for backing up MySQL or PostgreSQL.
-  b. Back up your application by copying into an archive folder (e.g. ``mattermost-back-YYYY-MM-DD-HH-mm``).
+#. Back up your data and application.
 
-  .. code-block:: sh
+   #. Back up your database using your organization’s standard procedures for backing up MySQL or PostgreSQL.
 
-    cd {install-path}
-    sudo cp -ra mattermost/ mattermost-back-$(date +'%F-%H-%M')/
+   #. Back up your application by copying into an archive folder (e.g. ``mattermost-back-YYYY-MM-DD-HH-mm``).
 
-7. Remove all files *except special directories* from within the current mattermost directory.
+      .. code-block:: sh
 
-  The special directories within mattermost are ``config``, ``logs``, and ``data`` (unless you have a different value configured for local storage, as per *Before you begin*). The following command clears the contents of mattermost, preserving only those directories and their contents.
-  You should first modify the second part of the command to ``xargs echo rm -r`` to verify what will be executed.
+        cd {install-path}
+        sudo cp -ra mattermost/ mattermost-back-$(date +'%F-%H-%M')/
 
-  .. code-block:: sh
+#. Remove all files *except special directories* from within the current mattermost directory.
 
-    sudo find mattermost/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/config -o -path mattermost/data -o -path mattermost/logs \) -prune \) | sudo xargs rm -r
+   The special directories within mattermost are ``config``, ``logs``, and ``data`` (unless you have a different value configured for local storage, as per *Before you begin*). The following command clears the contents of mattermost, preserving only those directories and their contents.
+   You should first modify the second part of the command to ``xargs echo rm -r`` to verify what will be executed.
+
+   .. code-block:: sh
+
+     sudo find mattermost/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/config -o -path mattermost/data -o -path mattermost/logs \) -prune \) | sudo xargs rm -r
     
-8. Change ownership of the new files before copying them.
+#. Change ownership of the new files before copying them.
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    sudo chown -hR {owner}:{group} {path-to}/mattermost-upgrade/
+     sudo chown -hR {owner}:{group} {path-to}/mattermost-upgrade/
 
-9. Copy the new files to your install directory and remove the temporary files.
+#. Copy the new files to your install directory and remove the temporary files.
 
-  Note that the ``n`` (no-clobber) flag and trailing ``.`` on source are very important.
+   Note that the ``n`` (no-clobber) flag and trailing ``.`` on source are very important.
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    sudo cp -rn {path-to}/mattermost-upgrade/. mattermost/
-    sudo rm -r {path-to}/mattermost-upgrade/
+     sudo cp -rn {path-to}/mattermost-upgrade/. mattermost/
+     sudo rm -r {path-to}/mattermost-upgrade/
 
-10. Start Mattermost server.
+#. Start Mattermost server.
 
-  On Ubuntu 14.04 and RHEL 6.6:
+   On Ubuntu 14.04 and RHEL 6.6:
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    sudo service mattermost start
+     sudo service mattermost start
 
-  On Ubuntu 16.04 and RHEL 7.1:
+   On Ubuntu 16.04 and RHEL 7.1:
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    sudo systemctl start mattermost
+     sudo systemctl start mattermost
 
-11. If you have TLS set up on your Mattermost server, you must activate the CAP_NET_BIND_SERVICE capability to allow the new Mattermost binary to bind to low ports.
+#. If you have TLS set up on your Mattermost server, you must activate the CAP_NET_BIND_SERVICE capability to allow the new Mattermost binary to bind to low ports.
 
-  .. code-block:: sh
+   .. code-block:: sh
 
-    cd {install-path}/mattermost
-    sudo setcap cap_net_bind_service=+ep ./bin/platform
+     cd {install-path}/mattermost
+     sudo setcap cap_net_bind_service=+ep ./bin/platform
 
-12. Upgrade your ``config.json`` schema:
+#. Upgrade your ``config.json`` schema:
 
-  a. Open the System Console and change a setting, then revert it. This should enable the Save button for that page.
-  b. Click **Save**.
-  c. Refresh the page.
+   #. Open the System Console and change a setting, then revert it. This should enable the Save button for that page.
+   #. Click **Save**.
+   #. Refresh the page.
 
-  Your current settings are preserved, and new settings are added with default values.
+   Your current settings are preserved, and new settings are added with default values.
 
 After the server is upgraded, users might need to refresh their browsers to experience any new features.
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -58,11 +58,11 @@ Owner and group of the install directory - *{owner}* and *{group}*
 
 6. Back up your data and application.
   a. Back up your database using your organization’s standard procedures for backing up MySQL or PostgreSQL.
-  b. Back up your application by copying into an archive folder (e.g. ``mattermost-back-YYYY-MM-DD``).
+  b. Back up your application by copying into an archive folder (e.g. ``mattermost-back-YYYY-MM-DD-HH-mm``).
 
-    ``sudo cp -ra {install-path}/mattermost/ {install-path}/{mattermost-back-YYYY-MM-DD}/``
+    ``sudo cp -ra {install-path}/mattermost/ {install-path}/mattermost-back-$(date +'%F-%H-%M')/``
 
-7. Copy only *new* files from the special folders in the extracted directory to the install directory.
+7. Copy only *new* files from the extracted special directories to the install directory, then remove those extracted directories so they do not overwrite the current ones.
 
   .. code-block:: text
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -46,7 +46,9 @@ Owner and group of the install directory - *{owner}* and *{group}*
 
 4. Extract the Mattermost Server files.
 
-  ``tar -xzf mattermost*.gz``
+  ``tar -x --transform='s,^[^/]\+,\0-upgrade,' -f mattermost*.gz``
+  
+  The ``transform`` option adds a suffix to the topmost extracted directory so it does not conflict with the usual install directory.
 
 5. Stop Mattermost Server.
 
@@ -56,21 +58,27 @@ Owner and group of the install directory - *{owner}* and *{group}*
 
 6. Back up your data and application.
   a. Back up your database using your organization’s standard procedures for backing up MySQL or PostgreSQL.
-  b. Back up your application by moving into your archive folder (e.g. ``mattermost-back-YYYY-MM-DD``).
+  b. Back up your application by copying into an archive folder (e.g. ``mattermost-back-YYYY-MM-DD``).
 
-    ``sudo mv {install-path}/mattermost {install-path}/{mattermost-back-YYYY-MM-DD}``
+    ``sudo cp -ra {install-path}/mattermost/ {install-path}/{mattermost-back-YYYY-MM-DD}/``
 
-7. Copy the files that you extracted earlier to the install directory.
-
-  ``sudo cp -r mattermost {install-path}``
-
-8. Restore your configuration, local file storage and logs.
+7. Copy only *new* files from the special folders in the extracted directory to the install directory.
 
   .. code-block:: text
 
-    sudo cp -r {install-path}/{mattermost-back-YYYY-MM-DD}/config {install-path}/mattermost
-    sudo cp -r {install-path}/{mattermost-back-YYYY-MM-DD}/data {install-path}/mattermost
-    sudo cp -r {install-path}/{mattermost-back-YYYY-MM-DD}/logs {install-path}/mattermost
+    sudo cp -nr mattermost-upgrade/config/. {install-path}/mattermost/config/
+    sudo rm -rf mattermost-upgrade/config/
+    sudo cp -nr mattermost-upgrade/data/. {install-path}/mattermost/data/
+    sudo rm -rf mattermost-upgrade/data/
+    sudo cp -nr mattermost-upgrade/logs/. {install-path}/mattermost/logs/
+    sudo rm -rf mattermost-upgrade/logs/
+
+8. Copy the remaining files to your install directory and remove the temporary files.
+
+  .. code-block:: text
+
+    sudo cp -r mattermost-upgrade/. {install-path}/mattermost/
+    sudo rm -rf mattermost-upgrade/
 
 9. Change ownership of the new files.
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -60,29 +60,31 @@ Owner and group of the install directory - *{owner}* and *{group}*
   a. Back up your database using your organization’s standard procedures for backing up MySQL or PostgreSQL.
   b. Back up your application by copying into an archive folder (e.g. ``mattermost-back-YYYY-MM-DD-HH-mm``).
 
-    ``sudo cp -ra {install-path}/mattermost/ {install-path}/mattermost-back-$(date +'%F-%H-%M')/``
+  .. code-block:: text
 
-7. Copy only *new* files from the extracted special directories to the install directory, then remove those extracted directories so they do not overwrite the current ones.
+    cd {install-path}
+    sudo cp -ra mattermost/ mattermost-back-$(date +'%F-%H-%M')/
+
+7. Remove all files *except special directories* from within the current install directory.
+
+  You should first test that you'll be deleting the correct files by modifying the second part of the command to ``xargs echo rm -r`` to see exactly what will be executed.
 
   .. code-block:: text
 
-    sudo cp -nr mattermost-upgrade/config/. {install-path}/mattermost/config/
-    sudo rm -rf mattermost-upgrade/config/
-    sudo cp -nr mattermost-upgrade/data/. {install-path}/mattermost/data/
-    sudo rm -rf mattermost-upgrade/data/
-    sudo cp -nr mattermost-upgrade/logs/. {install-path}/mattermost/logs/
-    sudo rm -rf mattermost-upgrade/logs/
+    sudo find mattermost/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path 'mattermost/config' -o -path 'mattermost/data' -o -path 'mattermost/logs' \) -prune \) | sudo xargs rm -r
+    
+8. Change ownership of the new files before copying them.
 
-8. Copy the remaining files to your install directory and remove the temporary files.
+  ``sudo chown -hR {owner}:{group} {path-to}/mattermost-upgrade/``
+
+9. Copy the new files to your install directory and remove the temporary files.
+
+  Note that the ``n`` (no-clobber) flag and trailing ``.`` on source are very important.
 
   .. code-block:: text
 
-    sudo cp -r mattermost-upgrade/. {install-path}/mattermost/
-    sudo rm -rf mattermost-upgrade/
-
-9. Change ownership of the new files.
-
-  ``sudo chown -R {owner}:{group} {install-path}/mattermost``
+    sudo cp -rn {path-to}/mattermost-upgrade/. mattermost/
+    sudo rm -r {path-to}/mattermost-upgrade/
 
 10. Start Mattermost server.
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -6,7 +6,7 @@ In most cases you can upgrade Mattermost Server in a few minutes, but the upgrad
 Upgrading to the Latest Version
 -------------------------------
 
-If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version earlier than 3.0.0, you must first `upgrade to version 3.0.3 <../administration/upgrading-to-3.0.html>`_.
+If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version earlier than 3.0.0, you must first `upgrade to version 3.0.3 <https://docs.mattermost.com/administration/upgrading-to-3.0.html?highlight=upgrading>`_.
 
 .. _before-you-begin:
 
@@ -15,7 +15,7 @@ If you are upgrading from version 3.0 or later, these instructions apply to you.
 Read these instructions carefully from start to finish. Make sure that you understand each step before starting the upgrade. If you have questions or concerns, you can ask on the Mattermost forum at https://forum.mattermost.org/.
 
 .. important::
-  Review the :doc:`important-upgrade-notes` to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
+  Review `important-upgrade-notes <https://docs.mattermost.com/administration/important-upgrade-notes.html?highlight=important%20upgrade>`_ to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
 
 You should gather the following information before starting the upgrade:
 
@@ -31,7 +31,7 @@ Owner and group of the install directory - *{owner}* and *{group}*
 .. note::
   If you are upgrading an HA cluster, `review these upgrade notes instead <https://docs.mattermost.com/deployment/cluster.html#upgrade-guide>`_.
 
-#. Review the :doc:`important-upgrade-notes` to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
+#. Review `important-upgrade-notes <https://docs.mattermost.com/administration/important-upgrade-notes.html?highlight=important%20upgrade>`_ to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
 
 #. In a terminal window on the server that hosts Mattermost Server, change to your home directory. If any, delete files and directories that might still exist from a previous download.
 


### PR DESCRIPTION
Leave writable directories in place so backup systems know the files stored there have not changed.