### PR TITLE
PLT-8347: Docs needed for CLI commands in Docker preview image

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -73,6 +73,11 @@ On Docker install, the ``/mattermost/bin`` directory was added to ``PATH``, so y
   .. code-block:: bash
 
     docker exec -it <your-mattermost-container-name> mattermost version
+    
+Using the CLI on Docker Preview
+-------------------------------
+
+The preceding documentation and command reference below also applies to the Mattermost docker preview image.
 
 Mattermost 3.6 and later
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -109,6 +109,7 @@ mattermost
     -  `mattermost export`_ - Compliance export commands
     -  `mattermost help`_ - Generate full documentation for the CLI
     -  `mattermost import`_ - Import data
+    -  `mattermost jobserver`_ - Start the Mattermost job server
     -  `mattermost ldap`_ - AD/LDAP related utilities
     -  `mattermost license`_ - Licensing commands
     -  `mattermost permissions`_ - Management of the permissions system
@@ -511,6 +512,22 @@ mattermost import slack
     .. code-block:: none
 
       sudo ./mattermost import slack myteam slack_export.zip
+
+mattermost jobserver
+--------------------
+
+  Description
+    Start the Mattermost job server.
+    
+  Format
+    .. code-block:: none
+
+      mattermost jobserver
+      
+  Example
+    .. code-block:: none
+
+      sudo ./mattermost jobserver
 
 mattermost ldap
 ----------------

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -77,7 +77,7 @@ On Docker install, the ``/mattermost/bin`` directory was added to ``PATH``, so y
 Using the CLI on Docker Preview
 -------------------------------
 
-The preceding documentation and command reference below also applies to the Mattermost docker preview image.
+The preceding documentation and command reference below also applies to the `Mattermost docker preview image <https://github.com/mattermost/mattermost-docker-preview>`_.
 
 Mattermost 3.6 and later
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The following commits should fix issue PLT-8347. 

As discussed in https://github.com/mattermost/mattermost-server/issues/8031, the Mattermost Docker preview image commands are identical to the production image. I did add the ```mattermost jobserver``` command into the reference section. 

I also want to, again, convey the importance of https://github.com/mattermost/mattermost-docker-preview/pull/35. When users test Mattermost with the preview image, they have to specify a PATH variable to the Mattermost binary. This is located in ```/mm/mattermost/bin```. If they don't, they cannot  use ```docker exec``` as described in the documentation. I feel that users, when first testing Mattermost, want the process to be as smooth as possible. These PR's facilitate this.

If there's anything I'm missing, please let me know.