### PR TITLE
Update config-settings.rst

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -342,7 +342,7 @@ Policy
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 *Removed in June 16, 2018 release*
 
-In v5.0 and later, permissions settings have been migrated to the new `Advanced Permissions <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ user interface.
+Permission policy settings are available in Enterprise Edition E10 and E20. In v5.0 and later, these settings are found in the `Advanced Permissions <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ page instead of configuration settings. 
 
 Enable sending team invites from
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
@wiersgallak - can you take a look at this doc and edit as needed? 

I think when we initially removed these from the config settings, [we also removed the fact](https://github.com/mattermost/docs/commit/43d400b3c8e4a85d775d7968d63a9cbebc86e52c#diff-5b251ece5f4aae3a0425d5a356d79380) that they only work in Enterprise Edition, so there was some confusion on the forums: https://forum.mattermost.org/t/add-new-members-to-team-only-admins/5657

I started to update it, but not sure exactly what it should say - could you take over and review or edit my changes as needed? 