### PR TITLE
Add saml auth migration command documentation

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -752,12 +752,15 @@ platform user invite
       sudo ./platform user invite user@example.com myteam
       sudo ./platform user invite user@example.com myteam1 myteam2
 
-platform user migrate_auth (to ldap)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+platform user migrate_auth
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   Description
-    Migrates all user accounts from one authentication provider to another. For example, you can upgrade your authentication provider from email to AD/LDAP. Output will display any accounts that are not migrated successfully.
+    Migrates all user accounts from one authentication provider to another. For example, you can upgrade your authentication provider from email to AD/LDAP, or from AD/LDAP to SAML. Output will display any accounts that are not migrated successfully.
 
+**Migrate to AD/LDAP**
+
+  Parameters
     -  ``from_auth``: The authentication service from which to migrate user accounts. Supported options: ``email``, ``gitlab``, ``saml``.
 
     -  ``to_auth``: The authentication service to which to migrate user accounts. Supported options: ``ldap``.
@@ -779,31 +782,25 @@ platform user migrate_auth (to ldap)
       --force  Ignore duplicate entries on the AD/LDAP server.
       --dryRun Run a simulation of the migration process without changing the database.
 
+**Migrate to SAML**
 
-platform user migrate_auth (to saml)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  Description
-    Migrates all user accounts from one authentication provider to another. For example, you can upgrade your authentication provider from email to SAML. Output will display any accounts that are not migrated successfully.
+  Parameters
 
     -  ``from_auth``: The authentication service from which to migrate user accounts. Supported options: ``email``, ``gitlab``. ``ldap``.
 
     -  ``to_auth``: The authentication service to which to migrate user accounts. Supported options: ``saml``.
 
-    -  ``users_file``: The path of a json file with the usernames and emails of all users to migrate to SAML. The username and email must be the same that the SAML service provider store. And the email must match with the email in mattermost database. For example:
+    -  ``users_file``: The path of a JSON file with the usernames and emails of all users to migrate to SAML. The username and email must be the same as in your SAML service provider. Moreover, the email must match the email address of the Mattermost user account. An example of the users file is below:
 
     .. code-block:: json
 
         {
-          "usr1@email.com": "usr.one",
-          "usr2@email.com": "usr.two"
+          "user1@email.com": "user.one",
+          "user2@email.com": "user.two"
         }
 
-  Users list generation
-    The users file generation depends on how the system is configure and which
-    SAML service are you using. You can use this two example scripts for
-    OneLogin and Okta services as starting point of your own script to get the
-    data from your service provider and configuration.
+  Users file generation
+    Generating the ``users_file`` depends on how the system is configured and which SAML service provider is used. Below are two sample scripts for OneLogin and Okta service providers. For ADFS, you can use the AD/LDAP protocol to directly extract the users information and export it to a JSON file.
 
     OneLogin:
 
@@ -852,7 +849,6 @@ platform user migrate_auth (to saml)
         with file("saml_users.json", "w") as fd:
             json.dump(mapping, fd)
 
-
   Format
     .. code-block:: none
 
@@ -862,11 +858,12 @@ platform user migrate_auth (to saml)
     .. code-block:: none
 
       sudo ./platform user migrate_auth email saml users.json
+
   Options
     .. code-block:: none
 
       --auto   Automatically migrate all users. Assumes the usernames and emails are identical between Mattermost and SAML services.
-      --dryRun Run a simulation of the migration process without changing the database.
+      --dryRun Run a simulation of the migration process without changing the database. Useful to test if the migration results in any errors.
 
 platform user password
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -842,12 +842,12 @@ platform user migrate_auth (to saml)
         mapping = {}
 
         for user in users.result:
-            mapping[user.email] = user.login
+            mapping[user.profile.email] = user.profile.login
 
         while not users.is_last_page():
             users = usersClient.get_paged_users(url=users.next_url)
             for user in users.result:
