### PR TITLE
Update command-line-tools.rst

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -767,7 +767,7 @@ platform user migrate_auth
   Parameters
     -  ``from_auth``: The authentication service from which to migrate user accounts. Supported options: ``email``, ``gitlab``, ``saml``.
 
-    -  ``to_auth``: The authentication service to which to migrate user accounts. Supported options: ``ldap``.
+    -  ``to_auth``: The authentication service to which to migrate user accounts. Supported options: ``ldap``, ``saml``.
 
     -  ``match_field``: The field that is guaranteed to be the same in both authentication services. For example, if the user emails are consistent set to email. Supported options: ``email``, ``username``.
 


### PR DESCRIPTION
@jasonblais can you confirm the proposed change is correct? I think we now support switching to SAML auth as well? 

(Also do we support migrating from LDAP to SAML? I wasn't sure on that, if so we probably need to add ``ldap`` to the from auth field as well). 