### PR TITLE
WIP: Update config-settings.rst

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -3463,7 +3463,7 @@ Group Unread Channels (Experimental)
 **Default Off**: Disables the unread channels sidebar section by default. Users can turned it on in **Account Settings** > **Sidebar**.
 
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature’s ``config.json`` setting is ``"ExperimentalGroupUnreadChannels": true`` as ``default_on`` or `"ExperimentalGroupUnreadChannels": false` as ``disabled``. |
+| This feature’s ``config.json`` setting is ``"ExperimentalGroupUnreadChannels": true`` as ``default_on`` or ``"ExperimentalGroupUnreadChannels": false`` as ``disabled``. |
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Team Settings


### PR DESCRIPTION
@esethna I got feedback that the config settings for the Experimental Group Unreads Channels here is wrong since the config.json can only take two options: true and false.

From George: "the document you've linked seems to contradict itself. How can there be three options default_on, default_off and disabled when the config.json can only take two options: true and false".

A customer tried to set ExperimentalGroupUnreadChannels to either default_on or default_off in the ServiceSettings block of config.json but they had to end up setting it like this: "ExperimentalGroupUnreadChannels": true

Do you know how the config settings doc should be fixed?