### PR TITLE
Create deploy-turnkeylinux.rst

### DIFF
--- a/source/install/deploy-turnkeylinux.rst
+++ b/source/install/deploy-turnkeylinux.rst
@@ -1,0 +1,6 @@
+.. _deploy-turnkeylinux:
+
+Deploy Mattermost on TurnKey Linux
+=============================
+
+`Download packaged Mattermost <https://hub.turnkeylinux.org/amazon/launch/mattermost/>`_ ISO, OVA or deploy to `AWS EC2 <https://hub.turnkeylinux.org/amazon/launch/mattermost/>`_

--- a/source/install/deploy-turnkeylinux.rst
+++ b/source/install/deploy-turnkeylinux.rst
@@ -3,4 +3,4 @@
 Deploy Mattermost on TurnKey Linux
 =============================
 
-`Download packaged Mattermost <https://hub.turnkeylinux.org/amazon/launch/mattermost/>`_ ISO, OVA or deploy to `AWS EC2 <https://hub.turnkeylinux.org/amazon/launch/mattermost/>`_
+`Download packaged Mattermost <https://turnkeylinux.org/mattermost/>`_ ISO, OVA or deploy to `AWS EC2 <https://hub.turnkeylinux.org/amazon/launch/mattermost/>`_


### PR DESCRIPTION
An open-source alternative to Bitnami Mattermost stack on Debian 9