### PR TITLE
Fix various minor visual bugs

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -332,7 +332,7 @@ Allow Team Administrators to edit others posts
 **False**:  Only System Administrators can edit other users' posts.
 
 .. note::
-This setting is only available for Team Edition servers. Enterprise Edition servers can use `Advanced Permissions <https://docs.mattermost.com/deployment/advanced-permissions.html>`__ to configure this permission.   
+  This setting is only available for Team Edition servers. Enterprise Edition servers can use `Advanced Permissions <https://docs.mattermost.com/deployment/advanced-permissions.html>`__ to configure this permission.
 
 
 Enable Team Directory
@@ -1091,7 +1091,7 @@ Group Filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (Optional) Enter an AD/LDAP Filter to use when searching for group objects (accepts `general syntax <http://www.ldapexplorer.com/en/manual/109010000-ldap-filter-syntax.htm>`__). Only the groups selected by the query will be able accessible to Mattermost. 
 
-This filter is defaulted to ```(|(objectClass=group)(objectClass=groupOfNames)(objectClass=groupOfUniqueNames))``` when blank.  
+This filter is defaulted to ``(|(objectClass=group)(objectClass=groupOfNames)(objectClass=groupOfUniqueNames))`` when blank.
 
 .. note::
   This filter is used only when AD/LDAP Group Sync is enabled.  See `AD/LDAP Group Sync documentation <https://docs.mattermost.com/deployment/ldap-group-sync.html>`_ for more information on enabling and configuring AD/LDAP Group Sync (*Available in Enterprise Edition E20 and higher*). 
@@ -2652,7 +2652,7 @@ Custom URL Schemes
 A list of URL schemes that are used for autolinking in message text. ``http``, ``https``, ``ftp``, ``tel`` and ``mailto`` always create links.
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"CustomUrlSchemes": []`` which takes an array of URL schemes such as ``["git", "smtp"]`.                                 |
+| This feature's ``config.json`` setting is ``"CustomUrlSchemes": []`` which takes an array of URL schemes such as ``["git", "smtp"]``.                                |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 ________

--- a/source/deployment/advanced-permissions.rst
+++ b/source/deployment/advanced-permissions.rst
@@ -64,7 +64,6 @@ Interface for naming, assigning teams and editing permissions in a Team Override
 Channel Override Permissions (E20)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
 *Available in a future release of Enterprise Edition E20*
 
 Allows Admins to restrict permissions within specific channels. Permissions under consideration for this phase include:
@@ -76,7 +75,6 @@ Allows Admins to restrict permissions within specific channels. Permissions unde
 Supplementary Roles (E20)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note::
 *Available in a future release of Enterprise Edition E20*
 
 Allows Admins to grant additional permissions to specific users or to a group of users based on AD/LDAP group membership. Permissions can be granted within the scope of channels, teams or system level.

--- a/source/developer/interactive-dialogs.rst
+++ b/source/developer/interactive-dialogs.rst
@@ -39,7 +39,7 @@ Interactive dialogs support the following parameters:
     "icon_url", "String", "(Optional) The URL of the icon used for your dialog. If none specified, no icon is displayed."
     "submit_label", "String", "(Optional) Label of the button to complete the dialog. Default is ``Submit``."
     "notify_on_cancel", "String", "(Optional) When true, sends an event back to the integration whenever there's a user-induced dialog cancellation. No other data is sent back with the event. Default is ``false``."
-    "state", "String", "(Optional) String provided by the integration that will be echoed back with dialog submission. Default is `` ``."
+    "state", "String", "(Optional) String provided by the integration that will be echoed back with dialog submission. Default is the empty string."
 
 Sample JSON is given below. Form submissions are sent back to the URL defined by the integration. You must also include the trigger ID you received from the slash command or interactive message.
 

--- a/source/getting-started/implementation_plan.rst
+++ b/source/getting-started/implementation_plan.rst
@@ -85,7 +85,7 @@ A recommended installation of Mattermost Enterprise E20 configured with a redund
 +-------------------+---------+---------------+--------+----------+
 
 .. note::
-Mattermost hardware sizing guidance can be found here: https://docs.mattermost.com/install/requirements.html#hardware-requirements
+  Mattermost hardware sizing guidance can be found here: https://docs.mattermost.com/install/requirements.html#hardware-requirements
 
 2.3 Project References
 .........................................

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -35,10 +35,10 @@ system. To share an attachment, click the thumbnail of an attachment, then click
 **Get Public Link**.
 
 .. Tip::
-If **Get Public Link** is not visible in the file previewer
-and you prefer that the feature is enabled, you can request your System 
-Admin to enable the feature from the System Console under 
-**Security > Public Links**.
+  If **Get Public Link** is not visible in the file previewer
+  and you prefer that the feature is enabled, you can request your System
+  Admin to enable the feature from the System Console under
+  **Security > Public Links**.
 
 Viewing Media:
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/install/install-ubuntu-1604-mysql.rst
+++ b/source/install/install-ubuntu-1604-mysql.rst
@@ -41,9 +41,9 @@ Install and set up the database for use by the Mattermost server. You can instal
   ``mysql> grant all privileges on mattermost.* to 'mmuser'@'%';``
 
   .. note::
-  This query grants the MySQL user we just created all privileges on the database for convenience. If you need more security you can use this query to grant the user only the privileges necessary to run Mattermost.
+    This query grants the MySQL user we just created all privileges on the database for convenience. If you need more security you can use this query to grant the user only the privileges necessary to run Mattermost.
 
-  ``mysql> GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, SELECT, UPDATE ON mattermost.* TO 'mmuser'@'%';``
+    ``mysql> GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, SELECT, UPDATE ON mattermost.* TO 'mmuser'@'%';``
 
 7. Log out of MySQL.
  

--- a/source/install/install-ubuntu-1804-mysql.rst
+++ b/source/install/install-ubuntu-1804-mysql.rst
@@ -38,9 +38,9 @@ Install and set up the database for use by the Mattermost server. You can instal
   ``mysql> grant all privileges on mattermost.* to 'mmuser'@'%';``
 
   .. note::
-  This query grants the MySQL user we just created all privileges on the database for convenience. If you need more security you can use this query to grant the user only the privileges necessary to run Mattermost.
+    This query grants the MySQL user we just created all privileges on the database for convenience. If you need more security you can use this query to grant the user only the privileges necessary to run Mattermost.
 
-  ``mysql> GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, SELECT, UPDATE ON mattermost.* TO 'mmuser'@'%';``
+    ``mysql> GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, SELECT, UPDATE ON mattermost.* TO 'mmuser'@'%';``
 
 8. Log out of MySQL.
 


### PR DESCRIPTION
This fixes a number of minor visual bugs in the documentation, primarily note/tip blocks that were contentless because their intended content wasn't properly indented.