### PR TITLE
Documenting community moderators

### DIFF
--- a/source/process/community-overview.rst
+++ b/source/process/community-overview.rst
@@ -120,7 +120,7 @@ Community Coordinator: TBD
 Knowledge Base Contributors 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
-Knowledge Base Contributors share feedback, questions and answers on Mattermost through forums for `trouble shooting <https://www.mattermost.org/troubleshoot/>`__, `feature proposals <https://www.mattermost.org/feature-ideas/>`__, Github Issues and `Mattermost community server <https://community.mattermost.com>`_.
+Knowledge Base Contributors share feedback, questions and answers on Mattermost through forums for `trouble shooting <https://www.mattermost.org/troubleshoot/>`__, `feature proposals <https://www.mattermost.org/feature-ideas/>`__, Github issues and the `Mattermost community server <https://community.mattermost.com>`_.
 
 Community Coordinator: Amy Blais
 

--- a/source/process/community-overview.rst
+++ b/source/process/community-overview.rst
@@ -120,9 +120,9 @@ Community Coordinator: TBD
 Knowledge Base Contributors 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
-Knowledge Base Contributors share feedback, questions and answers on Mattermost through forums for `trouble shooting <https://www.mattermost.org/troubleshoot/>`__, `feature proposals <https://www.mattermost.org/feature-ideas/>`__, and `other topics <https://forum.mattermost.org>`__. 
+Knowledge Base Contributors share feedback, questions and answers on Mattermost through forums for `trouble shooting <https://www.mattermost.org/troubleshoot/>`__, `feature proposals <https://www.mattermost.org/feature-ideas/>`__, Github Issues and `Mattermost community server <https://community.mattermost.com>`_.
 
-Community Coordinator: Paul Rothrock 
+Community Coordinator: Amy Blais
 
 Deployment Solution Contributors 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -153,14 +153,7 @@ Recognizing people's contributions is vital to keeping them engaged. Leverage th
 
 3. Focus on high impact, skill appropriate contributions 
 
-When possible, influence contributors to apply themselves to the highest impact tickets and projects appropriate for their skill level. Meaningful contributions early in the contributor journey are a powerful way to draw people into the community. 
-
-Community Moderators / Community Support Champions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Community Moderators and Community Support Champions include users outside Mattermost staff who help troubleshoot technical issues that other users are hitting. This is done on Github Issues, on the Forum and on `Mattermost community server <https://community.mattermost.com>`_.
-
-Community Coordinator: Amy Blais
+When possible, influence contributors to apply themselves to the highest impact tickets and projects appropriate for their skill level. Meaningful contributions early in the contributor journey are a powerful way to draw people into the community.
 
 Mattermost Staff  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/process/community-overview.rst
+++ b/source/process/community-overview.rst
@@ -162,8 +162,6 @@ Community Moderators and Community Support Champions include users outside Matte
 
 Community Coordinator: Amy Blais
 
-Community 
-
 Mattermost Staff  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/process/community-overview.rst
+++ b/source/process/community-overview.rst
@@ -155,6 +155,15 @@ Recognizing people's contributions is vital to keeping them engaged. Leverage th
 
 When possible, influence contributors to apply themselves to the highest impact tickets and projects appropriate for their skill level. Meaningful contributions early in the contributor journey are a powerful way to draw people into the community. 
 
+Community Moderators / Community Support Champions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Community Moderators and Community Support Champions include users outside Mattermost staff who help troubleshoot technical issues that other users are hitting. This is done on Github Issues, on the Forum and on `Mattermost community server <https://community.mattermost.com>`_.
+
+Community Coordinator: Amy Blais
+
+Community 
+
 Mattermost Staff  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documenting before announcing ``sadb`` and ``adanial`` as moderators.