### PR TITLE
prevent installation on SAN/NAS mounts

### DIFF
--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -62,6 +62,9 @@ Mattermost Server Operating System
 
 While community support exists for Fedora, FreeBSD and Arch Linux, Mattermost does not currently include production support for these platforms.
 
+.. note::
+  Please ensure that the directory you place your Mattermost installation in isn't a mounted SAN/NAS volume. This would have a negative performance impact.
+
 Database Software
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Added a note to prevent installation on SAN/NAS mounts as they may have a negative impact on the application server performance. Observed in customer environments.