### PR TITLE
leverage aws s3 sync --delete to avoid downtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,11 @@ install:
   - pipenv install --dev
 script:
   - make html
-before_deploy:
-  - aws s3 rm s3://docs.mattermost.com/ --recursive --region us-east-1
 deploy:
-  - provider: s3
-    access_key_id: AKIAJXLDG4C2F4MIZP4Q
-    secret_access_key:
-      secure: B+Wiu/EVTzWAMFxfCHBr2I5anZ27NgGxEwVP5s8c9iczfUznex5gWkmIVcq4jHqZN6E5fJopIyvUC/lhL0nWALcptO2HSqH8Du1B1GNTus2JRgFsFSkK0wuDtx9Lhsh4ExRlfYyQn1QF5gSyjZq/a9t2ZCZpGpeVlXFGVz64v1GJOKABP79bd6FiiK7wu+o99Bqk8KrxelU6S0gSSiI+f2se1H252NCBLJcoqkXwgqccQe6ttSgW8xPEm3kpOW7oS2hjMRtsUHS5VVFngH6TZeq+6m8+eXr21IrrAw0sWR0VimXsCztzs5mK7Njs4G6suDcF3ExqK8CCIRkD2BTdoWs/6PPgNduRDIWPS9XqpA21eRQcknzFkpl2ZBeZ+gP+xTDxUwJQ/qkGLutJkAzKObG3OWDyYCUvQ2dhQ1nQ/joZhTV9iWu6WoAjqDAlQWSSYahQkqVCNDi9D0HR1ujOIs/XQ7ePfzIRIv6eXhsVttlhrnCKBou789qav+2ufEueRp2xFcMCrrcybMkAPQpoVmjsQa3obtI09CoO7JIFgaYBhgv6U7i/W1bkeId0AfSRPn8PUyCC7arRYoayht4VSWVompBmgF4lJSuJdavUpdqQE6fE/fcZIX8aaYgpJS1uPmc0Q1tAgJyKfPXyP/AwJPiBNCwh98ElE1q4iEdUPMY=
-    bucket: docs.mattermost.com
-    local_dir: build/html
-    acl: public_read
-    region: us-east-1
-    skip_cleanup: true
-    detect_encoding: true
-    on:
-      repo: mattermost/docs
-      branch: master
-      python: 3.6
+  provider: script
+  script: aws s3 sync build/html dist s3://docs.mattermost.com/ --region=us-east-1 --acl public_read --delete
+  skip_cleanup: true
+  on:
+    repo: mattermost/docs
+    branch: master
+    python: 3.6


### PR DESCRIPTION
Effectively inline the `--delete` operation by not using Travis CI's `s3` deploy, but `aws s3 sync --delete` directly.

I don't know how to test this except by doing it live: suggestions?