### PR TITLE
add all props that are available in email template

### DIFF
--- a/source/deployment/customize-email.rst
+++ b/source/deployment/customize-email.rst
@@ -164,7 +164,6 @@ Sent to the user when account has been deactivated.
 
 **Body Props**:
  - SiteURL: URL of the Mattermost server
- - ServerURL: 
  - Title: Message heading
  - Info: Message body
  - Warning: Warning Text

--- a/source/deployment/customize-email.rst
+++ b/source/deployment/customize-email.rst
@@ -6,9 +6,14 @@ Most of the time these templates do not need to be modified.
 In case additional modifications are necessary, all available props in each email are listed below.  
 
 The email templates are located in the Mattermost server directory in the ``templates`` folder.
+The corresponding Strings for each prop can be found in the ``i18n`` folder. 
 
 .. note::
-  The props between different email templates are not interchangable without additional server code changes.
+  The props between different email templates are not interchangable without additional server code changes.  
+
+.. note::
+  Changes made inside of the ``templates`` or ``i18n`` folder might get overwritten during a server update. 
+  Please make sure to backup them accordingly.
 
 
 Available templates

--- a/source/deployment/customize-email.rst
+++ b/source/deployment/customize-email.rst
@@ -43,8 +43,8 @@ Sent to the user when email change has been requested. Contains verification lin
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - VerifyURL: Link for Verification
- - VerifyButton: Button for Verification
+ - VerifyURL: Link for verification
+ - VerifyButton: Button for verification
 
 
 SendEmailChangeEmail
@@ -70,7 +70,7 @@ Sent to the user upon account creation to verify email address.
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - VerifyURL: Link for Verification
+ - VerifyURL: Link for verification
  - Button: Button for confirmation
 
 
@@ -101,10 +101,10 @@ Sent to the user when account has been created. May also contain download links 
  - Info2: Continuation of message body
  - Info3: Continuation of message body
 
-Optional Props:
+**Optional Props**:
  - AppDownloadInfo
  - AppDownloadLink
- - VerifyURL: Link for Verification
+ - VerifyURL: Link for verification
 
 
 SendPasswordChangeEmail

--- a/source/deployment/customize-email.rst
+++ b/source/deployment/customize-email.rst
@@ -2,16 +2,16 @@ Email Templates
 ====================
 
 Mattermost has a few email templates that are sent out when a specific event occurs.
-Most of the time these do not need to be modified.
-In case additional modifications are neccessary all available props in each email are listed below.  
+Most of the time these templates do not need to be modified.
+In case additional modifications are necessary, all available props in each email are listed below.  
 
 The email templates are located in the Mattermost server directory in the ``templates`` folder.
 
 .. note::
-  The props between different email templates are not interchangable without additional server code changes!
+  The props between different email templates are not interchangable without additional server code changes.
 
 
-Available templates:
+Available templates
 ------------------------
 
 

--- a/source/deployment/customize-email.rst
+++ b/source/deployment/customize-email.rst
@@ -6,7 +6,7 @@ Most of the time these templates do not need to be modified.
 In case additional modifications are necessary, all available props in each email are listed below.  
 
 The email templates are located in the Mattermost server directory in the ``templates`` folder.
-The corresponding Strings for each prop can be found in the ``i18n`` folder. 
+The corresponding strings for each prop can be found in the ``i18n`` folder. 
 
 .. note::
   The props between different email templates are not interchangable without additional server code changes.  
@@ -30,7 +30,7 @@ Sent to the user when username has been changed.
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - Warning: Warning Text
+ - Warning: Warning text
 
 
 SendEmailChangeVerifyEmail
@@ -57,7 +57,7 @@ Sent to the user when email has been changed succesfully.
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - Warning: Warning Text
+ - Warning: Warning text
 
 
 SendVerifyEmail
