### PR TITLE
 Move plugins from Admin to Integrations section

### DIFF
--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -165,7 +165,6 @@ Learn how to extend Mattermost by integrating your workflows.
    :maxdepth: 2
    :glob:
 
-   /administration/plugins*
    /integrations/net-promoter-score*
    /developer/toolkit*
    /deployment/atlassian-integrations*

--- a/source/guides/integration.rst
+++ b/source/guides/integration.rst
@@ -29,6 +29,7 @@ See our documentation below.
    /developer/api.rst
    /developer/webhooks*
    /developer/slash*
+   /administration/plugins*
    /developer/message-attachments*
    /developer/interactive-messages*
    /developer/interactive-dialogs*


### PR DESCRIPTION
I envision the Administrator's Guide section about integrations be a generic overview of how to integrate with Mattermost, and the Integration Guide being more specific features/functionality supported by Mattermost.

Amy is helping create more generic integration pages for Git tools, incident response and bots, so this PR is in preparation of that.

This is also a follow-up to https://github.com/mattermost/docs/pull/2744