### PR TITLE
Add important upgrade notes to changelog

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -131,16 +131,12 @@ Mattermost v5.9.0 contains low to medium level security fixes. [Upgrading](http:
 - **v5.9.0, released 2019-04-16**
   - Original 5.9.0 release
   
-### Important Upgrade Note
-If **DisableLegacyMfa** setting in ``config.json`` is set to ``true`` and [multi-factor authentication]( https://docs.mattermost.com/deployment/auth.html) is enabled, ensure your users have upgraded to mobile app version 1.17 or later. Otherwise, users who have MFA enabled may not be able to log in successfully.
+### Breaking Changes since the last release
 
-If the setting is not defined in the ``config.json`` file, the **DisableLegacyMfa** setting is set to ``false`` by default to ensure no breaking changes.
+ - If **DisableLegacyMfa** setting in ``config.json`` is set to ``true`` and multi-factor authentication is enabled, ensure your users have upgraded to mobile app version 1.17 or later. Otherwise, users who have MFA enabled may not be able to log in successfully. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
+ - The public IP of the Mattermost application server is considered a reserved IP for additional security hardening in the context of untrusted external requests such as Open Graph metadata, webhooks or slash commands. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
 
-We recommend setting **DisableLegacyMfa** to ``true`` for additional security hardening.                                                                         
-
-The public IP of the Mattermost application server is considered a reserved IP for additional security hardening in the context of untrusted external requests such as Open Graph metadata, webhooks or slash commands.
-
-[See documentation](https://docs.mattermost.com/administration/config-settings.html#allow-untrusted-internal-connections-to) for additional information.
+**IMPORTANT:** If you upgrade from another release then 5.8, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
 
 ### Bug Fixes
 
@@ -160,13 +156,6 @@ The public IP of the Mattermost application server is considered a reserved IP f
  - Fixed an issue where invite tokens with a 48-hour expiry expired after 24 hours.
  - Fixed an issue where a blank screen appeared when opening a group message channel from "More" modal using Enter key.
  - Fixed an issue where Zoom plugin caused link metadata code to print warnings in the System Console.
- 
-### Compatibility
-
-#### Breaking Changes
-
- - If **DisableLegacyMfa** setting in ``config.json`` is set to ``true`` and multi-factor authentication is enabled, ensure your users have upgraded to mobile app version 1.17 or later. Otherwise, users who have MFA enabled may not be able to log in successfully. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
- - The public IP of the Mattermost application server is considered a reserved IP for additional security hardening in the context of untrusted external requests such as Open Graph metadata, webhooks or slash commands. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
 
 ### config.json
 
@@ -211,6 +200,12 @@ Mattermost v5.8.0 contains low to high level security fixes. [Upgrading](http://
   - Turned image proxy off by default, unless a server already had it enabled (including new installs). Also, warnings about not getting embedded content for a post were downgraded or removed. See [important upgrade notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
 - **v5.8.0, released 2019-02-16**
   - Original 5.8.0 release
+
+### Breaking Changes since the last release
+
+- The local image proxy has been added, and images displayed within the client are now affected by the ``AllowUntrustedInternalConnections`` setting. See [documentation](https://docs.mattermost.com/administration/image-proxy.html#local-image-proxy) for more details if you have trouble loading images.
+
+**IMPORTANT:** If you upgrade from another release then 5.7, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
 
 ### Highlights
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -1038,6 +1038,18 @@ Multiple setting options were added to `config.json`. Below is a list of the add
  - **v5.0.0, released 2018-06-16**
    - Original 5.0.0 release
 
+### Breaking Changes since the last release
+
+- All API v3 endpoints have been removed. [See documentation](https://api.mattermost.com/#tag/schema) to learn more about how to migrate your integrations to API v4. [Ticket #8708](https://mattermost.atlassian.net/browse/MM-8708).
+- `platform` binary has been renamed to mattermost for a clearer install and upgrade experience. **You should point your `systemd` service file at the new `mattermost` binary.** All command line tools, including the bulk loading tool and developer tools, have also been renamed from platform to mattermost. [Ticket #9985](https://mattermost.atlassian.net/browse/MM-9985).
+- A Mattermost user setting to configure desktop notification duration in **Account Settings** > **Notifications** > **Desktop Notifications** has been removed.
+- Slash commands configured to receive a GET request now have the payload encoded in the query string instead of receiving it in the body of the request, consistent with standard HTTP requests. Although unlikely, this could break custom slash commands that use GET requests incorrectly. [Ticket #10201](https://mattermost.atlassian.net/browse/MM-10201).
+- A new `config.json` setting to whitelist types of protocols for auto-linking has been added. [Ticket #9547](https://mattermost.atlassian.net/browse/MM-9547).
+- A new `config.json` setting to disable the [permanent APIv4 delete team parameter](https://api.mattermost.com/#tag/teams%2Fpaths%2F~1teams~1%7Bteam_id%7D%2Fput) has been added. The setting is off by default for all new and existing installs, except those deployed on GitLab Omnibus. A System Administrator can enable the API v4 endpoint from the config.json file. [Ticket #9916](https://mattermost.atlassian.net/browse/MM-9916).
+- An unused `ExtraUpdateAt` field has been removed from the channel model. [Ticket #9739](https://mattermost.atlassian.net/browse/MM-9739).
+
+**IMPORTANT:** If you upgrade from another release than 4.10, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
+
 ### Highlights
 
 #### Plugin Intercept

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -130,6 +130,17 @@ Mattermost v5.9.0 contains low to medium level security fixes. [Upgrading](http:
   - Mattermost v5.9.1 contains a high level security fix. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
 - **v5.9.0, released 2019-04-16**
   - Original 5.9.0 release
+  
+### Important Upgrade Note
+If **DisableLegacyMfa** setting in ``config.json`` is set to ``true`` and [multi-factor authentication]( https://docs.mattermost.com/deployment/auth.html) is enabled, ensure your users have upgraded to mobile app version 1.17 or later. Otherwise, users who have MFA enabled may not be able to log in successfully.
+
+If the setting is not defined in the ``config.json`` file, the **DisableLegacyMfa** setting is set to ``false`` by default to ensure no breaking changes.
+
+We recommend setting **DisableLegacyMfa** to ``true`` for additional security hardening.                                                                         
+
+The public IP of the Mattermost application server is considered a reserved IP for additional security hardening in the context of untrusted external requests such as Open Graph metadata, webhooks or slash commands.
+
+[See documentation](https://docs.mattermost.com/administration/config-settings.html#allow-untrusted-internal-connections-to) for additional information.
 
 ### Bug Fixes
 

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -136,7 +136,7 @@ Mattermost v5.9.0 contains low to medium level security fixes. [Upgrading](http:
  - If **DisableLegacyMfa** setting in ``config.json`` is set to ``true`` and multi-factor authentication is enabled, ensure your users have upgraded to mobile app version 1.17 or later. Otherwise, users who have MFA enabled may not be able to log in successfully. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
  - The public IP of the Mattermost application server is considered a reserved IP for additional security hardening in the context of untrusted external requests such as Open Graph metadata, webhooks or slash commands. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
 
-**IMPORTANT:** If you upgrade from another release then 5.8, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
+**IMPORTANT:** If you upgrade from another release than 5.8, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
 
 ### Bug Fixes
 
@@ -205,7 +205,7 @@ Mattermost v5.8.0 contains low to high level security fixes. [Upgrading](http://
 
 - The local image proxy has been added, and images displayed within the client are now affected by the ``AllowUntrustedInternalConnections`` setting. See [documentation](https://docs.mattermost.com/administration/image-proxy.html#local-image-proxy) for more details if you have trouble loading images.
 
-**IMPORTANT:** If you upgrade from another release then 5.7, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
+**IMPORTANT:** If you upgrade from another release than 5.7, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
 
 ### Highlights
 
@@ -374,6 +374,14 @@ Mattermost v5.7.0 contains low to medium level security fixes. [Upgrading](http:
 - **v5.6.0, released 2018-12-16**
   - Original 5.6.0 release
 
+### Breaking Changes since the last release
+
+ - Replaced WebRTC prototype with other video and audio calling solutions. [Learn more here](https://docs.mattermost.com/deployment/video-and-audio-calling.html).
+ - Removed support for IE11 Mobile View due to low usage and instability in order to invest that effort in maintaining a high quality experience on other more used browsers. End users on IE11 will thus have an increased minimum screen size.
+ - If EnablePublicChannelsMaterialization setting in config.json is set to false, an offline migration prior to upgrade may be required to synchronize the materialized table for public channels to increase channel search performance in the channel switcher (CTRL/CMD+K), channel autocomplete (~) and elsewhere in the UI. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
+ 
+**IMPORTANT:** If you upgrade from another release than 5.5, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
+
 ### Highlights
 
 #### Interactive Dialogs
@@ -444,10 +452,6 @@ Mattermost v5.7.0 contains low to medium level security fixes. [Upgrading](http:
  - Fixed an issue where pinned post list refreshed when a user posted a new message.
 
 ### Compatibility
-
-#### Deprecated Features
- - Replaced WebRTC prototype with other video and audio calling solutions. [Learn more here](https://docs.mattermost.com/deployment/video-and-audio-calling.html).
- - Removed support for IE11 Mobile View due to low usage and instability in order to invest that effort in maintaining a high quality experience on other more used browsers. End users on IE11 will thus have an increased minimum screen size.
 
 #### config.json
 
@@ -594,9 +598,14 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
 Release date: 2018-10-16
 
- - **Note: Mobile app version 1.13+ is required for servers 5.4+**
-
 - Mattermost v5.4.0 contains a low level security fix. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
+
+### Breaking Changes since the last release
+
+ - Mattermost mobile app version 1.13+ is required. File uploads will fail on earlier mobile app versions.
+ - In certain upgrade scenarios the new Allow Team Administrators to edit others posts setting under General then Users and Teams may be set to True while the Mattermost default in 5.1 and earlier and with new 5.4+ installations is False.
+
+**IMPORTANT:** If you upgrade from another release than 5.3, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
 
 ### Highlights
 
@@ -709,6 +718,12 @@ Mattermost v5.3.0 contains a high level security fix. [Upgrading](http://docs.ma
 - **v5.3.0, released 2018-09-16**
   - Original 5.3.0 release
 
+### Breaking Changes since the last release
+
+ - Those servers with Elasticsearch enabled will notice that hashtag search is case-sensitive.
+
+**IMPORTANT:** If you upgrade from another release than 5.2, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
+
 ### Highlights
 
 #### Search Date Filters
@@ -791,6 +806,12 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 ### Security Update
 
 - Mattermost v5.2.0 contains medium level security fixes. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
+
+### Breaking Changes since the last release
+
+ - Those servers upgrading from v4.1 - v4.4 directly to v5.2 or later and have JIRA enabled will need to re-enable the JIRA plugin after an upgrade.
+
+**IMPORTANT:** If you upgrade from another release than 5.1, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
 
 ### Highlights
 
@@ -915,6 +936,12 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 ### Security Update
 
 - Mattermost v5.1.0 contains multiple security fixes ranging from low to high severity. [Upgrading](http://docs.mattermost.com/administration/upgrade.html) is highly recommended. Details will be posted on our [security updates page](https://about.mattermost.com/security-updates/) 14 days after release as per the [Mattermost Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/).
+
+### Breaking Changes since the last release
+
+ - ``mattermost export`` CLI command is renamed to ``mattermost export schedule``. Make sure to update your scripts if you use this command.
+
+**IMPORTANT:** If you upgrade from another release than 5.0, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
 
 ### Highlights
 
@@ -1066,18 +1093,6 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 ### Compatibility
 
  - For a list of important changes with Mattermost v5.0, please [see our Forum announcement](https://forum.mattermost.org/t/upcoming-changes-with-mattermost-v5-0/5119).
-
-#### Deprecated Features
-
-For a list of past and upcoming deprecated features, [see our website](https://about.mattermost.com/deprecated-features/).
-
-1. All API v3 endpoints have been removed. [See documentation](https://api.mattermost.com/#tag/schema) to learn more about how to migrate your integrations to API v4. [Ticket #8708](https://mattermost.atlassian.net/browse/MM-8708).
-2. `platform` binary has been renamed to mattermost for a clearer install and upgrade experience. **You should point your `systemd` service file at the new `mattermost` binary.** All command line tools, including the bulk loading tool and developer tools, have also been renamed from platform to mattermost. [Ticket #9985](https://mattermost.atlassian.net/browse/MM-9985).
-3. A Mattermost user setting to configure desktop notification duration in **Account Settings** > **Notifications** > **Desktop Notifications** has been removed.
-4. Slash commands configured to receive a GET request now have the payload encoded in the query string instead of receiving it in the body of the request, consistent with standard HTTP requests. Although unlikely, this could break custom slash commands that use GET requests incorrectly. [Ticket #10201](https://mattermost.atlassian.net/browse/MM-10201).
-5. A new `config.json` setting to whitelist types of protocols for auto-linking has been added. [Ticket #9547](https://mattermost.atlassian.net/browse/MM-9547).
-6. A new `config.json` setting to disable the [permanent APIv4 delete team parameter](https://api.mattermost.com/#tag/teams%2Fpaths%2F~1teams~1%7Bteam_id%7D%2Fput) has been added. The setting is off by default for all new and existing installs, except those deployed on GitLab Omnibus. A System Administrator can enable the API v4 endpoint from the config.json file. [Ticket #9916](https://mattermost.atlassian.net/browse/MM-9916).
-7. An unused `ExtraUpdateAt` field has been removed from the channel model. [Ticket #9739](https://mattermost.atlassian.net/browse/MM-9739).
 
 #### config.json
 


### PR DESCRIPTION
I suggest to add the important upgrade notes directly into the changelog.

Why:
I guess most of the admins are going to https://mattermost.com/download/ and in the best case they hit "Changelog". But in the changelog, there is nothing regarding the important upgrade notes.

This PR (i think) helps that the admins can see this important changes at one place.

This PR is WIP to show how i would do it. If Mattermost agree i would add the other notes and clean up.