### PR TITLE
Add info on message edits not triggering mentions

### DIFF
--- a/source/help/messaging/mentioning-teammates.rst
+++ b/source/help/messaging/mentioning-teammates.rst
@@ -7,10 +7,10 @@ Mentioning Teammates
 @Mentions
 ---------
 
-Use @mentions to get the attention of specific team members.
+Use @mentions to get the attention of specific team members. 
 
-.. Note::
-   Message edits do not trigger new @mention notifications, desktop notifications, or notification sounds.
+Note that editing a message does not trigger new @mention notifications, desktop notifications, or notification sounds.
+
 
 @username
 ~~~~~~~~~

--- a/source/help/messaging/mentioning-teammates.rst
+++ b/source/help/messaging/mentioning-teammates.rst
@@ -9,7 +9,7 @@ Mentioning Teammates
 
 Use @mentions to get the attention of specific team members.
 
-Note
+.. Note::
 
 Message edits do not trigger new @mention notifications, desktop notifications, or notification sounds.
 

--- a/source/help/messaging/mentioning-teammates.rst
+++ b/source/help/messaging/mentioning-teammates.rst
@@ -10,7 +10,6 @@ Mentioning Teammates
 Use @mentions to get the attention of specific team members.
 
 .. Note::
-
 Message edits do not trigger new @mention notifications, desktop notifications, or notification sounds.
 
 @username

--- a/source/help/messaging/mentioning-teammates.rst
+++ b/source/help/messaging/mentioning-teammates.rst
@@ -10,7 +10,7 @@ Mentioning Teammates
 Use @mentions to get the attention of specific team members.
 
 .. Note::
-Message edits do not trigger new @mention notifications, desktop notifications, or notification sounds.
+   Message edits do not trigger new @mention notifications, desktop notifications, or notification sounds.
 
 @username
 ~~~~~~~~~

--- a/source/help/messaging/mentioning-teammates.rst
+++ b/source/help/messaging/mentioning-teammates.rst
@@ -9,6 +9,10 @@ Mentioning Teammates
 
 Use @mentions to get the attention of specific team members.
 
+Note
+
+Message edits do not trigger new @mention notifications, desktop notifications, or notification sounds.
+
 @username
 ~~~~~~~~~
 


### PR DESCRIPTION
Like in _Messages_ -> _Editing Messages_ there should be an information here, that editing a message to include a mention will not trigger the mention.