### PR TITLE
Adding note to docs re Forward80To443 related to Let's Encrypt 

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -97,6 +97,8 @@ Use Let's Encrypt
 | This feature's ``config.json`` setting is ``"UseLetsEncrypt": false`` with options ``true`` and ``false`` for above settings respectively.                        |
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. note::
+   If Let's Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443<https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let's Encrypt certification.
 
 Let's Encrypt Certificate Cache File
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/install/config-ssl-http2-apache2.rst
+++ b/source/install/config-ssl-http2-apache2.rst
@@ -7,7 +7,8 @@ Configuring Apache2 with SSL and HTTP/2 (Unofficial)
 
 Once you've configured Apache2 as a proxy for your Mattermost Server, the easiest way to enable SSL on Apache2 is via Let's Encrypt and `Certbot <https://certbot.eff.org/#ubuntuxenial-apache>`_.
 
-.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+.. note::
+   If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
 
 Once installed, run ``$ certbot --apache`` and follow the guide. Afterwards you should find a new configuration file in ``/etc/apache2/sites-available`` which should follow the format ``mysubdomain.mydomain.com-le-ssl.conf``.
 

--- a/source/install/config-ssl-http2-apache2.rst
+++ b/source/install/config-ssl-http2-apache2.rst
@@ -7,6 +7,8 @@ Configuring Apache2 with SSL and HTTP/2 (Unofficial)
 
 Once you've configured Apache2 as a proxy for your Mattermost Server, the easiest way to enable SSL on Apache2 is via Let's Encrypt and `Certbot <https://certbot.eff.org/#ubuntuxenial-apache>`_.
 
+.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+
 Once installed, run ``$ certbot --apache`` and follow the guide. Afterwards you should find a new configuration file in ``/etc/apache2/sites-available`` which should follow the format ``mysubdomain.mydomain.com-le-ssl.conf``.
 
 When opened, edit it to look something like the following:

--- a/source/install/config-ssl-http2-nginx.rst
+++ b/source/install/config-ssl-http2-nginx.rst
@@ -9,7 +9,8 @@ Although you can configure HTTP/2 without SSL, both Firefox and Chrome browsers 
 
 You can use any certificate that you want, but these instructions show you how to download and install certificates from `Let's Encrypt <https://letsencrypt.org/>`_, a free certificate authority.
 
-.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+.. note::
+   If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
 
 **To configure SSL and HTTP/2:**
 

--- a/source/install/config-ssl-http2-nginx.rst
+++ b/source/install/config-ssl-http2-nginx.rst
@@ -9,6 +9,8 @@ Although you can configure HTTP/2 without SSL, both Firefox and Chrome browsers 
 
 You can use any certificate that you want, but these instructions show you how to download and install certificates from `Let's Encrypt <https://letsencrypt.org/>`_, a free certificate authority.
 
+.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+
 **To configure SSL and HTTP/2:**
 
 1. Log in to the server that hosts NGINX and open a terminal window.

--- a/source/install/config-tls-mattermost.rst
+++ b/source/install/config-tls-mattermost.rst
@@ -29,6 +29,9 @@ The easiest option is to set up TLS on the Mattermost Server, but if you expect 
 
     a. Change the **Use Let's Encrypt** setting to ``true``.
     b. Restart the Mattermost server for these changes to take effect.
+    
+.. note::
+   If Let's Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443<https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let's Encrypt certification.
 
   **To use your own certificate**:
 

--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -252,6 +252,8 @@ Set up NGINX Server
 Set up NGINX with SSL (Recommended)
 -----------------------------------
 
+.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+
 1. You can use a free and an open certificate security like `Let's
    Encrypt <https://letsencrypt.org/>`_, this is how to proceed
 

--- a/source/install/ee-prod-rhel-6.rst
+++ b/source/install/ee-prod-rhel-6.rst
@@ -252,7 +252,8 @@ Set up NGINX Server
 Set up NGINX with SSL (Recommended)
 -----------------------------------
 
-.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+.. note::
+   If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
 
 1. You can use a free and an open certificate security like `Let's
    Encrypt <https://letsencrypt.org/>`_, this is how to proceed

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -345,6 +345,8 @@ Set up NGINX Server
 Set up NGINX with SSL (Recommended)
 -----------------------------------
 
+.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+
 1. You can use a free and an open certificate security like `Let's
    Encrypt <https://letsencrypt.org/>`_, this is how to proceed
 
@@ -352,7 +354,7 @@ Set up NGINX with SSL (Recommended)
 -  ``git clone https://github.com/letsencrypt/letsencrypt``
 -  ``cd letsencrypt``
 
-2. Be sure that the port 80 is not use by stopping NGINX
+2. Be sure that the port 80 is not in use by stopping NGINX
 
 -  ``sudo service nginx stop``
 -  ``netstat -na | grep ':80.*LISTEN'``

--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -345,7 +345,8 @@ Set up NGINX Server
 Set up NGINX with SSL (Recommended)
 -----------------------------------
 
-.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+.. note::
+   If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
 
 1. You can use a free and an open certificate security like `Let's
    Encrypt <https://letsencrypt.org/>`_, this is how to proceed

--- a/source/install/ee-prod-ubuntu.rst
+++ b/source/install/ee-prod-ubuntu.rst
@@ -233,7 +233,8 @@ Set up NGINX Server
 Set up NGINX with SSL (Recommended)
 -----------------------------------
 
-.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+.. note::
+   If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
 
 1. You can use a free and an open certificate security like let's
    encrypt, this is how to proceed

--- a/source/install/ee-prod-ubuntu.rst
+++ b/source/install/ee-prod-ubuntu.rst
@@ -233,6 +233,8 @@ Set up NGINX Server
 Set up NGINX with SSL (Recommended)
 -----------------------------------
 
+.. note:: If Let’s Encrypt is enabled, forward port 80 through a firewall, with `Forward80To443 <https://docs.mattermost.com/administration/config-settings.html#forward-port-80-to-443>`_ ``config.json`` setting set to ``true`` to complete the Let’s Encrypt certification.
+
 1. You can use a free and an open certificate security like let's
    encrypt, this is how to proceed
 


### PR DESCRIPTION
Added note that Forward80To443 config.json setting should also be set to true when enabling Let's Enrypt.