### PR TITLE
WIP: add spec for Guest Access

### DIFF
--- a/source/explorations/guest-accounts.rst
+++ b/source/explorations/guest-accounts.rst
@@ -1,0 +1,24 @@
+WIP
+
+
+Who is a target group for this file/MR:
+
+Designers (contribute UI designs): 
+  - what problem are we solving, what are the use cases that this problem affects, what are the user stories that are involve in solving this problem, what are the successful outcomes, what are the potential error paths and edge cases, how does this fit into the existing UI patterns we have, what design patterns already exist for solving this type of problem in competitive or commonly used products? 
+
+Developers (may contribute technical designs documentation): 
+  - what do we need to build, how should we build it, how does this fit in with what already exists, what is required now/ what will this look like in the future? 
+
+QA (may contribute test plans) 
+  - what are the use cases this solution solves, how does this affect other parts of the product, what are the successful paths and the error paths
+
+Sales/Marketing/Leadership/other internal stakeholders (contribute requirements and feedback):
+  - what business value will this feature provide us, why are we investing in solving this problem, what are the expected outcomes for our customers and our business, Who is requesting this, What are our competitors doing in comparison, why did we decide to solve the problem (technical/ux) the way that we did? 
+
+
+Who is NOT a target group for this file/MR:
+
+Customers & Community (contribute requirements, use cases and design feedback): 
+ - what feature is coming, what problem will it solve for them, how will it solve that problem, when can they expect it to be available.
+
+


### PR DESCRIPTION
it is faster to copy paste screenshots at the comments of the MRs rather than putting them at the file.
However, once the MR *-internal is accepted/rejected this file should be readable by an employee outside of these discussions