### PR TITLE
Update config-proxy-apache2.rst

### DIFF
--- a/source/install/config-proxy-apache2.rst
+++ b/source/install/config-proxy-apache2.rst
@@ -21,7 +21,8 @@ Copy the `default` configuration file found in the same directory.
 	1. If you're not setting up a subdomain your ``ServerName`` will simply be set to ``mydomain.com``.
 	2. ``ServerAlias`` can been added too if you want to capture ``www.mydomain.com``.
 	3. Remember to change the values to match your server's name, etc.
-	4. Save once finished.
+	4. If you have enabled TLS in the Mattermost settings, you must use the protocol ``wss://`` instead of ``ws://`` in the ``RewriteRule``
+	5. Save once finished.
 
 .. code-block:: apacheconf
 

--- a/source/install/config-proxy-apache2.rst
+++ b/source/install/config-proxy-apache2.rst
@@ -37,7 +37,7 @@ Copy the `default` configuration file found in the same directory.
 		  RewriteCond %{REQUEST_URI} /api/v[0-9]+/(users/)?websocket [NC,OR]
 		  RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC,OR]
 		  RewriteCond %{HTTP:CONNECTION} ^Upgrade$ [NC]
-		  RewriteRule .* wss://127.0.0.1:8065%{REQUEST_URI} [P,QSA,L]
+		  RewriteRule .* ws://127.0.0.1:8065%{REQUEST_URI} [P,QSA,L]
 
 		  <Location />
 			Require all granted

--- a/source/install/config-proxy-apache2.rst
+++ b/source/install/config-proxy-apache2.rst
@@ -21,7 +21,7 @@ Copy the `default` configuration file found in the same directory.
 	1. If you're not setting up a subdomain your ``ServerName`` will simply be set to ``mydomain.com``.
 	2. ``ServerAlias`` can been added too if you want to capture ``www.mydomain.com``.
 	3. Remember to change the values to match your server's name, etc.
-	4. If you have enabled TLS in the Mattermost settings, you must use the protocol ``wss://`` instead of ``ws://`` in the ``RewriteRule``
+	4. If you have enabled TLS in the Mattermost settings, you must use the protocol ``wss://`` instead of ``ws://`` in the ``RewriteRule``.
 	5. Save once finished.
 
 .. code-block:: apacheconf


### PR DESCRIPTION
Replaced default web socket URL.
Mattermost does not use TLS per default, so the default value should be ws:// and not wss://, and a note should be added about this.