### PR TITLE
Add hosting recommendation matrix between on-prem, AWS and Azure

### DIFF
--- a/source/deployment/scaling.rst
+++ b/source/deployment/scaling.rst
@@ -53,7 +53,7 @@ On AWS, we recommend using the following EC2 server types as a baseline:
 
 For the purposes of this guide, we will assume medium usage (10 MB/user/month with a 2x safety factor) for `storage estimates <https://docs.mattermost.com/install/requirements.html#alternate-storage-calculations>`_ and 200 MB/user/month for data transfer estimates. We will also assume on-demand pricing with no upfront payments, though more savings (typically 40% or more) can be achieved with reserved servers on 1–3 year commitments and upfront payments.
 
-As deployments scale above 5,000 users, additional servers are added for performance load-balancing and to provide additional redundancy (see our `High Availability Cluster guide <https://docs.mattermost.com/deployment/cluster.html#mattermost-server-configuration>`_).
+As deployments scale above 5,000 users, additional servers are added for performance load-balancing and for providing additional redundancy (see our `High Availability Cluster guide <https://docs.mattermost.com/deployment/cluster.html#mattermost-server-configuration>`_).
 
 `This spreadsheet <https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vRkhRPFsf1_91AXFbqnmUT0UnpdZ1ZagbiTw9sfuBAL21ncnu7fynZ3yDrp22-LXCeXh0-xF_NFFPp3/pubhtml>`_ shows how much hardware you’ll need for different-sized Mattermost deployments and provides an estimate of how much each will cost. It includes links to AWS’s cost calculator for various deployment sizes. The smaller deployment examples (i.e., 1,000 users and 5,000 users) are on the conservative side, with separate servers per function that can easily be scaled out as Mattermost is rolled out. 
 

--- a/source/deployment/scaling.rst
+++ b/source/deployment/scaling.rst
@@ -62,3 +62,20 @@ Here’s an example of the hardware you’ll need for a 10,000-user deployment:
 .. image:: ../images/scaling-3.PNG
 
 For more information, check out our `Administrator's Guide <https://docs.mattermost.com/guides/administrator.html>`_.
+
+Hosting Recommendation for 100,000+ users 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following matrix presents key features for a successful multi-region Mattermost implementation that scales to 100,000 users with support for high availability and geographically based traffic routing in on premises, AWS, and Azure deployments.
+
+.. csv-table::
+    :header: "Feature", "On Premises", "Amazon AWS", "Azure"
+
+    "Multi-region/data center support", "Yes", "Regions: 16", "Regions: 54"
+    "Auto scaling for Mattermost nodes", "Yes - using a solution like Kubernetes", "`AWS Auto Scaling <https://aws.amazon.com/ec2/autoscaling/>`_", "`Azure Autoscale <https://azure.microsoft.com/en-us/features/autoscale/>`_"
+    "Geographic based traffic routing", "Yes", "`Route 53 <https://aws.amazon.com/route53/>`_", "`Azure DNS <https://azure.microsoft.com/en-us/services/dns/>`_"
+    "Load balancing", "Yes", "`Elastic Load Balancer <https://aws.amazon.com/elasticloadbalancing/>`_", "`Azure Load Balancer <https://azure.microsoft.com/en-us/services/load-balancer/>`_"
+    "Multi-region, HA storage", "Yes", "`S3 <https://aws.amazon.com/s3/>`_", "?"
+    "Multi-region, HA MySQL", "Yes - using a solution like Galera", "`Aurora <https://aws.amazon.com/rds/aurora/>`_ / `RDS for MySQL <https://aws.amazon.com/rds/mysql/>`_", "`Azure MySQL <https://azure.microsoft.com/en-us/services/mysql/>`_"
+    "Multi-region, HA PostgreSQL", "Yes", "`Aurora <https://aws.amazon.com/rds/aurora/>`_ / `RDS for PostgreSQL <https://aws.amazon.com/rds/postgresql/>`_", "`Azure PostgreSQL <https://azure.microsoft.com/en-us/services/postgresql/>`_"
+    "Multi-region, HA elasticsearch", "Yes", "`Amazon Elasticsearch Service <https://aws.amazon.com/elasticsearch-service/>`_", "No"

--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -184,7 +184,7 @@ Learn how to support growth within Mattermost.
    :glob:
    
    /deployment/scaling*
-   /deployment/cluster*
+   /deployment/cluster.rst*
    /deployment/elastic*
    /deployment/metrics*
    /administration/performance-alerting-guide*


### PR DESCRIPTION
I'm not sure if this is the best place to put this table into, feedback welcome.