### PR TITLE
Add QA step to merge Se test updates on Release Day

### DIFF
--- a/source/process/bug-fix-release.md
+++ b/source/process/bug-fix-release.md
@@ -267,6 +267,8 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
     - Confirm marketing has been posted (animated GIFs, screenshots, mail announcement, tweets, blog posts)
     - Update @mattermosthq Twitter profile with the next release date
     - Prepare retweet of GitLab release tweet ([see example here](https://community.mattermost.com/core/pl/k7wchwj5mtrhucj6don96yx3sc))
+7. QA:
+    - Merge any updates made to Selenium tests during release testing
 
 ### K. (T-plus 5 working days) Release Updates
 1. Release Manager:

--- a/source/process/feature-release.md
+++ b/source/process/feature-release.md
@@ -308,6 +308,8 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
     - Confirm marketing has been posted (animated GIFs, screenshots, mail announcement, tweets, blog posts)
     - Update @mattermosthq Twitter profile with the next release date
     - Prepare retweet of GitLab release tweet ([see example here](https://community.mattermost.com/core/pl/k7wchwj5mtrhucj6don96yx3sc))
+7. QA:
+    - Merge any updates made to Selenium tests during release testing
 
 ### L. (T-plus 5 working days) Release Updates
 1. Release Manager:


### PR DESCRIPTION
To both the Feature and the Bug Fix Release Process docs add:

On release day, "Merge any updates made to Selenium tests during release testing"