### PR TITLE
Change heading for "0/5" subsection to properly link by autolink plugin

### DIFF
--- a/source/process/training.rst
+++ b/source/process/training.rst
@@ -407,11 +407,6 @@ Naming specific repeated mistake helps us find patterns, avoid repeated mistakes
 List of Terms
 ---------------------------
 
-0/5, 1/5, 2/5, 3/5, 4/5, 5/5
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-We use "x/5" to concisely communicate conviction. 0/5 means you don't have a strong opinion, you are just sharing an idea or asking a question. 5/5 means you are highly confident and would stake your reputation on the opinion you're expressing.
-
 Bug
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -467,6 +462,11 @@ An estimate of total energy, attention and effort required for a task.
 A one-line change to code can cost more mana than a 100-line change due to risk and the need for documentation, testing, support and all the other activities needed.
 
 Every feature added has an initial and on-going mana cost, which is taken into account in feature decisions.
+
+Out of 5
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We use "x/5" to concisely communicate conviction. 0/5 means you don't have a strong opinion, you are just sharing an idea or asking a question. 5/5 means you are highly confident and would stake your reputation on the opinion you're expressing.
 
 RHS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/process/training.rst
+++ b/source/process/training.rst
@@ -407,6 +407,14 @@ Naming specific repeated mistake helps us find patterns, avoid repeated mistakes
 List of Terms
 ---------------------------
 
+.. _id8:
+.. _out-of-5:
+
+0/5, 1/5, 2/5, 3/5, 4/5, 5/5
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We use "x/5" to concisely communicate conviction. 0/5 means you don't have a strong opinion, you are just sharing an idea or asking a question. 5/5 means you are highly confident and would stake your reputation on the opinion you're expressing.
+
 Bug
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -462,11 +470,6 @@ An estimate of total energy, attention and effort required for a task.
 A one-line change to code can cost more mana than a 100-line change due to risk and the need for documentation, testing, support and all the other activities needed.
 
 Every feature added has an initial and on-going mana cost, which is taken into account in feature decisions.
-
-Out of 5
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-We use "x/5" to concisely communicate conviction. 0/5 means you don't have a strong opinion, you are just sharing an idea or asking a question. 5/5 means you are highly confident and would stake your reputation on the opinion you're expressing.
 
 RHS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
@lieut-data To fix the autolink for "0/5, 1/5, .." (https://github.com/mattermost/platform-private/pull/146) - I didn't look into it in depth, but I don't think there is an easy way to make #id1 or #id8 static -- they are dynamic anchors by nature.

So to fix it properly for long-term, we should make a static section header for the term. I've included a proposal with this PR. The anchor used for the autolink plugin would be #out-of-5