### PR TITLE
The current upgrade manual disables manually installed plugins

### DIFF
--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -155,8 +155,10 @@ Location of your local storage directory
     .. code-block:: sh
 
       cd {install-path}/mattermost
-      sudo mv plugins~/ plugins
-      sudo mv client/plugins~/ client/plugins
+      sudo rsync -au plugins~/ plugins
+      sudo rm -rf plugins~
+      sudo rsync -au client/plugins~/ client/plugins
+      sudo rm -rf client/plugins~
 
 After the server is upgraded, users might need to refresh their browsers to experience any new features.
 


### PR DESCRIPTION
Hi everyone,

I recently discovered that the monthly mattermost server upgrade caused my plugins folders to have a strange structure. Thus, I opened the following post in the community forum:
[https://forum.mattermost.org/t/a-question-concerning-the-uprading-mattermost-server-documentation/7477](https://forum.mattermost.org/t/a-question-concerning-the-uprading-mattermost-server-documentation/7477)

There you can find a complete description of the problem. Furthermore, I was asked to create a pull request with my solution, so that you can check if it is okay.

One more comment: Using the -u flag with rsync keeps newer files in the destination folder, thus while upgrading mattermost, the prepackaged plugins are also upgraded.

Thank you for all your work,
Nils