### PR TITLE
Move NPS out of Integration Guide

### DIFF
--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -139,6 +139,7 @@ Learn how to maintain your Mattermost system.
    /administration/health-check*
    /administration/announcement-banner.rst
    /administration/bulk-export.rst
+   /integrations/net-promoter-score*
  
 Upgrade Mattermost
 ----------------------------

--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -136,10 +136,10 @@ Learn how to maintain your Mattermost system.
    /administration/command*
    /administration/scripts*
    /administration/statistics.md
+   /integrations/net-promoter-score*
    /administration/health-check*
    /administration/announcement-banner.rst
    /administration/bulk-export.rst
-   /integrations/net-promoter-score*
  
 Upgrade Mattermost
 ----------------------------

--- a/source/guides/integration.rst
+++ b/source/guides/integration.rst
@@ -11,7 +11,6 @@ See one of the sample integrations below or visit the `Mattermost Integrations D
    
    /integrations/jira*
    /integrations/zoom*
-   /integrations/net-promoter-score*
    /integrations/zapier*
 
 **Are you looking to develop an integration?**


### PR DESCRIPTION
I'm 4/5 NPS plugin doesn't belong in the Integration's Guide because it is not about integrating other systems into Mattermost.

![image](https://user-images.githubusercontent.com/13119842/59727244-e620a600-9202-11e9-8149-8691ce360407.png)

That said, I'm on the fence about whether this goes into an end user guide or admin guide. I opted for "Administration" section of the Admin Guide, but I'm 0/5 on that to be honest. 

Another option is creating a new section in TOC for telemetry and NPS survey (under Administrator's Guide), but that feels like a lot of emphasis for that topic.

Looking for thoughts.