### PR TITLE
Update ExperimentalHideTownSquareinLHS doc entry

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -4146,7 +4146,7 @@ Town Square is Hidden in Left-Hand Sidebar (Experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *Available in Enterprise Edition E10 and higher*
 
-**True**: When ``"ExperimentalTownSquareIsReadOnly": true``, hides Town Square in the left-hand sidebar if there are no unread messages in the channel.
+**True**: Hides Town Square in the left-hand sidebar if there are no unread messages in the channel.
 
 **False**: Town Square is always visible in the left-hand sidebar even if all messages have been read.
 


### PR DESCRIPTION
It was intended to only be enabled if Town Square is read only. We have a ticket to implement the expected behaviour [here](https://mattermost.atlassian.net/browse/MM-14293), but the fix is a large effort and not worth the time, especially since the setting has worked as-is for almost a year.

Thus, updating docs instead, and we can revisit later when we implement proper read-only announcement channels.