### PR TITLE
Fix developer setup links in remaining two places

### DIFF
--- a/source/developer/api-development-version4.rst
+++ b/source/developer/api-development-version4.rst
@@ -73,7 +73,7 @@ Implementing the API Handler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To implement the API handler you'll first need to `setup your developer
-environment <https://docs.mattermost.com/developer/developer-setup.html>`__, then follow these steps:
+environment <https://docs.mattermost.com/developer/dev-setup.html>`__, then follow these steps:
 
 1. Add the declaration for your endpoint.
 

--- a/source/developer/localization.rst
+++ b/source/developer/localization.rst
@@ -74,7 +74,7 @@ Test Translations
 
 If you'd like to review and verify translations prior to achieving Beta-quality status, you can follow these steps:
 
-1 - Build Mattermost on your machine following the `Developer Machine Setup Guides <http://docs.mattermost.com/developer/developer-setup.html>`_.
+1 - Build Mattermost on your machine following the `Developer Machine Setup Guides <https://docs.mattermost.com/developer/dev-setup.html>`_.
 
 2 - Download a copy of your translations to your local machine.
 


### PR DESCRIPTION
I had fixed one in https://github.com/mattermost/docs/pull/1739.

These two instances of old URL were remaining in the codebase.