### PR TITLE
Fix contributors guidelines link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see [Contribution Guidelines](https://docs.mattermost.com/developer/contribution-guide.html)
+Please see [Contribution Guidelines](https://developers.mattermost.com/contribute/getting-started/)


### PR DESCRIPTION
Currently the link in the CONTRIBUTORS.md leads to the old docs page which in turn just has a link to the new docs page. This PR fixes this mild annoyance ;)