### PR TITLE
4.10-docs

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -3577,6 +3577,17 @@ Town Square is Read-Only (Experimental)
 | This feature's ``config.json`` setting is ``"ExperimentalTownSquareIsReadOnly": false`` with options ``true`` and ``false`` for above settings respectively.                 |
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+Enable Automatic Replies (Experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**True**: Users can enable Automatic Replies in Account Settings > Notifications. Users set a custom message that will be automatically sent in response to Direct Messages.
+
+**False**: Disables the Automatic Direct Message Replies feature and hides it from Account Settings.
+
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalEnableAutomaticReplies": false`` with options ``true`` and ``false`` for above settings respectively.               |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
 Email Settings
 ~~~~~~~~~~~~~~
 

--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -73,7 +73,7 @@ Converting Public Channels to Private
 
 Click the channel name at the top of the center pane to access the drop-down menu, then click **Convert to Private Channel**. Team and System Admins have the ability to convert public channels to private channels. When a channel is converted, history and membership are preserved. Membership in a private channel is by invitation only. Publicly shared files remain accessible to anyone with the link. 
 
-Note that conversion of private channels to public channels is not supported given security concerns of sharing private channel history.
+Note that conversion of private channels to public channels is not supported in the user interface given security concerns of sharing private channel history; however, this function is available via `CLI command <https://docs.mattermost.com/administration/command-line-tools.html#platform-channel-modify>`_.
 
 Favoriting a Channel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -68,6 +68,13 @@ Click the channel name at the top of the center pane to access the drop-down men
 
 When a channel is deleted it is removed from the user interface, but an archived copy exists on the server in case it is needed for audit reasons later. Because of this, the URL of a newly created channel cannot be the same URL name as a deleted channel.
 
+Converting Public Channels to Private
+--------------------------------------
+
+Click the channel name at the top of the center pane to access the drop-down menu, then click **Convert to Private Channel**. Team and System Admins have the ability to convert public channels to private channels. When a channel is converted, history and membership are preserved. Membership in a private channel is by invitation only. Publicly shared files remain accessible to anyone with the link. 
+
+Note that conversion of private channels to public channels is not supported given security concerns of sharing private channel history.
+
 Favoriting a Channel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/help/settings/account-settings.rst
+++ b/source/help/settings/account-settings.rst
@@ -143,6 +143,10 @@ Reply Notifications
 
 In addition to **Words that Trigger Mentions**, this setting allows you to receive mention notifications when someone replies to a thread that you started or participated in. You are considered to start a thread when you post a message to which other members of your team reply. You are considered to participate in a thread when you post a message using the `reply button <https://docs.mattermost.com/help/getting-started/messaging-basics.html#messaging-basics>`_ in an already existing thread.
 
+Automatic Direct Message Replies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Set a custom message that will be automatically sent in response to Direct Messages. Mentions in Public and Private Channels will not trigger the automated reply. Enabling Automatic Replies sets your status to Out of Office and disables email and push notifications. This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html#automatic-direct-message-replies-experimental>`_.
+
 Display
 -------
 

--- a/source/help/settings/channel-settings.rst
+++ b/source/help/settings/channel-settings.rst
@@ -64,3 +64,10 @@ Channel Name
 In the channel menu, select **Rename Channel** to change the channel name or handle. Changing the channel handle changes the channel URL. Any channel
 member can edit this setting, unless the System Administrator has
 `restricted the permissions <https://docs.mattermost.com/administration/config-settings.html#enable-public-channel-renaming-for>`__.
+
+Convert Public Channels to Private
+----------------------------------
+
+Team and System Admins have the ability to convert public channels to private channels. When a channel is converted, history and membership are preserved. Membership in a private channel is by invitation only. Publicly shared files remain accessible to anyone with the link. 
+
+Note that conversion of private channels to public channels is not supported given security concerns of sharing private channel history.

--- a/source/help/settings/channel-settings.rst
+++ b/source/help/settings/channel-settings.rst
@@ -64,10 +64,3 @@ Channel Name
 In the channel menu, select **Rename Channel** to change the channel name or handle. Changing the channel handle changes the channel URL. Any channel
 member can edit this setting, unless the System Administrator has
 `restricted the permissions <https://docs.mattermost.com/administration/config-settings.html#enable-public-channel-renaming-for>`__.
-
-Convert Public Channels to Private
-----------------------------------
-
-Team and System Admins have the ability to convert public channels to private channels. When a channel is converted, history and membership are preserved. Membership in a private channel is by invitation only. Publicly shared files remain accessible to anyone with the link. 
-
-Note that conversion of private channels to public channels is not supported given security concerns of sharing private channel history.

--- a/source/help/settings/team-settings.rst
+++ b/source/help/settings/team-settings.rst
@@ -29,9 +29,9 @@ You can enter a description up to 50 characters in length.
 Team Icon
 ~~~~~~~~~~~~~~~~
 
-Your **Team Icon** appears in the team sidebar within the border of the existing team icons.
+Your **Team Icon** appears in the team sidebar, visible if users are members of more than one team. 
 
-You can upload a team icon in BMP, JPG or PNG format. Square images with a solid background color are recommended. Transparency in PNG icons will fill with a white background in the Team Sidebar.
+You can upload a team icon in BMP, JPG or PNG format. Square images with a solid background color are recommended, since transparency in PNG icons fills with a white background in the Team Sidebar. Removing the team icon resets the icon to default for all team members.
 
 Allow anyone to join this team
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/help/settings/team-settings.rst
+++ b/source/help/settings/team-settings.rst
@@ -31,7 +31,7 @@ Team Icon
 
 Your **Team Icon** appears in the team sidebar, visible if users are members of more than one team. 
 
-You can upload a team icon in BMP, JPG or PNG format. Square images with a solid background color are recommended, since transparency in PNG icons fills with a white background in the Team Sidebar. Removing the team icon resets the icon to default for all team members.
+You can upload a team icon in BMP, JPG or PNG format. Square images with a solid background color are recommended, since transparency in PNG icons fills with a white background in the Team Sidebar. Removing the team icon resets it to the default icon that contains the first two letters of the team name.
 
 Allow anyone to join this team
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Autoresponder
- Converting channel from public to private
- Team icon changes

Requested @grundleborg to submit a PR for the CLI command to reset permissions to default