### PR TITLE
Update prod-docker.rst

### DIFF
--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -71,8 +71,9 @@ You can run a production deployment on macOS by `installing Docker Compose using
 Other options:
 --------------
 
-To install Mattermost Team Edition instead of Mattermost Enterprise Edition, open ``docker-compose.yaml`` and comment out the following line:
+To install Mattermost Team Edition instead of Mattermost Enterprise Edition, open ``docker-compose.yaml`` and uncomment the following lines:
 
   .. code-block:: text
 
-    dockerfile: Dockerfile-enterprise
+      # args:
+      #   - edition=team


### PR DESCRIPTION
Correct docs on how to setup Team Edition.
There is no `dockerfile: Dockerfile-enterprise` in the current `docker-compose.yml` file

Edit: the compose file in question is: [mattermost-docker/blob/master/docker-compose.yml](https://github.com/mattermost/mattermost-docker/blob/master/docker-compose.yml)