### PR TITLE
Certificate-based authentication docs

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -3298,6 +3298,32 @@ To include every blocking event in the profile, set the rate to 1. To turn off p
 | This feature's ``config.json`` setting is ``"BlockProfileRate": "0"`` with decimal and whole number input between 0 and 1.                                           |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+Experimental Settings
+~~~~~~~~~~~~~~~~~~~~~~~~~
+*Available in Enterprise Edition E20*
+
+Enable Client-Side Certification
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**True**: Enables client-side certification for your Mattermost server. See `documentation <https://docs.mattermost.com/deployment/certificate-based-authentication.html>`_ to learn more.
+
+**False**: Client-side certification is disabled.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ClientSideCertEnable": false`` with options ``true`` and ``false`` for the above settings respectively.                 |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Client-Side Certification Login Method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Used in combination with the ``ClientSideCertEnable`` setting.
+
+**Primary**: After the client side certificate is verified, user's email is retrieved from the certificate and is used to log in without a password.
+
+**Secondary**: After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ClientSideCertCheck": secondary`` with options ``primary`` and ``secondary`` for the above settings respectively.       |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
 Analytics Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 *Available in Enterprise Edition E10 and higher*

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -11,8 +11,14 @@ Follow these steps to configure user CBA for your browser, Mattermost Desktop Ap
   :backlinks: top
   :local:
   :depth: 2
-  
-// XXX Consider breaking this into two stories: one about CBA for device (first half) and one about CBA for user (second half, involving the PureBred integration, extra config settings, and targeted for G20 SKU)
+
+Test
+~~~~~
+
+// XXX work in progress. To be updated once PR is finished and merged. Currently requires a special build from the `mm-cba-proto server branch <https://github.com/mattermost/mattermost-server/tree/mm-cba-proto>`_ licensed with Enterprise E20 key.
+
+The Mattermost server can be used to log in with a client side certifiate supplied as part of mutual TLS authentication from above. This guide has made some simple assumptions about how the certificates map to Mattermost users.
+
 
 Set Up mutual TLS authentication for the Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -24,8 +30,6 @@ In addition to thes steps for the Mattermost Web App and the Desktop Apps, more 
 .. note::
   For the purposes of this guide, the Mattermost server domain name is example.mattermost.com, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.
 
-// XXX Should we recommend MDM providers for iOS/Android apps for CBA on device? PureBred is for CBA on user for iOS only.
- 
 1. Create a `certificate authority (CA) key <https://en.wikipedia.org/wiki/Certificate_authority>`_ and a certificate for signing the client certificate. When establishing a TLS connection, the NGINX proxy server requests and validates a client certificate provided by the web app.
 
 .. code-block::
@@ -106,7 +110,7 @@ In addition to thes steps for the Mattermost Web App and the Desktop Apps, more 
  
   ...
 
-6. Confirm the CA key for ``mmuser`` works by the following curl command to the Mattermost proxy // XXX Do you mean NGINX proxy?
+6. Confirm the CA key for ``mmuser`` works by the following curl command to the proxy
 
 .. code-block::
 
@@ -137,20 +141,12 @@ You should see the Mattermost login page. If you see:
 Set up Mattermost server to log in with a client certificate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// XXX work in progress. To be updated once PR is finished and merged. Currently requires a special build from the `mm-cba-proto server branch <https://github.com/mattermost/mattermost-server/tree/mm-cba-proto>`_ licensed with Enterprise E20 key.
-
-// XXX Proof of concept video for webapp https://drive.google.com/file/d/1CmTvoxdbDhHlAsl_lu8TzItsRTt4rgkA/view
-// XXX Proof of concept video for mobile https://drive.google.com/file/d/1TRhSie5zjV72XHRReKriD-h9xgNDJAMr/view
-
-The Mattermost server can be used to log in with a client side certifiate supplied as part of mutual TLS authentication from above. This guide has made simple assumptions about how the certificates map to Mattermost users.
-
-1. First, set up mutual TLS authentication via the NGINX proxy using the steps above.
-2. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
+1. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
 
 - ``primary`` - After the client side certificate is verified, user's email is retrieved from the certificate and used to log in without a password.
 - ``secondary`` - After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
 
-3. Restart the Mattermost server.
+2. Restart the Mattermost server.
 
 On Ubuntu 14.04 and RHEL 6.6:
 
@@ -164,14 +160,10 @@ On Ubuntu 16.04, Debian Jessie, and RHEL 7.1:
 
   sudo systemctl restart mattermost
 
-4. Go to https://example.mattermost.com and try to log in . The server should require the x.509 cert to have an ``emailAddress`` equal to the Mattermost user's email.
-
-// XXX Next sections will be revised once PureBred implementation is finished for iOS. It supports PureBred key management on iOS with the CBA happening via mutual TLS as per the above set up.
+3. Go to https://example.mattermost.com and try to log in. The server should require the x.509 cert to have an ``emailAddress`` equal to the Mattermost user's email.
 
 Set up Purebred sample apps on iOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-// XXX These will likely be removed from the final docs, but I did a quick formatting edit for this section anyway.
 
 1. Clone the sample repos from `https://github.com/Purebred/KeyShareConsumer <https://github.com/Purebred/KeyShareConsumer>`_ and `https://github.com/Purebred/SampleKeyProvider <https://github.com/Purebred/SampleKeyProvider>`_.
 2. Replace all ``red.hound`` strings with ``com.mattermost``.
