### PR TITLE
Reduce size of search filter calendar image

### DIFF
--- a/source/help/getting-started/searching.rst
+++ b/source/help/getting-started/searching.rst
@@ -37,7 +37,7 @@ Use ``before:`` to find posts before a specified date and ``after:`` to find pos
 -  Searching ``website on: 2018-09-01`` will return messages that contain the keyword ``website`` that were posted on September 1, 2018.
 
 .. image:: ../../images/calendar2.png
-
+  :width: 300 px
 
 Quotation Marks
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Current image feels a little over-sized

![image](https://user-images.githubusercontent.com/13119842/46310984-da1a8880-c58e-11e8-95b8-6be034fe4210.png)
