### PR TITLE
Def of Mattermost staff & Mattermost employee

### DIFF
--- a/source/process/training.rst
+++ b/source/process/training.rst
@@ -567,6 +567,20 @@ A one-line change to code can cost more mana than a 100-line change due to risk 
 
 Every feature added has an initial and on-going mana cost, which is taken into account in feature decisions.
 
+Mattermost staff 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Mattermost staff refers to all people paid by Mattermost who work on a dedicated basis, including paid part-time contributors.
+
+Mattermost employee 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A Mattermost employee refers to Mattermost staff who reside in countries where we are able to provide employment relationships and who are employed there, such as the United States, Canada and other countries via Professional Employement Organizations. 
+
+The term "Mattermost employee" excludes staff that work with Mattermost through a consulting contract relationship in countries where Mattermost is not able to offer a formal employment relationship. 
+
+When talking about colleagues, it's more common to use the term "Mattermost staff", which includes people paid by Mattermost through both employment and consulting relationships. 
+
 RHS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Drafting explicit definitions of "Mattermost staff", vs. "Mattermost employee" as they're been sprinkled throughout our docs but not yet made explicit. 

There's discussions of "Mattermoster" in different threads and it's not clear if things have gone dead or if people are thinking about follow-ups, in my mind, at the minimum the definitions of Mattermost staff and Mattermost employee are consistent with what we've been using in the past. 

Please flag if anything seems different here than before?  

Other threads

 
- https://gitlab.com/mattermost/proposals/issues/28
- https://github.com/mattermost/docs/pull/2617