### PR TITLE
Modified the /etc/security/limits.conf

### DIFF
--- a/source/deployment/cluster.rst
+++ b/source/deployment/cluster.rst
@@ -96,10 +96,10 @@ Configuration Settings
 
   .. code-block:: none
 
-    soft nofile 65536
-    hard nofile 65536
-    soft nproc 8192
-    hard nproc 8192
+    * soft nofile 65536
+    * hard nofile 65536
+    * soft nproc 8192
+    * hard nproc 8192
 
 3. Increase the number of websocket connections
 


### PR DESCRIPTION
In various articles I see guidance to edit the limits.conf but it always advises defining the domain as well as type, item, value as per the file guidance. Is * or the mattermost user required in domain? Does the guidance vary for Ubuntu vs other linux distributions?
https://docs.datastax.com/en/archived/cassandra/2.0/cassandra/install/installRecommendSettings.html