### PR TITLE
Create placeholder page for bot-accounts.rst

### DIFF
--- a/source/developer/bot-accounts.rst
+++ b/source/developer/bot-accounts.rst
@@ -1,0 +1,1 @@
+This is a placeholder page for documenting Bot Accounts, which is shipping on Mattermost 5.12


### PR DESCRIPTION
This is to fix a redirect from https://mattermost.com/pl/default-bot-accounts, and to fix https://mattermost.atlassian.net/browse/MM-15478

Actual PR for docs to be submitted prior to 5.12 release.