### PR TITLE
remove reference to SkillSurvey checks during interview process

### DIFF
--- a/source/process/developer.rst
+++ b/source/process/developer.rst
@@ -77,7 +77,6 @@ Both declined and accepted candidates will be invited to share feedback on their
 - **Video call - Screening interview** - Selected candidates will be invited for a 25-minute screening call with a recruiter.
 - **Video call - Soft-skills discussion** - Next, candidates will be invited to schedule a 25-minute interview with a core committer to assess soft skills and for the candidate to learn more about the role.
 - **Audition** - Candidates who appear technically strong and culturally fit may be offered a real-world “try out” project with Mattermost team members to simulate what it would be like to work on a major open source project.
-- **Reference Checks** - You'll be sent an email request by `SkillSurvey <http://www.skillsurvey.com/>`__ to list 3 references who can verify your past achievements.
 - **Video call - CTO interview** - Candidates are invited to a 45-minute interview with our CTO and co-creator of the Mattermost open source project. The interview may include technical questions along with a discussion of either past work or results of the simulation, the candidate's interests, their career aspirations, and how being a core committer at Mattermost could align with those interests and aspirations.
 - **Video call - CEO interview** - Finally, candidates will have a 45-minute interview with our CEO.
 - **Email - Offer** - Successful candidates will receive an offer via email. Mattermost offers compensation competitive with a candidate's local market opportunities.


### PR DESCRIPTION
These checks are largely useless -- easily faked, and mostly covering things for which we've evaluated the candidate directly. This hasn't been a part of recent interviews anyway.