### PR TITLE
Changed umask value

### DIFF
--- a/source/scripts/generate-certificates/gencert.sh
+++ b/source/scripts/generate-certificates/gencert.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-umask 377
+umask 007
 
 certname="${CRT_FILENAME:-"mattermost-x509"}"
 openssl x509 \


### PR DESCRIPTION
I was getting an error running the script below
/bin$ ubuntu@ip-172-31-84-21:/usr/local/bin$ sudo gencert.sh
/bin$: No such file or directory
/bin$ x509: Cannot open input file mattermost-x509.key, No such file or directory
I updated the umask to 007and the script worked. I think the original umask 377 only allows read permissions to the owner not write.