### PR TITLE
Update install-rhel-66-mattermost.rst

### DIFF
--- a/source/install/install-rhel-66-mattermost.rst
+++ b/source/install/install-rhel-66-mattermost.rst
@@ -17,7 +17,7 @@ Assume that the IP address of this server is 10.10.10.2
 
 3. Extract the Mattermost Server files.
 
-  ``tar -xvzf *.gz``
+  ``tar xvzf *.gz``
 
 4. Move the extracted file to the ``/opt`` directory.
 


### PR DESCRIPTION
Error option of `tar` command