### PR TITLE
Update prod-docker.rst to add Git installation step.

### DIFF
--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -33,6 +33,7 @@ Production Docker Setup on Ubuntu
 3. **Deploy the Mattermost Production Docker** setup by running:
 
    .. code:: bash
+   
        sudo apt-get install git
        git clone https://github.com/mattermost/mattermost-docker.git
        cd mattermost-docker

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -33,7 +33,7 @@ Production Docker Setup on Ubuntu
 3. **Deploy the Mattermost Production Docker** setup by running:
 
    .. code:: bash
-
+       sudo apt-get install git
        git clone https://github.com/mattermost/mattermost-docker.git
        cd mattermost-docker
        docker-compose build


### PR DESCRIPTION
Git must be installed to run `git clone` command.

`wget` is also forced to install in the first step, but I recommend creating a pre-step to install all these requirements before installation steps begin.