### PR TITLE
s/:doc:/:ref:/ to fix cross document link

### DIFF
--- a/source/deployment/cluster.rst
+++ b/source/deployment/cluster.rst
@@ -276,7 +276,7 @@ Mattermost runs periodic tasks via the `job server <https://docs.mattermost.com/
  - Compliance exports
  - Elasticsearch indexing
 
-:doc:`Run all job servers <command-line-tools-mattermost-jobserver>` with ``--noschedule flag``, then set ``JobSettings.RunScheduler`` to ``true`` in config.json for all app servers in the cluster. The cluster leader will then be responsible for scheduling recurring jobs.
+:ref:`Run all job servers <command-line-tools-mattermost-jobserver>` with ``--noschedule flag``, then set ``JobSettings.RunScheduler`` to ``true`` in config.json for all app servers in the cluster. The cluster leader will then be responsible for scheduling recurring jobs.
 
 Upgrade Guide
 -------------


### PR DESCRIPTION
This fixes a link introduced in https://github.com/mattermost/docs/pull/2534 that wasn't rendering correctly in production.