-                mapping[user.email] = user.login
+                mapping[user.profile.email] = user.profile.login
 
         with file("saml_users.json", "w") as fd:
             json.dump(mapping, fd)

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -752,8 +752,8 @@ platform user invite
       sudo ./platform user invite user@example.com myteam
       sudo ./platform user invite user@example.com myteam1 myteam2
 
-platform user migrate_auth
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+platform user migrate_auth (to ldap)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   Description
     Migrates all user accounts from one authentication provider to another. For example, you can upgrade your authentication provider from email to AD/LDAP. Output will display any accounts that are not migrated successfully.
@@ -767,7 +767,7 @@ platform user migrate_auth
   Format
     .. code-block:: none
 
-      platform user migrate_auth {from_auth} {to_auth} {match_field}
+      platform user migrate_auth {from_auth} ldap {match_field}
 
   Example
     .. code-block:: none
@@ -777,6 +777,96 @@ platform user migrate_auth
     .. code-block:: none
 
       --force  Ignore duplicate entries on the AD/LDAP server.
+      --dryRun Run a simulation of the migration process without changing the database.
+
+
+platform user migrate_auth (to saml)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Description
+    Migrates all user accounts from one authentication provider to another. For example, you can upgrade your authentication provider from email to SAML. Output will display any accounts that are not migrated successfully.
+
+    -  ``from_auth``: The authentication service from which to migrate user accounts. Supported options: ``email``, ``gitlab``. ``ldap``.
+
+    -  ``to_auth``: The authentication service to which to migrate user accounts. Supported options: ``saml``.
+
+    -  ``users_file``: The path of a json file with the usernames and emails of all users to migrate to SAML. The username and email must be the same that the SAML service provider store. And the email must match with the email in mattermost database. For example:
+
+    .. code-block:: json
+
+        {
+          "usr1@email.com": "usr.one",
+          "usr2@email.com": "usr.two"
+        }
+
+  Users list generation
+    The users file generation depends on how the system is configure and which
+    SAML service are you using. You can use this two example scripts for
+    OneLogin and Okta services as starting point of your own script to get the
+    data from your service provider and configuration.
+
+    OneLogin:
+
+    .. code-block:: python
+
+        from onelogin.api.client import OneLoginClient
+        import json
+
+        client_id = input("Client id: ")
+        client_secret = input("Secret: ")
+        region = input("Region (us, eu): ")
+
+        client = OneLoginClient(client_id, client_secret, region)
+
+        mapping = {}
+        for user in client.get_users():
+            mapping[user.email] = user.username
+
+        with file("saml_users.json", "w") as fd:
+            json.dump(mapping, fd)
+
+    Okta:
+
+    .. code-block:: python
+
+        from okta import UsersClient
+        import json
+
+        base_url = input("Base url (example: https://example.okta.com): ")
+        api_token = input("API Token: ")
+
+        usersClient = UsersClient(base_url, api_token)
+
+        users = usersClient.get_paged_users(limit=25)
+
+        mapping = {}
+
+        for user in users.result:
+            mapping[user.email] = user.login
+
+        while not users.is_last_page():
+            users = usersClient.get_paged_users(url=users.next_url)
+            for user in users.result:
+                mapping[user.email] = user.login
+
+        with file("saml_users.json", "w") as fd:
+            json.dump(mapping, fd)
+
+
+  Format
+    .. code-block:: none
+
+      platform user migrate_auth {from_auth} saml {users_file}
+
+  Example
+    .. code-block:: none
+
+      sudo ./platform user migrate_auth email saml users.json
+  Options
+    .. code-block:: none
+
+      --auto   Automatically migrate all users. Assumes the usernames and emails are identical between Mattermost and SAML services.
+      --dryRun Run a simulation of the migration process without changing the database.
 
 platform user password
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It includes 2 python scripts that needs to be tested with OneLogin and Okta accounts, to verify that works (I'm not 100% because I haven't accounts there).

And this PR include the documentation of saml migration which will be included in the 4.8 version of mattermost, so must be merged accordingly to that.