### PR TITLE
Updated Ubuntu 16.04 unit file so service (re-)starts after automatic database updates

### DIFF
--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -90,10 +90,15 @@ Assume that the IP address of this server is 10.10.10.2.
     If you are using MySQL, replace ``postgresql.service`` with ``mysql.service`` in 2 places in the ``[Unit]`` section and 1 place in the ``[Install]`` section.
 
   .. note::
-    If you have installed MySQL or PostgreSQL on a dedicated server then you need to remove the ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section and replace the ``WantedBy=postgresql.service`` or ``WantedBy=mysql.service`` line in the ``[Install]`` section with ``WantedBy=multi-user.target`` or the Mattermost service will not start.
+    If you have installed MySQL or PostgreSQL on a dedicated server, then you need to
+     
+      - remove ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section, and 
+      - replace the ``WantedBy=postgresql.service`` or ``WantedBy=mysql.service`` line in the ``[Install]`` section with ``WantedBy=multi-user.target``
+    
+    or the Mattermost service will not start.
 
   .. note::
-    Setting ``WantedBy`` to your local database service ensures that whenever the database service is started, the Mattermost server is (re-)started too, preventing the Mattermost server from stopping to work after an automatic update of the database.
+    Setting ``WantedBy`` to your local database service ensures that whenever the database service is started, the Mattermost server starts too. This prevents the Mattermost server from stopping to work after an automatic update of the database.
 
   c. Make systemd load the new unit.
 

--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -93,7 +93,7 @@ Assume that the IP address of this server is 10.10.10.2.
     If you have installed MySQL or PostgreSQL on a dedicated server then you need to remove the ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section and replace the ``WantedBy=postgresql.service`` or ``WantedBy=mysql.service`` line in the ``[Install]`` section with ``WantedBy=multi-user.target`` or the Mattermost service will not start.
 
   .. note::
-    Setting ``WantedBy`` to your local database service ensures that whenever the database service is started the Mattermost is (re-)started too, preventing the Mattermost server from stopping to work after an automatic update of the database.
+    Setting ``WantedBy`` to your local database service ensures that whenever the database service is started, the Mattermost server is (re-)started too, preventing the Mattermost server from stopping to work after an automatic update of the database.
 
   c. Make systemd load the new unit.
 

--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -84,13 +84,16 @@ Assume that the IP address of this server is 10.10.10.2.
     LimitNOFILE=49152
 
     [Install]
-    WantedBy=multi-user.target
+    WantedBy=postgresql.service
 
   .. note::
-    If you are using MySQL, replace ``postgresql.service`` with ``mysql.service`` in 2 places in the ``[Unit]`` section.
+    If you are using MySQL, replace ``postgresql.service`` with ``mysql.service`` in 2 places in the ``[Unit]`` section and 1 place in the ``[Install]`` section.
 
   .. note::
-    If you have installed MySQL or PostgreSQL on a dedicated server then you need to remove the ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section or the Mattermost service will not start.
+    If you have installed MySQL or PostgreSQL on a dedicated server then you need to remove the ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section and replace the ``WantedBy=postgresql.service`` or ``WantedBy=mysql.service`` line in the ``[Install]`` section with ``WantedBy=multi-user.target`` or the Mattermost service will not start.
+
+  .. note::
+    Setting ``WantedBy`` to your local database service ensures that whenever the database service is started the Mattermost is (re-)started too, preventing the Mattermost server from stopping to work after an automatic update of the database.
 
   c. Make systemd load the new unit.
 


### PR DESCRIPTION
Closes [mattermost-server issue 8239](https://github.com/mattermost/mattermost-server/issues/8239).

**Issue**
On Ubuntu, the daily apt upgrade will stop Mattermost if it's about to apply an update to the database. If you follow the current instructions the mattermost.service will continue to run, but the server will be down (nginx reports `HTTP 502 bad gateway`).

**Solution**
A slight change to the unit file ensures that automatic update of the database cause the mattermost.service to be (re-)started.

Of note, applying these change to an existing installation requires your to re-enable the service, but I opted to not go into those details as the guide assumes you haven't enabled it yet.