### PR TITLE
Update header.html

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -19,6 +19,6 @@ Mattermost Documentation
    User's Guide <guides/user>
    Administrator's Guide <guides/administrator>
    Integration Guide <guides/integration>
-   Developer's Guide <guides/developer>
+   Developer's Guide <https://developers.mattermost.com/>
    Core Team Handbook <guides/core>
    

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -10,14 +10,13 @@
 			<i class="fa fa-bars"></i>
 		</div>
 		<ul class="header__links">
-			<li><a href="https://about.mattermost.com/features/">Solutions</a></li>
-			<li><a href="https://about.mattermost.com/pricing/">Pricing</a></li>
-			<li><a href="https://about.mattermost.com/community-applications/">Integrations</a></li>
-			<li><a href="https://about.mattermost.com/success-stories/">Success Stories</a></li>
-			<li><a class="active" href="https://docs.mattermost.com/">Docs</a></li>
-			<li><a href="https://about.mattermost.com/blog/">What's New</a></li>
-			<li><a href="https://about.mattermost.com/trial/">Trial</a></li>
-			<li><a href="https://about.mattermost.com/download/">Download</a></li>
+			<li><a href="https://developers.mattermost.com/">Developers</a></li>
+			<li><a href="https://mattermost.com/pricing/">Pricing</a></li>
+			<li><a href="https://about.mattermost.com/features/">Product</a></li>
+			<li><a href="https://docs.mattermost.com/">Docs</a></li>
+			<li><a href="https://mattermost.com/blog/">Blog</a></li>
+			<li><a href="https://mattermost.com/download/">Download</a></li>
+			<li><a href="https://mattermost.com/trial/">Trial</a></li>
 		</ul>
 		<div class="header__searchbar">
 			<form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -11,8 +11,8 @@
 		</div>
 		<ul class="header__links">
 			<li><a href="https://developers.mattermost.com/">Developers</a></li>
-			<li><a href="https://mattermost.com/pricing/">Pricing</a></li>
 			<li><a href="https://about.mattermost.com/features/">Product</a></li>
+			<li><a href="https://mattermost.com/pricing/">Pricing</a></li>
 			<li><a href="https://docs.mattermost.com/">Docs</a></li>
 			<li><a href="https://mattermost.com/blog/">Blog</a></li>
 			<li><a href="https://mattermost.com/download/">Download</a></li>

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -194,7 +194,7 @@
                 <div class="tile-divider"></div>
                 <p class="tile-description">Integrating other systems into messaging solution</p>
             </a>
-            <a class="tile" href="guides/developer.html">
+            <a class="tile" href="https://developers.mattermost.com/">
                 <h2 class="tile-title">Developer's Guide</h2>
                 <div class="tile-divider"></div>
                 <p class="tile-description">Contributing to the open source project</p>


### PR DESCRIPTION
1. Clicking the "Developer's Guide" on the front page now takes you to developers.mattermost.com
![image](https://user-images.githubusercontent.com/13119842/45001405-d1885f80-af9a-11e8-9d10-362a1fd78378.png)
2. The header on docs.mattermost.com is now `Developers - Product - Pricing - Docs - Blog - Download - Trial` where 
 - `Developers` links to https://developers.mattermost.com/
 - Others match the same links as in https://mattermost.com/ header