### PR TITLE
Update release-process.md

### DIFF
--- a/source/process/release-process.md
+++ b/source/process/release-process.md
@@ -172,8 +172,9 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Push next RC to acceptance and announce in Town Square with new RC link
     - Check CI servers running on release branch
 6. Marketing:
-    - Finish draft of blog post for mattermost.com and send for release manager and PMs to review
+    - Finish draft of blog post for mattermost.com and all art work (screenshots, GIFs and twitter banners) used for the blog post
         - Upgrade should be recommended if there are security fixes in this version, with a note thanking the security researcher
+    - Send blog post for release manager and PMs to review
 
 ### I. (T-minus 6 working days) Release Candidate Testing Finished
 
@@ -188,9 +189,7 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Confirm Changelog reflects any changes since it was merged (including known issues and contributors from all repositories)
       - If there is a security fix, confirm the Changelog recommends upgrade, with a note mentioning the security level and thanking the security researcher (security process doc for example)
 3. Marketing:
-    - Finish drafts of all art work (screenshots, GIFs and twitter banners) used for the blog post and review with PMs before sending to marketing lead for review
-    - Receive sign off on final version of MailChimp email blast and Twitter announcement and schedule for 08:00 PST on the date of marketing announcement
-      - **Note:** If the release contains a security update, also draft a Mailchimp email blast for the [Security Bulletin mailing list](http://eepurl.com/cAl5Rv)
+    - Send blog post for mattermost.com and all related art work for marketing lead to review
     - Find [www-gitlab-com merge request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests?scope=all&utf8=%E2%9C%93&state=opened&label_name%5B%5D=blog%20post&label_name%5B%5D=release) for latest GitLab release blog post and make request for adding GitLab Mattermost update (see [example request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests/2910#note_14096885), [example update](https://about.gitlab.com/2016/07/22/gitlab-8-10-released/#gitlab-mattermost-32)). Post to Release Discussion channel with link to request.
 4. QA:
     - Midday: Post at-channel reminders about testing, and DM team members whose tests are not marked Done
@@ -200,8 +199,6 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Verify all JIRA tickets other than newly filed bugs have been tested, verified, and closed
     - As bug fixes are merged and RCs are cut, verify fixes on new RCs and post in Release Channel after testing
     - As RCs are cut, update selenium.mattermost.com to latest RC
-5. Marketing:
-    - Finish PM review of blog post for mattermost.com and send for marketing lead to review
 
 ### J. (T-minus 2 working days) Release Build Cut
 

--- a/source/process/release-process.md
+++ b/source/process/release-process.md
@@ -156,6 +156,7 @@ Day when Leads and PMs decide which major features are included in the release, 
         - Update download links and testing server links to the latest RCs
     - Post list of tickets to be fixed to the Release Discussion channel ([see example](https://pre-release.mattermost.com/core/pl/65k77x3bnigw5f9ffohfxonnfy))
     - Update Changelog “Known Issues” section with any significant issues that were found and not fixed for the final release
+    - Confirm with performance team that load tests against the release candidate are run to find potential performance issues
 3. QA:
     - Update Release Discussion header with links to RC instances and testing spreadsheet ([template](https://pre-release.mattermost.com/core/pl/db3sur4r53d9tyih1i4wrmi9wy))
     - Post release testing instructions to Release Discussion channel ([template](https://pre-release.mattermost.com/core/pl/uprogtcqzpbk7nkmdkfnhqkcac))
@@ -163,7 +164,6 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Begin running all Selenium IDE tests
     - At end of day, post reminders about release testing in Release Discussion and Announcements channels, DM any team members who have zero test cells marked Done
 4. Dev:
-    - Run load tests against the release candidate to find potential performance issues
     - Make PRs for bug fixes to the release branch
     - Review PRs made from release branch and merge changes into the release branch as required and merge the release branch back into master once per day
     - Run daily automated upgrade tests to avoid catching upgrade bugs late
@@ -171,6 +171,9 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Verify with Release Manager before cutting any new RCs (approved fixes should be merged)
     - Push next RC to acceptance and announce in Town Square with new RC link
     - Check CI servers running on release branch
+6. Marketing:
+    - Finish draft of blog post for mattermost.com and send for release manager and PMs to review before sending for marketing lead to review
+        - Upgrade should be recommended if there are security fixes in this version, with a note thanking the security researcher
 
 ### I. (T-minus 6 working days) Release Candidate Testing Finished
 
@@ -185,9 +188,9 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Confirm Changelog reflects any changes since it was merged (including known issues and contributors from all repositories)
       - If there is a security fix, confirm the Changelog recommends upgrade, with a note mentioning the security level and thanking the security researcher (security process doc for example)
 3. Marketing:
-    - Finish draft of blog post for mattermost.com and send for release manager and PMs to review before sending for marketing lead to review
-        - Upgrade should be recommended if there are security fixes in this version, with a note thanking the security researcher
     - Finish drafts of all art work (screenshots, GIFs and twitter banners) used for the blog post and review with PMs before sending to marketing lead for review
+    - Receive sign off on final version of MailChimp email blast and Twitter announcement and schedule for 08:00 PST on the date of marketing announcement
+      - **Note:** If the release contains a security update, also draft a Mailchimp email blast for the [Security Bulletin mailing list](http://eepurl.com/cAl5Rv)
     - Find [www-gitlab-com merge request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests?scope=all&utf8=%E2%9C%93&state=opened&label_name%5B%5D=blog%20post&label_name%5B%5D=release) for latest GitLab release blog post and make request for adding GitLab Mattermost update (see [example request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests/2910#note_14096885), [example update](https://about.gitlab.com/2016/07/22/gitlab-8-10-released/#gitlab-mattermost-32)). Post to Release Discussion channel with link to request.
 4. QA:
     - Midday: Post at-channel reminders about testing, and DM team members whose tests are not marked Done
@@ -197,7 +200,6 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Verify all JIRA tickets other than newly filed bugs have been tested, verified, and closed
     - As bug fixes are merged and RCs are cut, verify fixes on new RCs and post in Release Channel after testing
     - As RCs are cut, update selenium.mattermost.com to latest RC
-
 
 ### J. (T-minus 2 working days) Release Build Cut
 
@@ -231,7 +233,6 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
     - Test upgrade from previous version to current version, following the [Upgrade Guide](http://docs.mattermost.com/administration/upgrade.html#upgrade-guide) with database upgrades on both MySQL and Postgres
     - Test upgrade from Team Edition to Enterprise edition based on the [Upgrade Guide](https://docs.mattermost.com/administration/upgrade.html#upgrade-team-edition-to-enterprise-edition)
     - Review any changes made to install guides, and test if necessary
-    - Run loadtests against the final release build to confirm there are no performance issues
     - Ensure [Security Policies](https://docs.mattermost.com/process/security.html) page has been updated
     - Update dependancies after release branch is cut in `mattermost-server`, `mattermost-webapp`, `desktop`, `mattermost-mobile` and `mattermost-redux`
 5. Logistics:
@@ -242,8 +243,6 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
       - Merge the docs release branch to master and verify all changes on docs.mattermost.com once the build is up
       - Submit a correction PR for any incorrect formatting or other errors missed during the initial review
 7. Marketing:
-    - Receive sign off on final version of MailChimp email blast and Twitter announcement and schedule for 08:00 PST on the date of marketing announcement
-    - **Note:** If the release contains a security update, also draft a Mailchimp email blast for the [Security Bulletin mailing list](http://eepurl.com/cAl5Rv)
     - Finalize blog post for mattermost.com, test on mobile view, and set timer for 08:00 PST on the day of release
     - Update feature lists on https://about.mattermost.com/pricing/ and https://about.mattermost.com/features/ with relevant new features
     - Add links to [Admin guide](https://docs.mattermost.com/guides/administrator.html) in the release blog post where needed

--- a/source/process/release-process.md
+++ b/source/process/release-process.md
@@ -172,7 +172,7 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Push next RC to acceptance and announce in Town Square with new RC link
     - Check CI servers running on release branch
 6. Marketing:
-    - Finish draft of blog post for mattermost.com and send for release manager and PMs to review before sending for marketing lead to review
+    - Finish draft of blog post for mattermost.com and send for release manager and PMs to review
         - Upgrade should be recommended if there are security fixes in this version, with a note thanking the security researcher
 
 ### I. (T-minus 6 working days) Release Candidate Testing Finished
@@ -200,6 +200,8 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Verify all JIRA tickets other than newly filed bugs have been tested, verified, and closed
     - As bug fixes are merged and RCs are cut, verify fixes on new RCs and post in Release Channel after testing
     - As RCs are cut, update selenium.mattermost.com to latest RC
+5. Marketing:
+    - Finish PM review of blog post for mattermost.com and send for marketing lead to review
 
 ### J. (T-minus 2 working days) Release Build Cut
 
@@ -243,6 +245,8 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
       - Merge the docs release branch to master and verify all changes on docs.mattermost.com once the build is up
       - Submit a correction PR for any incorrect formatting or other errors missed during the initial review
 7. Marketing:
+    - Receive sign off on final version of MailChimp email blast and Twitter announcement and schedule for 08:00 PST on the date of marketing announcement
+      - **Note:** If the release contains a security update, also draft a Mailchimp email blast for the [Security Bulletin mailing list](http://eepurl.com/cAl5Rv)
     - Finalize blog post for mattermost.com, test on mobile view, and set timer for 08:00 PST on the day of release
     - Update feature lists on https://about.mattermost.com/pricing/ and https://about.mattermost.com/features/ with relevant new features
     - Add links to [Admin guide](https://docs.mattermost.com/guides/administrator.html) in the release blog post where needed


### PR DESCRIPTION
1. Move ownership of running loadtests from dev ops to performance team. Asking release manager's help to confirm this from the performance team, currently `joram, christopher, jesse, jason`
2. Move marketing reviews one step earlier, so Ian gets to review the blog 6 working days before the final rather than 2. I think he proposed earlier to review it one week beforehand, but having a T-5 for that item alone isn't necessary.

^feedback welcome on the above @amyblais. First one came up during ABC sprint planning