### PR TITLE
Clean up service enable commands

### DIFF
--- a/source/install/ee-prod-rhel-7.rst
+++ b/source/install/ee-prod-rhel-7.rst
@@ -227,7 +227,6 @@ Set up Mattermost Server
    - Make sure the service is executable with ``sudo chmod 664 /etc/systemd/system/mattermost.service``
    * Reload the services with ``sudo systemctl daemon-reload``
    * Start Mattermost service with``\ sudo systemctl start mattermost.service``
-   * ``sudo chkconfig mattermost on``
    * Start server on reboot ``sudo systemctl enable mattermost.service``
 
 Unix-domain socket connection
@@ -294,8 +293,8 @@ Set up NGINX Server
           enabled=1
 
    -  ``sudo yum install nginx.x86_64``
-   -  ``sudo service nginx start``
-   -  ``sudo chkconfig nginx on``
+   -  ``sudo systemctl start nginx``
+   -  ``sudo systemctl enable nginx``
 
 4. Verify NGINX is running
 

--- a/source/install/install-rhel-71-mattermost.rst
+++ b/source/install/install-rhel-71-mattermost.rst
@@ -94,11 +94,7 @@ Assume that the IP address of this server is 10.10.10.2
 
     ``sudo systemctl daemon-reload``
 
-  f. Enable the Mattermost service.
-
-    ``sudo chkconfig mattermost on``
-
-  g. Set Mattermost to start on boot.
+  e. Set Mattermost to start on boot.
 
     ``sudo systemctl enable mattermost``
 

--- a/source/install/install-rhel-71-mysql.rst
+++ b/source/install/install-rhel-71-mysql.rst
@@ -43,7 +43,7 @@ Install and set up the database for use by the Mattermost server. You can instal
 
 9. Set MySQL to start automatically when the machine starts.
 
-  ``sudo chkconfig mysqld on``
+  ``sudo systemctl enable mysqld``
 
 10. Create the Mattermost user 'mmuser'.
 


### PR DESCRIPTION
we use the "systemctl enable" command to enable services on RHEL 7.
When we use the chkconfig command, we get the message:

  Note: Forwarding request to 'systemctl enable *.service'.