### PR TITLE
Added a note to ensure the plugin is enabled

### DIFF
--- a/source/integrations/jira.rst
+++ b/source/integrations/jira.rst
@@ -25,6 +25,9 @@ If you'd like to see support for additional events, `let us know <https://matter
 JIRA Setup Guide
 ~~~~~~~~~~~~~~~~~
 
+.. note::
+    Make sure the JIRA Plugin is enabled in **System Console > Plugins > Management** before continuing setup
+
 Enable JIRA on your Mattermost instance
 .........................................
 

--- a/source/integrations/jira.rst
+++ b/source/integrations/jira.rst
@@ -26,7 +26,7 @@ JIRA Setup Guide
 ~~~~~~~~~~~~~~~~~
 
 .. note::
-    Make sure the JIRA Plugin is enabled in **System Console > Plugins > Management** before continuing setup
+    Make sure that the JIRA Plugin is enabled in **System Console > Plugins > Management** before continuing setup.
 
 Enable JIRA on your Mattermost instance
 .........................................


### PR DESCRIPTION
Plugin must be enabled in Plugins > Management before it will work, but this was missing from the setup instructions.

Signed-off-by: Paul Rothrock <paul@movetoiceland.com>