### PR TITLE
Add warning when upgrading to 5.10 with read-only config.json

### DIFF
--- a/source/administration/important-upgrade-notes.rst
+++ b/source/administration/important-upgrade-notes.rst
@@ -11,6 +11,8 @@ Important Upgrade Notes
 |                                                    |                                                                                                                                                                  |
 |                                                    | This change was made because ``Update.Props == nil`` unintentionally cleared all ``Props``, such as the profile picture, instead of preserving them.             |
 +----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| v5.10.0                                            |  Following support added to store configuration in the database, it is now required for the ``config.json`` file to be writable for the server to start          |
++----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | v5.9.0                                             | If **DisableLegacyMfa** setting in ``config.json`` is set to ``true`` and `multi-factor authentication <https://docs.mattermost.com/deployment/auth.html>`_ is   |
 |                                                    | enabled, ensure your users have upgraded to mobile app version 1.17 or later. Otherwise, users who have MFA enabled may not be able to log in successfully.      |
 |                                                    |                                                                                                                                                                  |


### PR DESCRIPTION
I encountered this issue because we used a configmap (which is a read-only file) in Kubernetes to hold the configuration, and 5.10 refused to start.