### PR TITLE
Update install guides - listening on all IP addresses should be an optional step

### DIFF
--- a/source/install/install-debian-postgresql.rst
+++ b/source/install/install-debian-postgresql.rst
@@ -46,7 +46,7 @@ Assume that the IP address of this server is 10.10.10.1
 
   ``exit``
 
-9. A(Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/9.5/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
+9. (Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/9.4/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 
   a. Find the following line:
 

--- a/source/install/install-debian-postgresql.rst
+++ b/source/install/install-debian-postgresql.rst
@@ -46,7 +46,7 @@ Assume that the IP address of this server is 10.10.10.1
 
   ``exit``
 
-9. Allow PostgreSQL to listen on all assigned IP Addresses. Open ``/etc/postgresql/9.4/main/postgresql.conf`` as root in a text editor.
+9. A(Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/9.5/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 
   a. Find the following line:
 

--- a/source/install/install-rhel-7-postgresql.rst
+++ b/source/install/install-rhel-7-postgresql.rst
@@ -67,7 +67,7 @@ Installing PostgreSQL Database
 
   ``exit``
 
-15. Allow PostgreSQL to listen on all assigned IP Addresses.
+15. (Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/9.5/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 
   a. Open ``/var/lib/pgsql/9.4/data/postgresql.conf`` as root in a text editor.
 

--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -46,7 +46,7 @@ Assume that the IP address of this server is 10.10.10.1
 
   ``exit``
 
-9. Allow PostgreSQL to listen on all assigned IP Addresses. Open ``/etc/postgresql/9.5/main/postgresql.conf`` as root in a text editor.
+9. (Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/9.5/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 
   a. Find the following line:
 

--- a/source/install/install-ubuntu-1804-postgresql.rst
+++ b/source/install/install-ubuntu-1804-postgresql.rst
@@ -46,7 +46,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
   ``exit``
 
-9. (Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/9.5/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
+9. (Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/10/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 
   a. Find the following line:
 

--- a/source/install/install-ubuntu-1804-postgresql.rst
+++ b/source/install/install-ubuntu-1804-postgresql.rst
@@ -46,7 +46,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
   ``exit``
 
-9. Allow PostgreSQL to listen on all assigned IP Addresses. Open ``/etc/postgresql/10/main/postgresql.conf`` as root in a text editor.
+9. (Optional) If you use a different server for your database and the Mattermost app server, you may allow PostgreSQL to listen on all assigned IP Addresses. To do so, open ``/etc/postgresql/9.5/main/postgresql.conf`` as root in a text editor. As a best practice, ensure that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 
   a. Find the following line:
 


### PR DESCRIPTION
I noticed some guides use Postgres v9.4, some v9.5, some v10. I left it as-is, but is there any reason why this would be different?

Reopened from https://github.com/mattermost/docs/pull/2486