### PR TITLE
Update Instructions for links

### DIFF
--- a/source/developer/fx-guidelines.rst
+++ b/source/developer/fx-guidelines.rst
@@ -241,7 +241,7 @@ Display: Instructions
 
 Instructions, such as “A password reset link has been sent to ``you@email.com`` for your account. Please check your inbox.”, should be displayed as sentences ending in periods. One-line links, such as “Find it here”, should not end in periods or commas, but question marks are okay.
 
-Instructions containing a link to an external resource (ie: a blog article or docs.mattermost.com), should not be hard-coded.  A redirect page from about.mattermost.com should be used in product instructions.  Redirect pages should be formatted as https://about.mattermost.com/default-[SUBJECT]. An about.mattermost.com page can be requested from the Product team at Mattermost. 
+Instructions containing a link to an external resource (ie: a blog article or docs.mattermost.com), should not be hard-coded. A redirect page from about.mattermost.com should be used in product instructions. Redirect pages should be formatted as ``https://about.mattermost.com/default-[SUBJECT]``. An about.mattermost.com page can be requested from the Product team at Mattermost. 
 
     **Example:**
 

--- a/source/developer/fx-guidelines.rst
+++ b/source/developer/fx-guidelines.rst
@@ -241,7 +241,7 @@ Display: Instructions
 
 Instructions, such as “A password reset link has been sent to ``you@email.com`` for your account. Please check your inbox.”, should be displayed as sentences ending in periods. One-line links, such as “Find it here”, should not end in periods or commas, but question marks are okay.
 
-Instructions containing a link to an external resource (ie: a blog article or docs.mattermost.com), should not be hard-coded.  A redirect page from about.mattermost.com should be used in product instructions.  An about.mattermost.com page can be requested from the Product team at Mattermost. 
+Instructions containing a link to an external resource (ie: a blog article or docs.mattermost.com), should not be hard-coded.  A redirect page from about.mattermost.com should be used in product instructions.  Redirect pages should be formatted as https://about.mattermost.com/default-[SUBJECT]. An about.mattermost.com page can be requested from the Product team at Mattermost. 
 
     **Example:**
 


### PR DESCRIPTION
The instructions section has been updated to provide information on how to format redirects on about.mattermost.com