### PR TITLE
add info for mobile image preview troubleshooting

### DIFF
--- a/source/mobile/mobile-troubleshoot.rst
+++ b/source/mobile/mobile-troubleshoot.rst
@@ -55,6 +55,12 @@ and then ignore the gradle task with
 
   ./gradlew assembleRelease -x bundleReleaseJsAndAssets
 
+No image previews available in the mobile app
+---------------------------------------------
+
+This can happen if the server running Mattermost has its mime types not set up correctly.
+A server running Linux has this file located in ``/etc/mime.types``. This might vary depending on your specific OS and distribution.
+
 None of these solve my problem!
 -------------------------------
 

--- a/source/mobile/mobile-troubleshoot.rst
+++ b/source/mobile/mobile-troubleshoot.rst
@@ -61,6 +61,9 @@ No image previews available in the mobile app
 This can happen if the server running Mattermost has its mime types not set up correctly.
 A server running Linux has this file located in ``/etc/mime.types``. This might vary depending on your specific OS and distribution.
 
+Some distributions also ship without ``mailcap`` which can result in missing or incorrectly configured mime types.
+
+
 None of these solve my problem!
 -------------------------------
 


### PR DESCRIPTION
This comes up regularly on the forums so it's probably good to add this to the documentation.