### PR TITLE
Update example message attachement

### DIFF
--- a/source/developer/message-attachments.rst
+++ b/source/developer/message-attachments.rst
@@ -94,22 +94,22 @@ Here is an example message attachment:
         "title_link": "http://docs.mattermost.com/developer/message-attachments.html",
         "fields": [
           {
-            "short": false,
+            "short":"false",
             "title":"Long Field",
             "value":"Testing with a very long piece of text that will take up the whole width of the table. And then some more text to make it extra long."
           },
           {
-            "short":true,
+            "short":"true",
             "title":"Column One",
             "value":"Testing"
           },
           {
-            "short":true,
+            "short":"true",
             "title":"Column Two",
             "value":"Testing"
           },
           {
-          "short":false,
+          "short":"false",
           "title":"Another Field",
           "value":"Testing"
           }


### PR DESCRIPTION
Fixes issue that was caused by missed double quotes. As describes in the same document this has to be a string not boolean.

Documentation states:

short: Optionally set to “True” or “False” to indicate whether the value is short enough to be displayed beside other values.