### PR TITLE
Proposing download links

### DIFF
--- a/source/help/apps/desktop-changelog.rst
+++ b/source/help/apps/desktop-changelog.rst
@@ -4,9 +4,13 @@ Desktop Application Changelog
 Release v4.1.1
 ----------------------------
 
-Release date: May 17, 2018
-
 This release contains multiple bug fixes for Mac due to an incorrect build for v4.1.0. Windows and Linux apps are not affected.
+
+**Release date:** May 17, 2018
+
+**Download Binary:** `Windows 32-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win32.exe>`_ | `Windows 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win64.exe>`_ | `Mac <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-mac.zip>`_ | `Linux 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-linux-x64.tar.gz>`_ 
+
+**View Source Code:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop>`_
 
 Bug Fixes
 ~~~~~~~~~~~~~~~

--- a/source/help/apps/desktop-changelog.rst
+++ b/source/help/apps/desktop-changelog.rst
@@ -1,6 +1,23 @@
 Desktop Application Changelog
 ========================================
 
+Release v4.1.2
+----------------------------
+
+This release contains a bug fix for all platforms.
+
+- **Release date:** May 25, 2018
+- **Download Binary:** `Windows 32-bit <https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win32.exe>`_ | `Windows 64-bit <https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.exe>`_ | `Mac <https://releases.mattermost.com/desktop/4.1.2/mattermost-desktop-4.1.2-mac.zip>`_ | `Linux 64-bit <https://releases.mattermost.com/desktop/4.1.2/mattermost-desktop-4.1.2-linux-x64.tar.gz>`_ 
+- **View Source Code:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop/tree/v4.1.2>`_
+
+Bug Fixes
+~~~~~~~~~~~~~~~
+
+All Platforms
+^^^^^^^^^^^^^
+
+- Fixed an issue where the popup dialog to authenticate a user to their proxy or server didn't work.
+
 Release v4.1.1
 ----------------------------
 

--- a/source/help/apps/desktop-changelog.rst
+++ b/source/help/apps/desktop-changelog.rst
@@ -6,11 +6,9 @@ Release v4.1.1
 
 This release contains multiple bug fixes for Mac due to an incorrect build for v4.1.0. Windows and Linux apps are not affected.
 
-**Release date:** May 17, 2018
-
-**Download Binary:** `Windows 32-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win32.exe>`_ | `Windows 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win64.exe>`_ | `Mac <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-mac.zip>`_ | `Linux 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-linux-x64.tar.gz>`_ 
-
-**View Source Code:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop>`_
+- **Release date:** May 17, 2018
+- **Download Binary:** `Windows 32-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win32.exe>`_ | `Windows 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win64.exe>`_ | `Mac <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-mac.zip>`_ | `Linux 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-linux-x64.tar.gz>`_ 
+- **View Source Code:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop>`_
 
 Bug Fixes
 ~~~~~~~~~~~~~~~

--- a/source/help/apps/desktop-changelog.rst
+++ b/source/help/apps/desktop-changelog.rst
@@ -8,7 +8,7 @@ This release contains multiple bug fixes for Mac due to an incorrect build for v
 
 - **Release date:** May 17, 2018
 - **Download Binary:** `Windows 32-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win32.exe>`_ | `Windows 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-setup-4.1.1-win64.exe>`_ | `Mac <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-mac.zip>`_ | `Linux 64-bit <https://releases.mattermost.com/desktop/4.1.1/mattermost-desktop-4.1.1-linux-x64.tar.gz>`_ 
-- **View Source Code:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop>`_
+- **View Source Code:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop/tree/v4.1.1>`_
 
 Bug Fixes
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Propose adding download links to changelog so we can add a new menu option in Desktop App for `Desktop app -> Help -> Check for newer version` which would go the changelog and allow users to notice a new version, and download it right away. 

![image](https://user-images.githubusercontent.com/177788/40460317-eb7f71b6-5eba-11e8-9a10-33d0dad38746.png)


I've been waiting for 4.1.1 for a long time because of the loading animation. It was very difficult for me to check for a new version. This modification to our changelog process makes it easier to check for newer versions and immediately download once one is found. 

If we do this, propose creating a redirect link from mattermost.com so we don't hardcode to a page, and instead make a link that can be redirected easily in future.