### PR TITLE
Document for engineer onboarding timeline & expectations

### DIFF
--- a/source/guides/core.rst
+++ b/source/guides/core.rst
@@ -57,6 +57,7 @@ Core Developer Handbook
 
    /developer/core-developer-handbook*
    /process/support*
+   /process/engineer-expectations*
 
 Documentation Style Guide
 -------------------------

--- a/source/process/engineer-expectations.md
+++ b/source/process/engineer-expectations.md
@@ -2,7 +2,7 @@
 
 This is the general timeline and expectations for new engineers starting at Mattermost. It is meant to guide new engineers, help them focus on the right tasks, and set expectations to help them be successful at Mattermost. It is not a hard timeline and circumstances may shorten, lengthen or re-order the timeline.
 
-##### Week 1: Focus on environment setup and introductions
+#### Week 1: Focus on environment setup and introductions
 - Set up equipment and environment (e.g. complete the day 1 checklist)
   - Get laptop, set up developer environment
   - Clone enterprise repo
@@ -23,10 +23,10 @@ This is the general timeline and expectations for new engineers starting at Matt
 - [Read and understand the core values](https://docs.mattermost.com/process/handbook.html#leadership-principles)
 - Work on 1-3 small tickets to get used to dev processes
 
-##### Week 2: Focus on digesting information dump
+#### Week 2: Focus on digesting information dump
 - Continue getting used to processes and workflows
-  - Sit in on some spec/design/technical meetings, your dev lead should send you invites to these meetings
-  - Do some code reviews, your dev lead should assign you to some
+  - Sit in on some spec/design/technical meetings (your dev lead should send you invites to these meetings)
+  - Do some code reviews (your dev lead should assign you some)
 - Introduction meetings
   - Meet with a different team member for 30min each day
 - Mentor for the week is a senior teammate
@@ -36,7 +36,7 @@ This is the general timeline and expectations for new engineers starting at Matt
   - Go over core values with dev lead
 - Work on 1-3 small tickets
 
-##### Weeks 3-4: Focus on solidifying role in the team
+#### Weeks 3-4: Focus on solidifying role in the team
 - Start taking a more active role as a member of your dev team
 - Begin to participate in some spec/design/technical meetings
   - Provide feedback/ask questions, have an active role in the meetings
@@ -46,21 +46,21 @@ This is the general timeline and expectations for new engineers starting at Matt
   - Meet once a week and start regular weekly 1-1s
 - Work on some medium size tickets
 
-##### Weeks 5-8 (Month 2): Work on your first project as dev owner
-- Begin work on your first large ish task and be the dev owner of it
+#### Weeks 5-8 (Month 2): Work on your first project as dev owner
+- Begin work on your first larger task and be the dev owner of it
 - Act as the dev owner in the spec/design/technical meetings
 - Write up a brief technical specification if necessary
 - Work on small/medium tickets each sprint alongside the larger task
 - It is expected that your first project takes longer to complete than usual
 
-##### Weeks 9-11 (Month 3): Work on more and/or larger projects as dev owner
+#### Weeks 9-11 (Month 3): Work on more and/or larger projects as dev owner
 - Take what you learned being dev owner on your first project and improve upon it
 - Act as dev owner and write technical specs for more and larger projects
 - Work on small/medium tickets to fill in gaps
 - Complete deliverables in a more timely fashion
 - Attend a "Tech Moonshots" developer meeting
 
-##### Week 12: Informal performance evaluation
+#### Week 12: Informal performance evaluation
 - Dev lead will give you your performance evaluation
 - A self survey will be sent to you
 - Surveys will be sent out to your peers
@@ -68,16 +68,16 @@ This is the general timeline and expectations for new engineers starting at Matt
   - Evaluated on core values
 - Goal here is to let you know how you’re performing and to help you improve and be a better engineer
 
-##### Weeks 13-16 (Month 4): Act on your performance evaluation and focus on community
+#### Weeks 13-16 (Month 4): Act on your performance evaluation and focus on community
 - Continue to improve on fulfilling engineering responsibilities and completing quality deliverables in a timely fashion
 - Begin acting on any feedback given during the performance evaluation
 - Start taking a more active role in the open source community
   - Proactively answer questions in channels
   - Create help wanted tickets and mentor contributors working on them
   - Find a community buddy (a contributor you interact with fairly often)
-- Start helping to answer customer support questions
+- Start helping to reply to customer support questions
 
-##### Weeks 17-20 (Month 5): Become an authority
+#### Weeks 17-20 (Month 5): Become an authority
 - Start to become an authority on some part of the product/codebase
   - Begin thinking about what part of the code you want to “own”, what do you want to be known for at Mattermost
   - Could be something you built on a past project
@@ -88,4 +88,4 @@ This is the general timeline and expectations for new engineers starting at Matt
   - Think about what you would work on if there were three of you, and use the community to help you as your clones
 - Complete engineering responsibilities and deliverables on pace with fellow teammates
 
-##### Weeks 21+ (Month 6+): Continue to grow as an engineer, be a leader in the community, and be an integral part of the Mattermost engineering org
+#### Weeks 21+ (Month 6+): Continue to grow as an engineer, be a leader in the community, and be an integral part of the Mattermost engineering org.

--- a/source/process/engineer-expectations.md
+++ b/source/process/engineer-expectations.md
@@ -11,7 +11,7 @@ This is the general timeline and expectations for new engineers starting at Matt
   - HR set up (benefits, health insurance, etc.)
 - Meet the team
   - Meet with a different team member for 30min each day
-- Meet with your mentor (dev lead)
+- Meet with your mentor for the week (dev lead)
   - Meet for at least 10-15 minutes everyday
 - Attend weekly team/company meetings to get the feeling for them
   - Sprint Planning

--- a/source/process/engineer-expectations.md
+++ b/source/process/engineer-expectations.md
@@ -1,0 +1,91 @@
+# Engineer Onboarding Timeline & Expectations
+
+This is the general timeline and expectations for new engineers starting at Mattermost. It is meant to guide new engineers, help them focus on the right tasks, and set expectations to help them be successful at Mattermost. It is not a hard timeline and circumstances may shorten, lengthen or re-order the timeline.
+
+##### Week 1: Focus on environment setup and introductions
+- Set up equipment and environment (e.g. complete the day 1 checklist)
+  - Get laptop, set up developer environment
+  - Clone enterprise repo
+  - Log in to all accounts (Gmail, GitHub, JIRA, OneLogin, Community, Community Daily)
+  - Expense equipment
+  - HR set up (benefits, health insurance, etc.)
+- Meet the team
+  - Meet with a different team member for 30min each day
+- Meet with your mentor (dev lead)
+  - Meet for at least 10-15 minutes everyday
+- Attend weekly team/company meetings to get the feeling for them
+  - Sprint Planning
+  - Developer Meeting
+  - Company All Hands
+  - Platform Meeting
+  - Developer Hangouts
+  - Video Game Hour
+- [Read and understand the core values](https://docs.mattermost.com/process/handbook.html#leadership-principles)
+- Work on 1-3 small tickets to get used to dev processes
+
+##### Week 2: Focus on digesting information dump
+- Continue getting used to processes and workflows
+  - Sit in on some spec/design/technical meetings, your dev lead should send you invites to these meetings
+  - Do some code reviews, your dev lead should assign you to some
+- Introduction meetings
+  - Meet with a different team member for 30min each day
+- Mentor for the week is a senior teammate
+  - Meet for at least 10-15 minutes everyday
+- Meet with dev lead
+  - Meet 2-3 times in the week
+  - Go over core values with dev lead
+- Work on 1-3 small tickets
+
+##### Weeks 3-4: Focus on solidifying role in the team
+- Start taking a more active role as a member of your dev team
+- Begin to participate in some spec/design/technical meetings
+  - Provide feedback/ask questions, have an active role in the meetings
+- Mentor for each week is a different teammate
+  - Meet for at least 10-15 minutes everyday
+- Meet with dev lead
+  - Meet once a week and start regular weekly 1-1s
+- Work on some medium size tickets
+
+##### Weeks 5-8 (Month 2): Work on your first project as dev owner
+- Begin work on your first large ish task and be the dev owner of it
+- Act as the dev owner in the spec/design/technical meetings
+- Write up a brief technical specification if necessary
+- Work on small/medium tickets each sprint alongside the larger task
+- It is expected that your first project takes longer to complete than usual
+
+##### Weeks 9-11 (Month 3): Work on more and/or larger projects as dev owner
+- Take what you learned being dev owner on your first project and improve upon it
+- Act as dev owner and write technical specs for more and larger projects
+- Work on small/medium tickets to fill in gaps
+- Complete deliverables in a more timely fashion
+- Attend a "Tech Moonshots" developer meeting
+
+##### Week 12: Informal performance evaluation
+- Dev lead will give you your performance evaluation
+- A self survey will be sent to you
+- Surveys will be sent out to your peers
+  - Evaluated on what is being done well, what could be improved
+  - Evaluated on core values
+- Goal here is to let you know how you’re performing and to help you improve and be a better engineer
+
+##### Weeks 13-16 (Month 4): Act on your performance evaluation and focus on community
+- Continue to improve on fulfilling engineering responsibilities and completing quality deliverables in a timely fashion
+- Begin acting on any feedback given during the performance evaluation
+- Start taking a more active role in the open source community
+  - Proactively answer questions in channels
+  - Create help wanted tickets and mentor contributors working on them
+  - Find a community buddy (a contributor you interact with fairly often)
+- Start helping to answer customer support questions
+
+##### Weeks 17-20 (Month 5): Become an authority
+- Start to become an authority on some part of the product/codebase
+  - Begin thinking about what part of the code you want to “own”, what do you want to be known for at Mattermost
+  - Could be something you built on a past project
+  - Be the “go to” person for that area
+  - Tends to happen naturally if you take true ownership of the projects you’ve worked on
+- Create some help wanted tickets/campaigns to get the community involved in your area of authority
+  - Focus on high impact tasks
+  - Think about what you would work on if there were three of you, and use the community to help you as your clones
+- Complete engineering responsibilities and deliverables on pace with fellow teammates
+
+##### Weeks 21+ (Month 6+): Continue to grow as an engineer, be a leader in the community, and be an integral part of the Mattermost engineering org


### PR DESCRIPTION
>This is the general timeline and expectations for new engineers starting at Mattermost. It is meant to guide new engineers, help them focus on the right tasks, and set expectations to help them be successful at Mattermost. It is not a hard timeline and circumstances may shorten, lengthen or re-order the timeline.

This has already been reviewed by Corey, most of the dev leads and some other devs.