### PR TITLE
document subpath support

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -36,17 +36,13 @@ The URL that users will use to access Mattermost. The port number is required if
 
 This field is required in Mattermost v3.8 and later.
 
+In Mattermost v5.1 and later, the URL may contain a subpath such as `https://example.com/company/mattermost`.
+
 If Site URL is not set, the following features will operate incorrectly:
 
  - email notifications will contain broken links, and email batching will not work
  - authentication via OAuth 2.0, including GitLab, Google and Office 365, will fail
  - plugins may not work as expected
-
-.. note:: Do not append a team name to the end of the site URL.
-
-Correct example: ``https://mattermost.example.com:8065``
-
-Incorrect example: ``https://mattermost.example.com/team_name``
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"SiteURL": ""`` with string input.                                                                     |

--- a/source/install/config-cloudfront.rst
+++ b/source/install/config-cloudfront.rst
@@ -7,12 +7,16 @@ Configuring CloudFront to host Mattermost's static assets allows for improved ca
 
 1. Create an S3 bucket using your desired domain. In our example it will be mattermost.example.com.
 2. Enable static hosting for your S3 bucket.
-3. From the Mattermost distribution, upload the ``client`` directory to S3 and rename it to ``static``. You can use the AWS CLI command below from within the ``client`` directory  to upload all the files to S3. The files must be publicly readable with the permission ``public-read``.
+3. If your SiteURL is configured with a subpath (such as https://example.com/company/mattermost), your static assets must be rewritten before uploading. You can use the command below to rewrite the assets for the given subpath:
+
+    ``mattermost config subpath --path /company/mattermost``
+
+4. From the Mattermost distribution, upload the ``client`` directory to S3 and rename it to ``static``. You can use the AWS CLI command below from within the ``client`` directory  to upload all the files to S3. The files must be publicly readable with the permission ``public-read``.
 
     ``aws s3 cp --acl public-read --recursive . s3://static.spinmint.com/static/``
 
-4. Set up your Mattermost app server and create a record from a subdomain of your desired domain to point directly to your app server. This is to bypass CloudFront to connect WebSockets. For our example we will use the domain ws.mattermost.example.com. If you have multiple app servers, this domain should point to the load balancer/proxy such as ALB or NGINX.
-5. Create a Web CloudFront distribution with the following configuration.
+5. Set up your Mattermost app server and create a record from a subdomain of your desired domain to point directly to your app server. This is to bypass CloudFront to connect WebSockets. For our example we will use the domain ws.mattermost.example.com. If you have multiple app servers, this domain should point to the load balancer/proxy such as ALB or NGINX.
+6. Create a Web CloudFront distribution with the following configuration.
 
    a. Set Origin Domain Name to the S3 bucket you created above.
    b. (Recommended) Set Redirect HTTP to ``HTTPS`` for Viewer Protocol Policy.
@@ -23,8 +27,8 @@ Configuring CloudFront to host Mattermost's static assets allows for improved ca
    g. Select ``Custom SSL Certificate`` and set the certificate for your domain.
    h. Set Default Root Object to ``/static/root.html``.
 
-6. After creating your distribution. You need to add an additional origin. Select the origins tab and create an origin. Set the origin domain name to your Mattermost load balancer.
-7. Next, create a behavior. 
+7. After creating your distribution. You need to add an additional origin. Select the origins tab and create an origin. Set the origin domain name to your Mattermost load balancer.
+8. Next, create a behavior. 
 
    a. Set the Path Pattern to ``/api/*``.
    b. Set the origin to your Mattermost app server or load balancer.
@@ -32,7 +36,7 @@ Configuring CloudFront to host Mattermost's static assets allows for improved ca
    d. Set Forward Cookies to `All`.
    e. Set Query string forwarding and Caching to ``Forward all, cache based on all``.
 
-8. Next, set up some custom error responses under the Error Pages tab.
+9. Next, set up some custom error responses under the Error Pages tab.
 
    a. Set HTTP Error Code to ``403``.
    b. Set Customize Error Response to ``Yes``.
@@ -40,8 +44,8 @@ Configuring CloudFront to host Mattermost's static assets allows for improved ca
    d. Set HTTP Response Code to ``200``.
    e. Repeat the above steps for HTTP Error Code 404.
 
-9. Now you can set up the domain you want Mattermost to be served from to point to your CloudFront distribution. Setting up this domain is beyond the scope of this guide.
-10. Finally, set these Mattermost ``config.json`` settings:
+10. Now you can set up the domain you want Mattermost to be served from to point to your CloudFront distribution. Setting up this domain is beyond the scope of this guide.
+11. Finally, set these Mattermost ``config.json`` settings:
 
     a. SiteURL: ``https://mattermost.example.com``
     b. WebsocketURL: ``wss://ws.mattermost.example.com``
@@ -51,6 +55,6 @@ Configuring CloudFront to host Mattermost's static assets allows for improved ca
 Upgrade Notes
 ~~~~~~~~~~~~~~~
 
-When you upgrade your Mattermost app servers, you will need to re-upload the new client to your S3 bucket (see step 3 above).
+When you upgrade your Mattermost app servers, you will need to re-upload the new client to your S3 bucket (see steps 3 and 4 above).
 
 You should also run a CloudFront invalidation for ``/static/root.html``. You can do this in the console under the invalidations tab. 

--- a/source/install/config-cloudfront.rst
+++ b/source/install/config-cloudfront.rst
@@ -5,7 +5,7 @@ Configuring CloudFront to host Mattermost static assets
 
 Configuring CloudFront to host Mattermost's static assets allows for improved caching performance and shorter load times for those members of your team geographicly distributed throughout the world. 
 
-1. Create an S3 bucket using your desired domain. In our example it will be mattermost.example.com.
+1. Create an S3 bucket using your desired domain. In our example it will be ``mattermost.example.com``.
 2. Enable static hosting for your S3 bucket.
 3. If your SiteURL is configured with a subpath (such as https://example.com/company/mattermost), your static assets must be rewritten before uploading. You can use the command below to rewrite the assets for the given subpath:
 
@@ -15,7 +15,7 @@ Configuring CloudFront to host Mattermost's static assets allows for improved ca
 
     ``aws s3 cp --acl public-read --recursive . s3://static.spinmint.com/static/``
 
-5. Set up your Mattermost app server and create a record from a subdomain of your desired domain to point directly to your app server. This is to bypass CloudFront to connect WebSockets. For our example we will use the domain ws.mattermost.example.com. If you have multiple app servers, this domain should point to the load balancer/proxy such as ALB or NGINX.
+5. Set up your Mattermost app server and create a record from a subdomain of your desired domain to point directly to your app server. This is to bypass CloudFront to connect WebSockets. For our example we will use the domain ``ws.mattermost.example.com``. If you have multiple app servers, this domain should point to the load balancer/proxy such as ALB or NGINX.
 6. Create a Web CloudFront distribution with the following configuration.
 
    a. Set Origin Domain Name to the S3 bucket you created above.
@@ -23,11 +23,11 @@ Configuring CloudFront to host Mattermost's static assets allows for improved ca
    c. Set allowed HTTP Methods to ``GET, HEAD, OPTIONS, POST, PATCH, DELETE``.
    d. Set Forward Cookies to ``All``.
    e. Set Query string forwarding and Caching to ``Forward all, cache based on all``.
-   f. Set your Alternate Domain Names to the domain you want Mattermost to be accessible from, mattermost.example.com in our example.
+   f. Set your Alternate Domain Names to the domain you want Mattermost to be accessible from, e.g. ``mattermost.example.com``.
    g. Select ``Custom SSL Certificate`` and set the certificate for your domain.
    h. Set Default Root Object to ``/static/root.html``.
 
-7. After creating your distribution. You need to add an additional origin. Select the origins tab and create an origin. Set the origin domain name to your Mattermost load balancer.
+7. After creating your distribution, you need to add an additional origin. Select the origins tab and create an origin. Set the origin domain name to your Mattermost load balancer.
 8. Next, create a behavior. 
 
    a. Set the Path Pattern to ``/api/*``.


### PR DESCRIPTION
Document subpath support. This complements the more developer focussed documentation at https://github.com/mattermost/mattermost-developer-documentation/pull/128.