### PR TITLE
Add note to license upload for cli and cluster setups

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -832,8 +832,8 @@ mattermost license upload
 
       ./mattermost license upload /path/to/license/mylicensefile.mattermost-license
 
-.. note:
-    The Mattermost server needs to be restarted after uploading a license file for any changes to take effect. Also for cluster setups the license file needs to be uploaded to every node.
+.. note::
+  The Mattermost server needs to be restarted after uploading a license file for any changes to take effect. Also for cluster setups the license file needs to be uploaded to every node.
 
 mattermost logs
 ------------------

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -832,6 +832,9 @@ mattermost license upload
 
       ./mattermost license upload /path/to/license/mylicensefile.mattermost-license
 
+  .. note:
+    The Mattermost server needs to be restarted after uploading a license file for any changes to take effect. Also for cluster setups the license file needs to be uploaded to every node.
+
 mattermost logs
 ------------------
 

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -833,7 +833,7 @@ mattermost license upload
       ./mattermost license upload /path/to/license/mylicensefile.mattermost-license
 
 .. note::
-  The Mattermost server needs to be restarted after uploading a license file for any changes to take effect. Also for cluster setups the license file needs to be uploaded to every node.
+  The Mattermost server needs to be restarted after uploading a license file for any changes to take effect. Also, for cluster setups the license file needs to be uploaded to every node.
 
 mattermost logs
 ------------------

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -832,7 +832,7 @@ mattermost license upload
 
       ./mattermost license upload /path/to/license/mylicensefile.mattermost-license
 
-  .. note:
+.. note:
     The Mattermost server needs to be restarted after uploading a license file for any changes to take effect. Also for cluster setups the license file needs to be uploaded to every node.
 
 mattermost logs

--- a/source/install/ee-install.rst
+++ b/source/install/ee-install.rst
@@ -84,7 +84,7 @@ Use this command to upload a new license or to replace an existing license with 
   mattermost license upload {license}
 
 .. note::
-  If you upload the license via `mattermost license upload` CLI, you need to restart the Mattermost server after uploading. Also if you're running a cluster setup the license file needs to be uploaded to every node.
+  If you upload the license via `mattermost license upload` CLI, you need to restart the Mattermost server after uploading. Also, if you're running a cluster setup, the license file needs to be uploaded to every node.
 
 
 See `documentation for more information on the command line tools <https://docs.mattermost.com/administration/command-line-tools.html#mattermost-license-upload>`__.

--- a/source/install/ee-install.rst
+++ b/source/install/ee-install.rst
@@ -83,6 +83,10 @@ Use this command to upload a new license or to replace an existing license with 
 
   mattermost license upload {license}
 
+.. note::
+  If you upload the license via CLI you need to restart the mattermost server after uploading. Also if you're running a cluster setup the license file needs to be uploaded to every node.
+
+
 See `documentation for more information on the command line tools <https://docs.mattermost.com/administration/command-line-tools.html#mattermost-license-upload>`__.
 
 **Through the System Console:**


### PR DESCRIPTION
Currently the docs do not state that the mattermost server needs a restart to reflect changes after uploading a license file. 

Also added a note for cluster setups specifying that the license file needs to be uploaded to every note in the setup.