### PR TITLE
add troubleshooting info for broken server session data on desktop app

### DIFF
--- a/source/install/desktop.rst
+++ b/source/install/desktop.rst
@@ -132,6 +132,14 @@ Desktop App constantly refreshes the page
     - Mac: Open Finder, and navigate to the ``~/Library/Application Support/Mattermost`` folder, then delete the ``Local Storage`` folder.
     - Linux: Open the file manager, and navigate to the ``~/.config/Mattermost`` folder, then delete the ``Local Storage`` folder.
       
+Desktop App constantly asks to log in to Mattermost server
+  This issue can occur after a crash or unexpected shutdown of the Desktop app that causes the app data to be corrupted. To resolve the issue:
+
+    - Windows: Open Windows File Explorer, and navigate to the ``%USERPROFILE%\AppData\Roaming\Mattermost`` folder, then delete the ``IndexedDB`` folder.
+    - Mac: Open Finder, and navigate to the ``~/Library/Application Support/Mattermost`` folder, then delete the ``IndexedDB`` folder.
+    - Linux: Open the file manager, and navigate to the ``~/.config/Mattermost`` folder, then delete the ``IndexedDB`` folder.
+
+
 For additional troubleshooting tips, see the `troubleshooting guide <https://www.mattermost.org/troubleshoot/>`_.
 
 Reporting Issues


### PR DESCRIPTION
This adds some info to the troubleshooting section that should fix the bug discussed in the MM Desktop App channel that sometimes can happen after a crash. 