### PR TITLE
Fixed spacing of database section in 4.7 changelog

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -151,6 +151,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 **User.Position field:**
 - Increased size of `user.Position` from `35` to `128` characters.
+
 **OAuth state parameter:**
 - Increased OAuth2 state parameter limit from `128` to `1024`.
 


### PR DESCRIPTION
It currently appears like 
![image](https://user-images.githubusercontent.com/3277310/36599653-10d78904-187e-11e8-88b8-26d5c69d9fae.png)
