### PR TITLE
Correct startup instructions

### DIFF
--- a/source/install/install-rhel-66-mattermost.rst
+++ b/source/install/install-rhel-66-mattermost.rst
@@ -49,10 +49,10 @@ Assume that the IP address of this server is 10.10.10.2
 
 8. Test the Mattermost server to make sure everything works.
 
-    a. Change to the ``bin`` directory:
-      ``cd /opt/mattermost/bin``
+    a. Change to the ``mattermost`` directory:
+      ``cd /opt/mattermost``
     b. Start the Mattermost server as the user *mattermost*:
-      ``sudo -u mattermost ./platform``
+      ``sudo -u mattermost ./bin/platform``
 
   When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 


### PR DESCRIPTION
Fix to prevent following error:
[2018/05/23 11:17:27 EDT] [EROR] failed to start up plugins: mkdir ./client/plugins: no such file or directory