### PR TITLE
Update links for pricing and product pages in release checklist

### DIFF
--- a/source/process/feature-release.md
+++ b/source/process/feature-release.md
@@ -251,7 +251,7 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
     - Receive sign off on final version of MailChimp email blast and Twitter announcement and schedule for 08:00 PST on the date of marketing announcement
       - **Note:** If the release contains a security update, also draft a Mailchimp email blast for the [Security Bulletin mailing list](http://eepurl.com/cAl5Rv)
     - Finalize blog post for mattermost.com, test on mobile view, and set timer for 08:00 PST on the day of release
-    - Update feature lists on https://about.mattermost.com/pricing/ and https://about.mattermost.com/features/ with relevant new features
+    - Update feature lists on https://mattermost.com/pricing/ and https://mattermost.com/product/ with relevant new features
     - Add links to [Admin guide](https://docs.mattermost.com/guides/administrator.html) in the release blog post where needed
 
 ### K. (T-minus 0 working days) Release Day


### PR DESCRIPTION
Also, let's confirm the pages are updated, e.g. MFA is still listed as E10, and there is no LDAP group sync.

(I think you posted about this to marketing team, but maybe we need to update our process to make sure they get done)