### PR TITLE
Fix minor docs typos and inconsistencies

### DIFF
--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -148,7 +148,7 @@ For other troubleshooting tips for WebSocket errors, see `potential solutions he
     environment:
       # set same as db credentials and dbname
       - MM_USERNAME=mmuser
-      - MM_PASSWORD=mmuser_password
+      - MM_PASSWORD=mmuser-password
       - MM_DBNAME=mattermost
       - VIRTUAL_HOST=mymattermost.tld
     expose:

--- a/source/install/install-debian-postgresql.rst
+++ b/source/install/install-debian-postgresql.rst
@@ -40,7 +40,7 @@ Assume that the IP address of this server is 10.10.10.1
 
 7. Exit the PostgreSQL interactive terminal.
 
-  ``postgre=# \q``
+  ``postgres=# \q``
 
 8. Log out of the *postgres* account.
 

--- a/source/install/install-debian-postgresql.rst
+++ b/source/install/install-debian-postgresql.rst
@@ -29,7 +29,7 @@ Assume that the IP address of this server is 10.10.10.1
 
 5.  Create the Mattermost user 'mmuser'.
 
-  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser_password';``
+  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser-password';``
 
   .. note::
     Use a password that is more secure than 'mmuser-password'.

--- a/source/install/install-rhel-6-postgresql.rst
+++ b/source/install/install-rhel-6-postgresql.rst
@@ -54,7 +54,7 @@ Installing PostgreSQL Database
 
 13. Exit the PostgreSQL interactive terminal.
 
-  ``postgre=# \q``
+  ``postgres=# \q``
 
 14. Log out of the *postgres* account.
 

--- a/source/install/install-rhel-6-postgresql.rst
+++ b/source/install/install-rhel-6-postgresql.rst
@@ -43,7 +43,7 @@ Installing PostgreSQL Database
 
 11.  Create the Mattermost user 'mmuser'.
 
-  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser_password';``
+  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser-password';``
 
   .. note::
     Use a password that is more secure than 'mmuser-password'.

--- a/source/install/install-rhel-7-postgresql.rst
+++ b/source/install/install-rhel-7-postgresql.rst
@@ -50,7 +50,7 @@ Installing PostgreSQL Database
 
 11.  Create the Mattermost user 'mmuser'.
 
-  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser_password';``
+  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser-password';``
 
   .. note::
     Use a password that is more secure than 'mmuser-password'.

--- a/source/install/install-rhel-7-postgresql.rst
+++ b/source/install/install-rhel-7-postgresql.rst
@@ -61,7 +61,7 @@ Installing PostgreSQL Database
 
 13. Exit the PostgreSQL interactive terminal.
 
-  ``postgre=# \q``
+  ``postgres=# \q``
 
 14. Log out of the *postgres* account.
 

--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -40,7 +40,7 @@ Assume that the IP address of this server is 10.10.10.1
 
 7. Exit the PostgreSQL interactive terminal.
 
-  ``postgre=# \q``
+  ``postgres=# \q``
 
 8. Log out of the *postgres* account.
 

--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -29,7 +29,7 @@ Assume that the IP address of this server is 10.10.10.1
 
 5.  Create the Mattermost user 'mmuser'.
 
-  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser_password';``
+  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser-password';``
 
   .. note::
     Use a password that is more secure than 'mmuser-password'.

--- a/source/install/install-ubuntu-1804-postgresql.rst
+++ b/source/install/install-ubuntu-1804-postgresql.rst
@@ -40,7 +40,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
 7. Exit the PostgreSQL interactive terminal.
 
-  ``postgre=# \q``
+  ``postgres=# \q``
 
 8. Log out of the *postgres* account.
 

--- a/source/install/install-ubuntu-1804-postgresql.rst
+++ b/source/install/install-ubuntu-1804-postgresql.rst
@@ -29,7 +29,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
 5.  Create the Mattermost user 'mmuser'.
 
-  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser_password';``
+  ``postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser-password';``
 
   .. note::
     Use a password that is more secure than 'mmuser-password'.

--- a/source/install/prod-windows-2012.rst
+++ b/source/install/prod-windows-2012.rst
@@ -103,14 +103,14 @@ for Mattermost to utilize.
     .. code:: sql
 
        CREATE DATABASE mattermost;
-       CREATE USER mmuser IDENTIFIED BY 'mmuser_password';
+       CREATE USER mmuser IDENTIFIED BY 'mmuser-password';
        GRANT ALL ON mattermost.* TO mmuser;
        exit
 
 21. To confirm the database and user were configured correctly
 
     a. Connect to the MySQL server/datbase by executing ``mysql -u mmuser -p mattermost`` 
-    b. When prompted, entering ``mmuser_password``
+    b. When prompted, entering ``mmuser-password``
     c. If If successful, you will be at the ``mysql>`` prompt 
     d. Type ``exit`` to finish
 
@@ -136,7 +136,7 @@ Set up Mattermost Server
    * Update database name and server in the the connection string:
      
      * Old: ``"DataSource": "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8"``    
-     * New: ``"DataSource": "mmuser:mmuser_password@tcp(10.0.0.1:3306)/mattermost?charset=utf8mb4,utf8"``
+     * New: ``"DataSource": "mmuser:mmuser-password@tcp(10.0.0.1:3306)/mattermost?charset=utf8mb4,utf8"``
 
    .. note :: Optionally you may continue to edit configuration settings in ``config.json`` or use the 
       System Console described in a later section to finish the configuration.

--- a/source/install/prod-windows-2012.rst
+++ b/source/install/prod-windows-2012.rst
@@ -418,4 +418,3 @@ Finish Mattermost Server Setup
       net stop mattermost
       net start mattermost
 
-


### PR DESCRIPTION
Fixed a couple instances of typos around the postgres prompt (missing a trailing 's').

And be consistent with the sample database password.  There were 37 instances of "mmuser-password", and 9 instances of "mmuser_password".  So I changed all of the "mmuser_password" to "mmuser-password" in the interest of consistency.  Now, copy-and-paste from the install docs works much better.

Thanks!
Dustin