@@ -84,7 +84,7 @@ Sent to the user when sign-in method has been changed (i.e. from email to LDAP, 
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - Warning: Warning Text
+ - Warning: Warning text
 
 
 SendWelcomeEmail
@@ -117,7 +117,7 @@ Sent to the user when password has been changed.
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - Warning: Warning Text
+ - Warning: Warning text
 
 
 SendAccessTokenEmail
@@ -130,7 +130,7 @@ Sent to the user when an access token has been added to the account.
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - Warning: Warning Text
+ - Warning: Warning text
 
 
 SendPasswordResetEmail
@@ -158,7 +158,7 @@ Sent to the user when multi-factor authentication method has been changed.
  - SiteURL: URL of the Mattermost server
  - Info: Message body
  - Title: Message heading
- - Warning: Warning Text
+ - Warning: Warning text
 
 
 SendDeactivateAccountEmail
@@ -171,7 +171,7 @@ Sent to the user when account has been deactivated.
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - Warning: Warning Text
+ - Warning: Warning text
 
 
 SendInviteEmails

--- a/source/deployment/customize-email.rst
+++ b/source/deployment/customize-email.rst
@@ -1,0 +1,186 @@
+Email Templates
+====================
+
+Mattermost has a few email templates that are sent out when a specific event occurs.
+Most of the time these do not need to be modified.
+In case additional modifications are neccessary all available props in each email are listed below.  
+
+The email templates are located in the Mattermost server directory in the ``templates`` folder.
+
+.. note::
+  The props between different email templates are not interchangable without additional server code changes!
+
+
+Available templates:
+------------------------
+
+
+SendChangeUsernameEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when username has been changed.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - Warning: Warning Text
+
+
+SendEmailChangeVerifyEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when email change has been requested. Contains verification link and button.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - VerifyUrl: Link for Verification
+ - VerifyButton: Button for Verification
+
+
+SendEmailChangeEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when email has been changed succesfully.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - Warning: Warning Text
+
+
+SendVerifyEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user upon account creation to verify email address.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - VerifyUrl: Link for Verification
+ - Button: Button for confirmation
+
+
+SendSignInChangeEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when sign-in method has been changed (i.e. from email to LDAP, etc.)
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - Warning: Warning Text
+
+
+SendWelcomeEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when account has been created. May also contain download links to Apps as well as email verification links.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - Button: Button for confirmation
+ - Info2: Continuation of message body
+ - Info3: Continuation of message body
+
+Optional Props:
+ - AppDownloadInfo
+ - AppDownloadLink
+ - VerifyUrl: Link for Verification
+
+
+SendPasswordChangeEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when password has been changed.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - Warning: Warning Text
+
+
+SendAccessTokenEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when an access token has been added to the account.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - Warning: Warning Text
+
+
+SendPasswordResetEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when password request has been initiated.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info1: Message body
+ - Info2: Continuation of message body
+ - ResetUrl: Url to reset password
+ - Button: Button for confirmation
+
+
+SendMfaChangeEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when multi-factor authentication method has been changed.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Info: Message body
+ - Title: Message heading
+ - Warning: Warning Text
+
+
+SendDeactivateAccountEmail
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when account has been deactivated.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - ServerURL: 
+ - Title: Message heading
+ - Info: Message body
+ - Warning: Warning Text
+
+
+SendInviteEmails
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose**:
+Sent to the user when team invite via email has been used.
+
+**Body Props**:
+ - SiteURL: URL of the Mattermost server
+ - Title: Message heading
+ - Info: Message body
+ - Button: Button for confirmation
+ - ExtraInfo: Additional info about Mattermost
+ - TeamURL: URL to the team the user has been invited to
+ - Link: URL for team invite confirmation (not to be confused with TeamURL)

--- a/source/deployment/customize-email.rst
+++ b/source/deployment/customize-email.rst
@@ -1,5 +1,5 @@
 Email Templates
-====================
+===============
 
 Mattermost has a few email templates that are sent out when a specific event occurs.
 Most of the time these templates do not need to be modified.
@@ -11,17 +11,17 @@ The corresponding Strings for each prop can be found in the ``i18n`` folder.
 .. note::
   The props between different email templates are not interchangable without additional server code changes.  
 
-.. note::
+.. warning::
   Changes made inside of the ``templates`` or ``i18n`` folder might get overwritten during a server update. 
   Please make sure to backup them accordingly.
 
 
 Available templates
-------------------------
+-------------------
 
 
 SendChangeUsernameEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when username has been changed.
@@ -43,12 +43,12 @@ Sent to the user when email change has been requested. Contains verification lin
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - VerifyUrl: Link for Verification
+ - VerifyURL: Link for Verification
  - VerifyButton: Button for Verification
 
 
 SendEmailChangeEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when email has been changed succesfully.
@@ -61,7 +61,7 @@ Sent to the user when email has been changed succesfully.
 
 
 SendVerifyEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user upon account creation to verify email address.
@@ -70,12 +70,12 @@ Sent to the user upon account creation to verify email address.
  - SiteURL: URL of the Mattermost server
  - Title: Message heading
  - Info: Message body
- - VerifyUrl: Link for Verification
+ - VerifyURL: Link for Verification
  - Button: Button for confirmation
 
 
 SendSignInChangeEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when sign-in method has been changed (i.e. from email to LDAP, etc.)
@@ -88,7 +88,7 @@ Sent to the user when sign-in method has been changed (i.e. from email to LDAP, 
 
 
 SendWelcomeEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when account has been created. May also contain download links to Apps as well as email verification links.
@@ -104,11 +104,11 @@ Sent to the user when account has been created. May also contain download links 
 Optional Props:
  - AppDownloadInfo
  - AppDownloadLink
- - VerifyUrl: Link for Verification
+ - VerifyURL: Link for Verification
 
 
 SendPasswordChangeEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when password has been changed.
@@ -121,7 +121,7 @@ Sent to the user when password has been changed.
 
 
 SendAccessTokenEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when an access token has been added to the account.
@@ -134,7 +134,7 @@ Sent to the user when an access token has been added to the account.
 
 
 SendPasswordResetEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when password request has been initiated.
@@ -144,12 +144,12 @@ Sent to the user when password request has been initiated.
  - Title: Message heading
  - Info1: Message body
  - Info2: Continuation of message body
- - ResetUrl: Url to reset password
+ - ResetURL: URL to reset password
  - Button: Button for confirmation
 
 
 SendMfaChangeEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when multi-factor authentication method has been changed.
@@ -162,7 +162,7 @@ Sent to the user when multi-factor authentication method has been changed.
 
 
 SendDeactivateAccountEmail
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when account has been deactivated.
@@ -175,7 +175,7 @@ Sent to the user when account has been deactivated.
 
 
 SendInviteEmails
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 **Purpose**:
 Sent to the user when team invite via email has been used.

--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -74,7 +74,8 @@ Learn how to configure settings to meet your unique requirements.
 
    /deployment/on-boarding.rst  
    /administration/config-settings.rst
-   /deployment/customize-mattermost.rst 
+   /deployment/customize-mattermost.rst
+   /deployment/customize-email.rst 
    /administration/branding.rst
 
 Mobile Apps


### PR DESCRIPTION
This was created in regard to #2125 
Additional info can surely be added but this should give users a quick overview over what can be used in what template without having to dig through the templates first.

Categorization is subject to change but I thought this was fitting because it is a) configuration of an existing instance and b) done after deployment.

Open for any changes as always :)