### PR TITLE
Slack reference changes.

### DIFF
--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -173,7 +173,7 @@ Any requests that are made to the response URL should either be a plain text or 
 Markdown formatting
 ~~~~~~~~~~~~~~~~~~~~
 
-A rich range of formatting unavailable in Slack is made possible through :doc:`Markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by slash commands.
+A rich range of formatting is made possible through :doc:`Markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by slash commands.
 
 For example, to create a message with a heading and an italicized text on the next line, use the following response. 
 
@@ -248,7 +248,7 @@ Tips and Best Practices
 
 3. You can restrict who can create slash commands in `System Console > Integrations > Custom Integrations <https://docs.mattermost.com/administration/config-settings.html#restrict-managing-integrations-to-admins>`_.
 
-4. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates Slack's proprietary JSON format <../developer/slash-commands#translate-slacks-proprietary-data-format-to-mattermost>`_.
+4. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates Slack's JSON format <../developer/slash-commands#translate-slacks-data-format-to-mattermost>`_.
 
 5. The external application may be written in any programming language. It needs to provide a URL which receives the request sent by your Mattermost server and responds with in the required JSON format.
 
@@ -264,8 +264,8 @@ Slack Compatibility
 
 Mattermost makes it easy to migrate integrations written for Slack to Mattermost. 
 
-Translate Slack's proprietary data format to Mattermost
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Translate Slack's data format to Mattermost
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mattermost automatically translates the data coming from Slack:
 

--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -173,7 +173,7 @@ Any requests that are made to the response URL should either be a plain text or 
 Markdown formatting
 ~~~~~~~~~~~~~~~~~~~~
 
-A rich range of formatting is made possible through :doc:`Markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by slash commands.
+A rich range of formatting is made possible through :doc:`Markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost markdown. All of these options are also supported by slash commands.
 
 For example, to create a message with a heading and an italicized text on the next line, use the following response. 
 

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -139,7 +139,7 @@ Channels can be mentioned by including *@channel* or *<!channel>*. For example:
 Markdown formatting
 ~~~~~~~~~~~~~~~~~~~~
 
-A rich range of formatting is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by incoming webhooks.
+A rich range of formatting is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost markdown. All of these options are also supported by incoming webhooks.
 
 For example, to create a message with a heading, and an italicized text on the next line, use the following payload. 
 

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -139,7 +139,7 @@ Channels can be mentioned by including *@channel* or *<!channel>*. For example:
 Markdown formatting
 ~~~~~~~~~~~~~~~~~~~~
 
-A rich range of formatting unavailable in Slack is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by incoming webhooks.
+A rich range of formatting is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by incoming webhooks.
 
 For example, to create a message with a heading, and an italicized text on the next line, use the following payload. 
 
@@ -170,7 +170,7 @@ Tips and Best Practices
 
 3. You can restrict who can create incoming webhooks in `System Console > Integrations > Custom Integrations <https://docs.mattermost.com/administration/config-settings.html#restrict-managing-integrations-to-admins>`_.
 
-4. Mattermost incoming webhooks are Slack-compatible. You can copy-and-paste code used for a Slack incoming webhook to create Mattermost integrations. Mattermost `automatically translates the Slack's proprietary JSON payload format <../developer/webhooks-incoming#translate-slacks-proprietary-data-format-to-mattermost>`_.
+4. Mattermost incoming webhooks are Slack-compatible. You can copy-and-paste code used for a Slack incoming webhook to create Mattermost integrations. Mattermost `automatically translates the Slack's proprietary JSON payload format <../developer/webhooks-incoming#translate-slacks-data-format-to-mattermost>`_.
 
 5. The external application may be written in any programming language as long as it supports sending an HTTP POST request in the required JSON format to a specified Mattermost URL.
 
@@ -192,8 +192,8 @@ Slack Compatibility
 
 Mattermost makes it easy to migrate integrations written for Slack to Mattermost. 
 
-Translate Slack's proprietary data format to Mattermost
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Translate Slack's data format to Mattermost
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mattermost automatically translates the data coming from Slack:
 

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -160,7 +160,7 @@ Channels can be mentioned by including *@channel* or *<!channel>*. For example:
 Markdown formatting
 ~~~~~~~~~~~~~~~~~~~~
 
-A rich range of formatting unavailable in Slack is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by outgoing webhooks.
+A rich range of formatting is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by outgoing webhooks.
 
 For example, to create a message with a heading, and an italicized text on the next line, use the following response. 
 
@@ -193,7 +193,7 @@ Tips and Best Practices
 
 4. You can restrict who can create outgoing webhooks in `System Console > Integrations > Custom Integrations <https://docs.mattermost.com/administration/config-settings.html#restrict-managing-integrations-to-admins>`_.
 
-5. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates the Slack's proprietary JSON response format <../developer/webhooks-outgoing#translate-slacks-proprietary-data-format-to-mattermost>`_.
+5. Mattermost outgoing webhooks are Slack-compatible. You can copy-and-paste code used for a Slack outgoing webhook to create Mattermost integrations. Mattermost `automatically translates the Slack's proprietary JSON response format <../developer/webhooks-outgoing#translate-slacks-data-format-to-mattermost>`_.
 
 6. The external application may be written in any programming language. It needs to provide a URL which reacts to the request sent by your Mattermost server, and send an HTTP POST in the required JSON format as a response.
  
@@ -209,8 +209,8 @@ Slack Compatibility
 
 Mattermost makes it easy to migrate integrations written for Slack to Mattermost. 
 
-Translate Slack's proprietary data format to Mattermost
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Translate Slack's data format to Mattermost
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mattermost automatically translates the data coming from Slack:
 

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -160,7 +160,7 @@ Channels can be mentioned by including *@channel* or *<!channel>*. For example:
 Markdown formatting
 ~~~~~~~~~~~~~~~~~~~~
 
-A rich range of formatting is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost Markdown. All of these options are also supported by outgoing webhooks.
+A rich range of formatting is made possible through :doc:`markdown support <../help/messaging/formatting-text>` in Mattermost, including headings, formatted fonts, tables, inline images and other options supported by Mattermost markdown. All of these options are also supported by outgoing webhooks.
 
 For example, to create a message with a heading, and an italicized text on the next line, use the following response. 
 


### PR DESCRIPTION
"unavailable in Slack": irrelevant.
"Slack's proprietary JSON format": is there some standard format for workflow process apps to export JSON in comparison? If not then it's not necessary to differentiate.