### PR TITLE
Use OPTION in place of ALT for mac shortcuts

### DIFF
--- a/source/help/messaging/keyboard-shortcuts.rst
+++ b/source/help/messaging/keyboard-shortcuts.rst
@@ -11,13 +11,13 @@ Navigation
 +----------------------------------------+----------------------------------------+------------------------------------------------------------------------------+
 | On Windows                             | On Mac                                 | Description                                                                  |
 +========================================+========================================+==============================================================================+
-| ALT+UP                                 | ALT+UP                                 | Previous channel or direct message in left hand sidebar                      |
+| ALT+UP                                 | OPTION+UP                              | Previous channel or direct message in left hand sidebar                      |
 +----------------------------------------+----------------------------------------+------------------------------------------------------------------------------+
-| ALT+DOWN                               | ALT+DOWN                               | Next channel or direct message in left hand sidebar                          |
+| ALT+DOWN                               | OPTION+DOWN                            | Next channel or direct message in left hand sidebar                          |
 +----------------------------------------+----------------------------------------+------------------------------------------------------------------------------+
-| ALT+SHIFT+UP                           | ALT+SHIFT+UP                           | Previous channel or direct message in left hand sidebar with unread messages |
+| ALT+SHIFT+UP                           | OPTION+SHIFT+UP                        | Previous channel or direct message in left hand sidebar with unread messages |
 +----------------------------------------+----------------------------------------+------------------------------------------------------------------------------+
-| ALT+SHIFT+DOWN                         | ALT+SHIFT+DOWN                         | Next channel or direct message in left hand sidebar with unread messages     |
+| ALT+SHIFT+DOWN                         | OPTION+SHIFT+DOWN                      | Next channel or direct message in left hand sidebar with unread messages     |
 +----------------------------------------+----------------------------------------+------------------------------------------------------------------------------+
 | CTRL+K                                 | CMD+K                                  | Open a quick channel switcher dialog                                         |
 +----------------------------------------+----------------------------------------+------------------------------------------------------------------------------+


### PR DESCRIPTION
In testing the Mac shortcuts, I found that the following shortcuts work with the `option` key as opposed to the `command` key which is the equivalent of `alt` on Windows. More importantly, I think it makes sense to call the `option` button what it is 😄 