@@ -201,9 +193,8 @@ Set up Purebred sample apps on iOS
 Run the modified Mattermost React Native Mobile App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// XXX work in progress. To be updated once PR is finished and merged. Currently requires a special build from the `mm-cba-proto mobile branch <https://github.com/mattermost/mattermost-mobile/tree/mm-cba-proto>`_.
-
-1. Import the certificate from the previous section above into the Mattermost iOS App.
-2. TBD: Use the certificate for mutual TLS authentication. About 2 weeks of development work is still required to modify the underlying Mattermost React Native code to support this step.
-3. TBD: A user account is created automatically on first use. Requires development work to support this step.
-4. TBD: The login credentials for email/password are bypassed, and instead a login button is displayed similar to SAML 2.0 SSO. Requires development work to support this step.
+1. Fork the `cba <https://github.com/mattermost/mattermost-mobile/blob/cba>`_ branch from the mattermost-mobile repository.
+2. Set **ExperimentalClientSideCertEnable** to ``true`` in the `mattermost-mobile/assets/base/config.json <https://github.com/mattermost/mattermost-mobile/blob/cba/assets/base/config.json#L15>`_ file.
+3. `Use this guide <https://docs.mattermost.com/mobile/mobile-compile-yourself.html>`_ to build the apps based on the branch you created and modified in steps 1 and 2.
+4. Import the certificate from the previous section above into the Mattermost iOS App and use it for mutual TLS authentication. You can `watch a demonstration video of this step here <https://drive.google.com/file/d/1zzk9XQ6RBvsWbCTrIfgE0484pD7w9Ux1/view>`_.
+5. A user account is created automatically on first use, and the login credentials for email/password are bypassed with a button to sign in with the client-side certificate instead.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -1,0 +1,209 @@
+Certificate-Based Authentication (E20)
+=======================================
+
+Certificate-based authentication (CBA) can be used identify a user or a device before granting access to Mattermost, providing an additional layer of security to access the system.
+
+Enterprise Edition E20 supports device CBA with client side certificates through SAML 2.0 SSO and mutual TLS authentication at the NGINX proxy level. Additional configuration is required for user CBA.
+
+Follow these steps to configure user CBA for your browser, Mattermost Desktop Apps, and the Mattermost iOS App. Before you begin, follow the `official guides to install Mattermost <https://docs.mattermost.com/guides/administrator.html#installing-mattermost>`_ on your system, including NGINX configuration as a proxy with SSL and HTTP/2, and a valid Let's Encrypt certificate.
+
+.. contents::
+  :backlinks: top
+  :local:
+  :depth: 2
+  
+// XXX Should break this into two stories: one about CBA for device (first half) and one about CBA for user (second half, involving the PureBred integration, extra config settings, and targeted for government)
+
+Set Up mutual TLS authentication for the Web App
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enterprise Edition E20 supports device CBA with client side certificates through SAML 2.0 SSO and mutual TLS authentication at the NGINX proxy level. Many SAML service providers support certificate authentication, such as `ADFS and Azure AD <https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configure-user-certificate-authentication>`_.
+
+In addition to thes steps for the Mattermost Web App and the Desktop Apps, more information about setting up mutual TLS authentication `can be found here <https://blog.codeship.com/how-to-set-up-mutual-tls-authentication/>`_.
+
+.. note::
+  For the purposes of this guide, the Mattermost server domain name is example.mattermost.com, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.
+
+// XXX Should we recommend MDM providers for iOS/Android apps for CBA on device? PureBred is for CBA on user for iOS only.
+ 
+1. Create a `certificate authority (CA) key <https://en.wikipedia.org/wiki/Certificate_authority>`_ and a certificate for signing the client certificate. When establishing a TLS connection, the NGINX proxy server requests and validates a client certificate provided by the web app.
+
+.. code-block::
+
+  openssl genrsa -des3 -out ca.mattermost.key 4096
+
+  pass phrase: capassword
+
+.. code-block::
+
+  openssl req -new -x509 -days 365 -key ca.mattermost.key -out ca.mattermost.crt
+
+  Country Name: US
+  State: Maryland
+  Locality Name: Meade
+  Organization Name: Mattermost
+  Organization Unit: Smarttotem
+  Common Name: example.mattermost.com
+  Email Address: admin@mattermost.com
+
+2. Create the client side key for ``mmuser`` with a passphrase, and the certificate signing request:
+
+.. code-block::
+
+  openssl genrsa -des3 -out mmuser-mattermost.key 1024
+
+  passphrase: mmuser-passphrase
+
+.. code-block::
+
+  openssl req -new -key mmuser-mattermost.key -out mmuser-mattermost.csr
+
+  Country Name: US
+  State: Maryland
+  Locality Name: Meade
+  Organization Name: Mattermost
+  Organization Unit: Smarttotem
+  Common Name: mmuser
+  Email Address: mmuser@mattermost.com
+
+  Challenge password: mmuser-passphrase
+
+3. Sign the user's client certificate with the previously created CA certificate.
+
+.. code-block::
+
+  openssl x509 -req -days 365 -in mmuser-mattermost.csr -CA ca.mattermost.crt -CAkey ca.mattermost.key -set_serial 01 -out mmuser-mattermost.crt
+
+
+4. Check the newly generated client certificate for ``mmuser``
+
+.. code-block::
+
+  openssl x509 -in mmuser-mattermost.crt -text -noout
+
+5. Open the file ``/etc/nginx/sites-available/mattermost`` and modify the following lines, so that the NGINX proxy server requests and verifies the client certificate:
+
+.. code-block::
+  :emphasize-lines: 4-5, 10-11, 16-17
+
+  ssl on;
+  ssl_certificate /etc/letsencrypt/live/example.mattermost.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/example.mattermost.com/privkey.pem;
+  ssl_client_certificate /opt/mattermost/config/ca.mattermost.crt;
+  ssl_verify_client on;
+
+  ...
+
+  location ~ /api/v[0-9]+/(users/)?websocket$ {
+   proxy_set_header X-SSL-Client-Cert $ssl_client_cert;
+   proxy_set_header X-SSL-Client-Cert-Subject-DN $ssl_client_s_dn;
+     
+  ...
+
+  location / {
+   proxy_set_header X-SSL-Client-Cert $ssl_client_cert;
+   proxy_set_header X-SSL-Client-Cert-Subject-DN $ssl_client_s_dn;
+ 
+  ...
+
+6. Confirm the CA key for ``mmuser`` works by the following curl command to the Mattermost proxy // XXX Do you mean NGINX proxy?
+
+.. code-block::
+
+  curl -v -s -k --key mmuser-mattermost.key --cert mmuser-mattermost.crt:mmuser-passphrase https://example.mattermost.com
+
+You should see the Mattermost login page. If you see:
+
+ - ``No required SSL certificate was sent``, something went wrong. Review the above steps and try again.
+ - ``* error reading X.509 key or certificate file: Decryption has failed.``, make sure the passphrase is included together with the certificate, because curl doesn't prompt for it separately. 
+
+7. Generate a PKCS12 file from the CA key and certificate, to install the certificate into your client machine for your browser to use.
+
+.. code-block::
+
+  openssl pkcs12 -export -out mmuser-mattermost.p12 -inkey mmuser-mattermost.key -in mmuser-mattermost.crt -certfile ca.mattermost.crt
+
+  Enter Export Password: mmuser-passphrase
+
+8. Repeat steps 2-7 above for other users as needed.
+
+9. Import the generated .p12 file in step 7 into your key chain. In the Chrome browser on macOS:
+
+		1. Go to **Settings > Advanced > Privacy and security > Manage certificates**. This opens the Keychain Access app.
+		2. Go to **File > Import Items** and select the ``mmuser-mattermost.p12`` file.
+
+10. Go to https://example.mattermost.com. You should see a popup for the client certifcate request.
+
+Set up Mattermost server to log in with a client certificate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// XXX work in progress. To be updated once PR is finished and merged. Currently requires a special build from the `mm-cba-proto server branch <https://github.com/mattermost/mattermost-server/tree/mm-cba-proto>`_ licensed with Enterprise E20 key.
+
+// XXX Proof of concept video for webapp https://drive.google.com/file/d/1CmTvoxdbDhHlAsl_lu8TzItsRTt4rgkA/view
+// XXX Proof of concept video for mobile https://drive.google.com/file/d/1TRhSie5zjV72XHRReKriD-h9xgNDJAMr/view
+
+The Mattermost server can be used to log in with a client side certifiate supplied as part of mutual TLS authentication from above. This guide has made simple assumptions about how the certificates map to Mattermost users.
+
+1. First, set up mutual TLS authentication via the NGINX proxy using the steps above.
+2. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
+
+- ``primary`` - After the client side certificate is verified, user's email is retrieved from the certificate and used to log in without a password.
+- ``secondary`` - After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
+
+3. Restart the Mattermost server.
+
+On Ubuntu 14.04 and RHEL 6.6:
+
+.. code-block::
+
+  sudo restart mattermost
+
+On Ubuntu 16.04, Debian Jessie, and RHEL 7.1:
+
+.. code-block::
+
+  sudo systemctl restart mattermost
+
+4. Go to https://example.mattermost.com and try to log in . The server should require the x.509 cert to have an ``emailAddress`` equal to the Mattermost user's email.
+
+// XXX Next sections will be revised once PureBred implementation is finished for iOS. It supports PureBred key management on iOS with the CBA happening via mutual TLS as per the above set up.
+
+Set up Purebred sample apps on iOS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// XXX These will likely be removed from the final docs, but I did a quick formatting edit for this section.
+
+1. Clone the sample repos from `https://github.com/Purebred/KeyShareConsumer <https://github.com/Purebred/KeyShareConsumer>`_ and `https://github.com/Purebred/SampleKeyProvider <https://github.com/Purebred/SampleKeyProvider>`_.
+2. Replace all ``red.hound`` strings with ``com.mattermost``.
+3. Open the KeyShareConsumer and SampleKeyProvider apps. Go to **Project settings > Target > ...**
+
+    - Verify all the bundle indentifiers are renamed to ``com.mattermost`.
+    - Select **Mattermost Team** for the signing profile.
+
+.. note::
+  A real iOS device is required to run the sample apps, since some of the libraries do not target ``x86_amd64``.
+
+4. Run both apps on the device and confirm they can interact with each other on the device.
+5. Import one of the existing sample keys from the SampleKeyProvider app to KeyShareConsumer app.
+6. If the import succeeds, then import the ``mmuser-mattermost.p12`` certificate into the SampleKeyProvider app.
+7. Modify ``ViewController.m`` by adding the following:
+
+.. code-block::
+
+  NSURL* fifth = [NSURL URLWithString:[[NSBundle mainBundle] pathForResource:@"mmuser-mattermost" ofType:@"p12"]];
+  OSStatus stat5 = [Pkcs12ViewController importP12:fifth password:@"mmuser-passphrase" deleteAfterImport:false];
+    
+  if(0 == stat1 && 0 == stat2 && 0 == stat3 && 0 == stat4 && 0 == stat5)
+  {
+
+9. Rerun the sample, and import the new key ``mmuser-mattermost.p12`` which appears as ``mmuser``. Confirm everything works with the sample apps.
+
+Run the modified Mattermost React Native Mobile App
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// XXX work in progress. To be updated once PR is finished and merged. Currently requires a special build from the `mm-cba-proto mobile branch <https://github.com/mattermost/mattermost-mobile/tree/mm-cba-proto>`_.
+
+1. Import the certificate from the previous section above into the Mattermost iOS App.
+2. TBD: Use the certificate for mutual TLS authentication. About 2 weeks of development work is still required to modify the underlying Mattermost React Native code to support this step.
+3. TBD: A user account is created automatically on first use. Requires development work to support this step.
+4. TBD: The login credentials for email/password are bypassed, and instead a login button is displayed similar to SAML 2.0 SSO. Requires development work to support this step.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -12,7 +12,7 @@ Follow these steps to configure user CBA for your browser, Mattermost Desktop Ap
   :local:
   :depth: 2
   
-// XXX Should break this into two stories: one about CBA for device (first half) and one about CBA for user (second half, involving the PureBred integration, extra config settings, and targeted for government)
+// XXX Consider breaking this into two stories: one about CBA for device (first half) and one about CBA for user (second half, involving the PureBred integration, extra config settings, and targeted for G20 SKU)
 
 Set Up mutual TLS authentication for the Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -171,7 +171,7 @@ On Ubuntu 16.04, Debian Jessie, and RHEL 7.1:
 Set up Purebred sample apps on iOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// XXX These will likely be removed from the final docs, but I did a quick formatting edit for this section.
+// XXX These will likely be removed from the final docs, but I did a quick formatting edit for this section anyway.
 
 1. Clone the sample repos from `https://github.com/Purebred/KeyShareConsumer <https://github.com/Purebred/KeyShareConsumer>`_ and `https://github.com/Purebred/SampleKeyProvider <https://github.com/Purebred/SampleKeyProvider>`_.
 2. Replace all ``red.hound`` strings with ``com.mattermost``.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -10,14 +10,6 @@ Follow these steps to configure user CBA for your browser, Mattermost Desktop Ap
   :local:
   :depth: 2
 
-Run a custom build of the Mattermost server
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Fork the `mm-cba-proto <https://github.com/mattermost/mattermost-server/tree/mm-cba-proto>`_ branch from the mattermost-server repository.
-2. `Use this guide <https://docs.mattermost.com/developer/dev-setup.html>`_ to create a custom build of the server based on the branch from step 1.
-
-With this custom build, the Mattermost server can be used to log in with a client side certifiate supplied as part of mutual TLS authentication from above. This guide has made some simple assumptions about how the certificates map to Mattermost users.
-
 Set up mutual TLS authentication for the Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -26,6 +18,8 @@ Set up mutual TLS authentication for the Web App
 
 .. note::
   For the purposes of this guide, the Mattermost server domain name is example.mattermost.com, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.
+
+Before starting, you can download a binary built daily off of the `master` branch from here for testing: https://releases.mattermost.com/mattermost-platform/master/mattermost-enterprise-linux-amd64.tar.gz
 
 1. Create a `certificate authority (CA) key <https://en.wikipedia.org/wiki/Certificate_authority>`_ and a certificate for signing the client certificate. When establishing a TLS connection, the NGINX proxy server requests and validates a client certificate provided by the web app.
 
@@ -74,7 +68,6 @@ Set up mutual TLS authentication for the Web App
 .. code-block::
 
   openssl x509 -req -days 365 -in mmuser-mattermost.csr -CA ca.mattermost.crt -CAkey ca.mattermost.key -set_serial 01 -out mmuser-mattermost.crt
-
 
 4. Check the newly generated client certificate for ``mmuser``
 
@@ -137,7 +130,7 @@ You should see the Mattermost login page. If you see:
 Set up Mattermost server to log in with a client certificate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Make sure the custom build from the ``mm-cba-proto`` branch is licensed with a valid Enterprise Edition E20 license.
+1. Make sure your Mattermost server is licensed with a valid Enterprise Edition E20 license.
 2. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
 
 - ``primary`` - After the client side certificate is verified, user's email is retrieved from the certificate and used to log in without a password.
@@ -171,7 +164,7 @@ On Ubuntu 16.04, Debian Jessie, and RHEL 7.1:
 Run the modified Mattermost React Native Mobile App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Fork the `cba <https://github.com/mattermost/mattermost-mobile/blob/cba>`_ branch from the mattermost-mobile repository.
-2. Set **ExperimentalClientSideCertEnable** to ``true`` in the `mattermost-mobile/assets/base/config.json <https://github.com/mattermost/mattermost-mobile/blob/cba/assets/base/config.json#L15>`_ file.
+1. Fork the `master <https://github.com/mattermost/mattermost-mobile/blob/master>`_ branch from the mattermost-mobile repository.
+2. Set **ExperimentalClientSideCertEnable** to ``true`` in the `mattermost-mobile/assets/base/config.json <https://github.com/mattermost/mattermost-mobile/blob/master/assets/base/config.json#L15>`_ file.
 3. `Use this guide <https://docs.mattermost.com/mobile/mobile-compile-yourself.html>`_ to build the apps based on the branch you created and modified in steps 1 and 2.
 4. Import the certificate from the previous section above into the Mattermost iOS App and use it for mutual TLS authentication. You can `watch a demonstration video of this step here <https://drive.google.com/file/d/1zzk9XQ6RBvsWbCTrIfgE0484pD7w9Ux1/view>`_.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -165,34 +165,6 @@ On Ubuntu 16.04, Debian Jessie, and RHEL 7.1:
 
 4. Go to https://example.mattermost.com and try to log in. The server should require the x.509 cert to have an ``emailAddress`` equal to the Mattermost user's email.
 
-Set up Purebred sample apps on iOS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-  A real iOS device is required to run the sample apps, since some of the libraries do not target ``x86_amd64``.
-
-1. Clone the sample repos from `https://github.com/Purebred/KeyShareConsumer <https://github.com/Purebred/KeyShareConsumer>`_ and `https://github.com/Purebred/SampleKeyProvider <https://github.com/Purebred/SampleKeyProvider>`_.
-2. Replace all ``red.hound`` strings with ``com.mattermost``.
-3. Open the KeyShareConsumer and SampleKeyProvider apps. Go to **Project settings > Target > ...**
-
-    - Verify all the bundle indentifiers are renamed to ``com.mattermost`.
-    - Select **Mattermost Team** for the signing profile.
-
-4. Run both apps on the device and confirm they can interact with each other on the device.
-5. Import one of the existing sample keys from the SampleKeyProvider app to KeyShareConsumer app.
-6. If the import succeeds, then import (or drag-and-drop) the ``mmuser-mattermost.p12`` certificate into the SampleKeyProvider app.
-7. Modify ``ViewController.m`` by adding the following:
-
-.. code-block::
-
-  NSURL* fifth = [NSURL URLWithString:[[NSBundle mainBundle] pathForResource:@"mmuser-mattermost" ofType:@"p12"]];
-  OSStatus stat5 = [Pkcs12ViewController importP12:fifth password:@"mmuser-passphrase" deleteAfterImport:false];
-    
-  if(0 == stat1 && 0 == stat2 && 0 == stat3 && 0 == stat4 && 0 == stat5)
-  {
-
-8. Rerun the sample, and import the new key ``mmuser-mattermost.p12`` which appears as ``mmuser``. Confirm everything works with the sample apps.
-
 Run the modified Mattermost React Native Mobile App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -3,8 +3,6 @@ Certificate-Based Authentication (E20)
 
 Certificate-based authentication (CBA) can be used identify a user or a device before granting access to Mattermost, providing an additional layer of security to access the system.
 
-Enterprise Edition E20 supports device CBA with client side certificates through SAML 2.0 SSO and mutual TLS authentication at the NGINX proxy level. Additional configuration is required for user CBA.
-
 Follow these steps to configure user CBA for your browser, Mattermost Desktop Apps, and the Mattermost iOS App. Before you begin, follow the `official guides to install Mattermost <https://docs.mattermost.com/guides/administrator.html#installing-mattermost>`_ on your system, including NGINX configuration as a proxy with SSL and HTTP/2, and a valid Let's Encrypt certificate.
 
 .. contents::
@@ -22,10 +20,6 @@ With this custom build, the Mattermost server can be used to log in with a clien
 
 Set up mutual TLS authentication for the Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Enterprise Edition E20 supports device CBA with client side certificates through SAML 2.0 SSO and mutual TLS authentication at the NGINX proxy level. Many SAML service providers support certificate authentication, such as `ADFS and Azure AD <https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configure-user-certificate-authentication>`_.
-
-In addition to thes steps for the Mattermost Web App and the Desktop Apps, more information about setting up mutual TLS authentication `can be found here <https://blog.codeship.com/how-to-set-up-mutual-tls-authentication/>`_.
 
 .. note::
   For the purposes of this guide, the Mattermost server domain name is example.mattermost.com, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -12,15 +12,15 @@ Follow these steps to configure user CBA for your browser, Mattermost Desktop Ap
   :local:
   :depth: 2
 
-Test
-~~~~~
+Run a custom build of the Mattermost server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// XXX work in progress. To be updated once PR is finished and merged. Currently requires a special build from the `mm-cba-proto server branch <https://github.com/mattermost/mattermost-server/tree/mm-cba-proto>`_ licensed with Enterprise E20 key.
+1. Fork the `mm-cba-proto <https://github.com/mattermost/mattermost-server/tree/mm-cba-proto>`_ branch from the mattermost-server repository.
+2. `Use this guide <https://docs.mattermost.com/developer/dev-setup.html>`_ to create a custom build of the server based on the branch from step 1.
 
-The Mattermost server can be used to log in with a client side certifiate supplied as part of mutual TLS authentication from above. This guide has made some simple assumptions about how the certificates map to Mattermost users.
+With this custom build, the Mattermost server can be used to log in with a client side certifiate supplied as part of mutual TLS authentication from above. This guide has made some simple assumptions about how the certificates map to Mattermost users.
 
-
-Set Up mutual TLS authentication for the Web App
+Set up mutual TLS authentication for the Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Enterprise Edition E20 supports device CBA with client side certificates through SAML 2.0 SSO and mutual TLS authentication at the NGINX proxy level. Many SAML service providers support certificate authentication, such as `ADFS and Azure AD <https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configure-user-certificate-authentication>`_.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -1,9 +1,9 @@
 Certificate-Based Authentication (E20)
 =======================================
 
-Certificate-based authentication (CBA) can be used identify a user or a device before granting access to Mattermost, providing an additional layer of security to access the system.
+Certificate-based authentication (CBA) can be used to identify a user or a device before granting access to Mattermost, providing an additional layer of security to access the system.
 
-Follow these steps to configure user CBA for your browser, Mattermost Desktop Apps, and the Mattermost iOS App. Before you begin, follow the `official guides to install Mattermost <https://docs.mattermost.com/guides/administrator.html#installing-mattermost>`_ on your system, including NGINX configuration as a proxy with SSL and HTTP/2, and a valid Let's Encrypt certificate.
+Follow these steps to configure user CBA for your browser, Mattermost Desktop Apps, and the Mattermost iOS App. Before you begin, follow the `official guides to install Mattermost <https://docs.mattermost.com/guides/administrator.html#installing-mattermost>`_ on your system, including NGINX configuration as a proxy with SSL and HTTP/2, and a valid SSL certificate such as Let's Encrypt.
 
 .. contents::
   :backlinks: top
@@ -20,6 +20,9 @@ With this custom build, the Mattermost server can be used to log in with a clien
 
 Set up mutual TLS authentication for the Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+  Generating the client certificates in this section is optional if you have already generated them before.
 
 .. note::
   For the purposes of this guide, the Mattermost server domain name is example.mattermost.com, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -88,7 +88,6 @@ In addition to thes steps for the Mattermost Web App and the Desktop Apps, more 
 5. Open the file ``/etc/nginx/sites-available/mattermost`` and modify the following lines, so that the NGINX proxy server requests and verifies the client certificate:
 
 .. code-block::
-  :emphasize-lines: 4-5, 10-11, 16-17
 
   ssl on;
   ssl_certificate /etc/letsencrypt/live/example.mattermost.com/fullchain.pem;
@@ -136,17 +135,27 @@ You should see the Mattermost login page. If you see:
 		1. Go to **Settings > Advanced > Privacy and security > Manage certificates**. This opens the Keychain Access app.
 		2. Go to **File > Import Items** and select the ``mmuser-mattermost.p12`` file.
 
-10. Go to https://example.mattermost.com. You should see a popup for the client certifcate request.
+10. Go to https://example.mattermost.com. You should see a popup for the client certificate request.
 
 Set up Mattermost server to log in with a client certificate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
+1. Make sure the custom build from the ``mm-cba-proto`` branch is licensed with a valid Enterprise Edition E20 license.
+2. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
 
 - ``primary`` - After the client side certificate is verified, user's email is retrieved from the certificate and used to log in without a password.
 - ``secondary`` - After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
 
-2. Restart the Mattermost server.
+The ``config.json`` file should then have the following lines
+
+.. code-block::
+
+  "ExperimentalSettings": {
+      "ClientSideCertEnable": true,
+      "ClientSideCertCheck": "secondary"
+  },
+
+3. Restart the Mattermost server.
 
 On Ubuntu 14.04 and RHEL 6.6:
 
@@ -160,10 +169,13 @@ On Ubuntu 16.04, Debian Jessie, and RHEL 7.1:
 
   sudo systemctl restart mattermost
 
-3. Go to https://example.mattermost.com and try to log in. The server should require the x.509 cert to have an ``emailAddress`` equal to the Mattermost user's email.
+4. Go to https://example.mattermost.com and try to log in. The server should require the x.509 cert to have an ``emailAddress`` equal to the Mattermost user's email.
 
 Set up Purebred sample apps on iOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+  A real iOS device is required to run the sample apps, since some of the libraries do not target ``x86_amd64``.
 
 1. Clone the sample repos from `https://github.com/Purebred/KeyShareConsumer <https://github.com/Purebred/KeyShareConsumer>`_ and `https://github.com/Purebred/SampleKeyProvider <https://github.com/Purebred/SampleKeyProvider>`_.
 2. Replace all ``red.hound`` strings with ``com.mattermost``.
@@ -172,12 +184,9 @@ Set up Purebred sample apps on iOS
     - Verify all the bundle indentifiers are renamed to ``com.mattermost`.
     - Select **Mattermost Team** for the signing profile.
 
-.. note::
-  A real iOS device is required to run the sample apps, since some of the libraries do not target ``x86_amd64``.
-
 4. Run both apps on the device and confirm they can interact with each other on the device.
 5. Import one of the existing sample keys from the SampleKeyProvider app to KeyShareConsumer app.
-6. If the import succeeds, then import the ``mmuser-mattermost.p12`` certificate into the SampleKeyProvider app.
+6. If the import succeeds, then import (or drag-and-drop) the ``mmuser-mattermost.p12`` certificate into the SampleKeyProvider app.
 7. Modify ``ViewController.m`` by adding the following:
 
 .. code-block::
@@ -188,7 +197,7 @@ Set up Purebred sample apps on iOS
   if(0 == stat1 && 0 == stat2 && 0 == stat3 && 0 == stat4 && 0 == stat5)
   {
 
-9. Rerun the sample, and import the new key ``mmuser-mattermost.p12`` which appears as ``mmuser``. Confirm everything works with the sample apps.
+8. Rerun the sample, and import the new key ``mmuser-mattermost.p12`` which appears as ``mmuser``. Confirm everything works with the sample apps.
 
 Run the modified Mattermost React Native Mobile App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -197,4 +206,3 @@ Run the modified Mattermost React Native Mobile App
 2. Set **ExperimentalClientSideCertEnable** to ``true`` in the `mattermost-mobile/assets/base/config.json <https://github.com/mattermost/mattermost-mobile/blob/cba/assets/base/config.json#L15>`_ file.
 3. `Use this guide <https://docs.mattermost.com/mobile/mobile-compile-yourself.html>`_ to build the apps based on the branch you created and modified in steps 1 and 2.
 4. Import the certificate from the previous section above into the Mattermost iOS App and use it for mutual TLS authentication. You can `watch a demonstration video of this step here <https://drive.google.com/file/d/1zzk9XQ6RBvsWbCTrIfgE0484pD7w9Ux1/view>`_.
-5. A user account is created automatically on first use, and the login credentials for email/password are bypassed with a button to sign in with the client-side certificate instead.

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -1,5 +1,7 @@
-Certificate-Based Authentication (E20)
-=======================================
+Certificate-Based Authentication (Experimental)
+================================================
+
+*Available as an experimental feature in Enterprise Edition E20.*
 
 Certificate-based authentication (CBA) can be used to identify a user or a device before granting access to Mattermost, providing an additional layer of security to access the system.
 
@@ -13,119 +15,7 @@ Follow these steps to configure user CBA for your browser, Mattermost Desktop Ap
 Set up mutual TLS authentication for the Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-  Generating the client certificates in this section is optional if you have already generated them before.
-
-.. note::
-  For the purposes of this guide, the Mattermost server domain name is ``example.mattermost.com``, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.
-
-Before starting, you can download a binary built daily off of the `master` branch from here for testing: https://releases.mattermost.com/mattermost-platform/master/mattermost-enterprise-linux-amd64.tar.gz
-
-1. Create a `certificate authority (CA) key <https://en.wikipedia.org/wiki/Certificate_authority>`_ and a certificate for signing the client certificate. When establishing a TLS connection, the NGINX proxy server requests and validates a client certificate provided by the web app.
-
-.. code-block::
-
-  openssl genrsa -des3 -out ca.mattermost.key 4096
-
-  pass phrase: capassword
-
-.. code-block::
-
-  openssl req -new -x509 -days 365 -key ca.mattermost.key -out ca.mattermost.crt
-
-  Country Name: US
-  State: Maryland
-  Locality Name: Meade
-  Organization Name: Mattermost
-  Organization Unit: Smarttotem
-  Common Name: example.mattermost.com
-  Email Address: admin@mattermost.com
-
-2. Create the client side key for ``mmuser`` with a passphrase, and the certificate signing request:
-
-.. code-block::
-
-  openssl genrsa -des3 -out mmuser-mattermost.key 1024
-
-  passphrase: mmuser-passphrase
-
-.. code-block::
-
-  openssl req -new -key mmuser-mattermost.key -out mmuser-mattermost.csr
-
-  Country Name: US
-  State: Maryland
-  Locality Name: Meade
-  Organization Name: Mattermost
-  Organization Unit: Smarttotem
-  Common Name: mmuser
-  Email Address: mmuser@mattermost.com
-
-  Challenge password: mmuser-passphrase
-
-3. Sign the user's client certificate with the previously created CA certificate:
-
-.. code-block::
-
-  openssl x509 -req -days 365 -in mmuser-mattermost.csr -CA ca.mattermost.crt -CAkey ca.mattermost.key -set_serial 01 -out mmuser-mattermost.crt
-
-4. Check the newly generated client certificate for ``mmuser``:
-
-.. code-block::
-
-  openssl x509 -in mmuser-mattermost.crt -text -noout
-
-5. Open the file ``/etc/nginx/sites-available/mattermost`` and modify the following lines, so that the NGINX proxy server requests and verifies the client certificate:
-
-.. code-block::
-
-  ssl on;
-  ssl_certificate /etc/letsencrypt/live/example.mattermost.com/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/example.mattermost.com/privkey.pem;
-  ssl_client_certificate /opt/mattermost/config/ca.mattermost.crt;
-  ssl_verify_client on;
-
-  ...
-
-  location ~ /api/v[0-9]+/(users/)?websocket$ {
-   proxy_set_header X-SSL-Client-Cert $ssl_client_cert;
-   proxy_set_header X-SSL-Client-Cert-Subject-DN $ssl_client_s_dn;
-     
-  ...
-
-  location / {
-   proxy_set_header X-SSL-Client-Cert $ssl_client_cert;
-   proxy_set_header X-SSL-Client-Cert-Subject-DN $ssl_client_s_dn;
- 
-  ...
-
-6. Confirm the CA key for ``mmuser`` works by the following curl command to the proxy:
-
-.. code-block::
-
-  curl -v -s -k --key mmuser-mattermost.key --cert mmuser-mattermost.crt:mmuser-passphrase https://example.mattermost.com
-
-You should see the Mattermost login page. If you see:
-
- - ``No required SSL certificate was sent``, something went wrong. Review the above steps and try again.
- - ``* error reading X.509 key or certificate file: Decryption has failed.``, make sure the passphrase is included together with the certificate, because curl doesn't prompt for it separately. 
-
-7. Generate a PKCS12 file from the CA key and certificate, to install the certificate into your client machine for your browser to use:
-
-.. code-block::
-
-  openssl pkcs12 -export -out mmuser-mattermost.p12 -inkey mmuser-mattermost.key -in mmuser-mattermost.crt -certfile ca.mattermost.crt
-
-  Enter Export Password: mmuser-passphrase
-
-8. Repeat steps 2-7 above for other users as needed.
-
-9. Import the generated .p12 file in step 7 into your key chain. In the Chrome browser on macOS:
-
-		1. Go to **Settings > Advanced > Privacy and security > Manage certificates**. This opens the Keychain Access app.
-		2. Go to **File > Import Items** and select the ``mmuser-mattermost.p12`` file.
-
-10. Go to https://example.mattermost.com. You should see a popup for the client certificate request.
+This is the first step for setting up certificate-based authentication. If you haven't set up mutual TLS authentication yet, `see our documentation to learn more <https://docs.mattermost.com/deployment/ssl-client-certificate.html>`_.
 
 Set up Mattermost server to log in with a client certificate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/deployment/certificate-based-authentication.rst
+++ b/source/deployment/certificate-based-authentication.rst
@@ -17,7 +17,7 @@ Set up mutual TLS authentication for the Web App
   Generating the client certificates in this section is optional if you have already generated them before.
 
 .. note::
-  For the purposes of this guide, the Mattermost server domain name is example.mattermost.com, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.
+  For the purposes of this guide, the Mattermost server domain name is ``example.mattermost.com``, and the user account is ``mmuser`` with email ``mmuser@mattermost.com`` and password ``mmuser-password``.
 
 Before starting, you can download a binary built daily off of the `master` branch from here for testing: https://releases.mattermost.com/mattermost-platform/master/mattermost-enterprise-linux-amd64.tar.gz
 
@@ -63,13 +63,13 @@ Before starting, you can download a binary built daily off of the `master` branc
 
   Challenge password: mmuser-passphrase
 
-3. Sign the user's client certificate with the previously created CA certificate.
+3. Sign the user's client certificate with the previously created CA certificate:
 
 .. code-block::
 
   openssl x509 -req -days 365 -in mmuser-mattermost.csr -CA ca.mattermost.crt -CAkey ca.mattermost.key -set_serial 01 -out mmuser-mattermost.crt
 
-4. Check the newly generated client certificate for ``mmuser``
+4. Check the newly generated client certificate for ``mmuser``:
 
 .. code-block::
 
@@ -99,7 +99,7 @@ Before starting, you can download a binary built daily off of the `master` branc
  
   ...
 
-6. Confirm the CA key for ``mmuser`` works by the following curl command to the proxy
+6. Confirm the CA key for ``mmuser`` works by the following curl command to the proxy:
 
 .. code-block::
 
@@ -110,7 +110,7 @@ You should see the Mattermost login page. If you see:
  - ``No required SSL certificate was sent``, something went wrong. Review the above steps and try again.
  - ``* error reading X.509 key or certificate file: Decryption has failed.``, make sure the passphrase is included together with the certificate, because curl doesn't prompt for it separately. 
 
-7. Generate a PKCS12 file from the CA key and certificate, to install the certificate into your client machine for your browser to use.
+7. Generate a PKCS12 file from the CA key and certificate, to install the certificate into your client machine for your browser to use:
 
 .. code-block::
 
@@ -133,7 +133,7 @@ Set up Mattermost server to log in with a client certificate
 1. Make sure your Mattermost server is licensed with a valid Enterprise Edition E20 license.
 2. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
 
-- ``primary`` - After the client side certificate is verified, user's email is retrieved from the certificate and used to log in without a password.
+- ``primary`` - After the client side certificate is verified, user's email is retrieved from the certificate and is used to log in without a password.
 - ``secondary`` - After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
 
 The ``config.json`` file should then have the following lines
@@ -164,7 +164,7 @@ On Ubuntu 16.04, Debian Jessie, and RHEL 7.1:
 Run the modified Mattermost React Native Mobile App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Fork the `master <https://github.com/mattermost/mattermost-mobile/blob/master>`_ branch from the mattermost-mobile repository.
+1. Fork the `master <https://github.com/mattermost/mattermost-mobile>`_ branch from the mattermost-mobile repository.
 2. Set **ExperimentalClientSideCertEnable** to ``true`` in the `mattermost-mobile/assets/base/config.json <https://github.com/mattermost/mattermost-mobile/blob/master/assets/base/config.json#L15>`_ file.
 3. `Use this guide <https://docs.mattermost.com/mobile/mobile-compile-yourself.html>`_ to build the apps based on the branch you created and modified in steps 1 and 2.
 4. Import the certificate from the previous section above into the Mattermost iOS App and use it for mutual TLS authentication. You can `watch a demonstration video of this step here <https://drive.google.com/file/d/1zzk9XQ6RBvsWbCTrIfgE0484pD7w9Ux1/view>`_.

--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -52,6 +52,7 @@ Deployment
    /deployment/sso-ldap*
    /deployment/auth*
    /deployment/sso-saml.rst
+   /deployment/certificate-based-authentication*
    /deployment/scaling*
    /deployment/cluster.rst
    /deployment/elastic*


### PR DESCRIPTION
Items to resolve:

1) ~~The section about logging in with a client cert: "There is a lot of foot shooting potential with these settings"~~
2) ~~SSL client cert setup via TLS mutual auth was broken to its own doc here: https://docs.mattermost.com/deployment/ssl-client-certificate.html~~
3) ~~Document config settings~~