### PR TITLE
Restore text about invitations expire time to 48h, and removed relation with the InviteId.

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1502,14 +1502,6 @@ Require Email Verification
 | This feature's ``config.json`` setting is ``"RequireEmailVerification": false`` with options ``true`` and ``false`` for above settings respectively.                 |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Email Invite Salt
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-32-character (to be randomly generated via System Console) salt added to signing of email invitation links. Click **Regenerate** to create new salt.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"InviteSalt": ""`` with string input.                                                                                    |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
 Enable Open Server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 **True**: Users can sign up to the server from the root page without an invite.

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1504,7 +1504,7 @@ Require Email Verification
 
 Email Invite Salt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-32-character (to be randomly generated via System Console) salt added to signing of email invitation links. Email invitation links expire after 24 hours except if the salt is regenerated, then existing email invitation links invalidate immediately.  Click **Regenerate** to create new salt.
+32-character (to be randomly generated via System Console) salt added to signing of email invitation links. Click **Regenerate** to create new salt.
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"InviteSalt": ""`` with string input.                                                                                    |

--- a/source/help/getting-started/managing-members.rst
+++ b/source/help/getting-started/managing-members.rst
@@ -11,7 +11,7 @@ If enabled by your System Admin, you can add people to your team in one of three
 Direct Invites
 ~~~~~~~~~~~~~~
 
-Direct invites are invitation emails sent from your team's server directly to the invited person's email address. A link within the invitation directs them to an account creation page. Invitation links sent by email expire after 24 hours or invalidate immediately if the System Admin regenerates the `Email Invite Salt <https://docs.mattermost.com/administration/config-settings.html#email-invite-salt>`_.
+Direct invites are invitation emails sent from your team's server directly to the invited person's email address. A link within the invitation directs them to an account creation page. Invitation links sent by email expire after 48 hours.
 
 **To send a direct invite**:
 

--- a/source/help/getting-started/managing-members.rst
+++ b/source/help/getting-started/managing-members.rst
@@ -11,7 +11,7 @@ If enabled by your System Admin, you can add people to your team in one of three
 Direct Invites
 ~~~~~~~~~~~~~~
 
-Direct invites are invitation emails sent from your team's server directly to the invited person's email address. A link within the invitation directs them to an account creation page. Invitation links sent by email expire after 48 hours.
+Direct invites are invitation emails sent from your team's server directly to the invited person's email address. A link within the invitation directs them to an account creation page. Invitation links sent by email expire after 48 hours and can be used only one time.
 
 **To send a direct invite**:
 


### PR DESCRIPTION
The email invitations were bound to the InviteId, but we change it, and now are
independent.