### PR TITLE
Add a database change to 5.10 changelog

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -156,6 +156,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
    - PERMISSION_READ_OTHERS_BOTS
    - PERMISSION_MANAGE_BOTS
    - PERMISSION_MANAGE_OTHERS_BOTS
+ - `Bots` table was added.
 
 ### Known Issues
  - Attachments menu on mobile view is partly cut off on the right-hand side.


### PR DESCRIPTION
Server PR: https://github.com/mattermost/mattermost-server/pull/10378

I believe this was missed in the changelog because it wasn't included in https://github.com/mattermost/mattermost-server/blob/master/store/sqlstore/upgrade.go, and the feature didn't officially ship until 5.12

---

@amyblais for editor review
@crspeller for dev review to confirm no other database changes were made as a result of bot accounts. Writing the full changes below, given some were already recorded and hence not all of them are visible in the diff.

```
 - Granted the following permissions for the System Admin, in preparation for an upcoming bot accounts feature:
   - PERMISSION_CREATE_BOT
   - PERMISSION_READ_BOTS
   - PERMISSION_READ_OTHERS_BOTS
   - PERMISSION_MANAGE_BOTS
   - PERMISSION_MANAGE_OTHERS_BOTS
 - `Bots` table was added.
```