### PR TITLE
Fix link to Enterprise upgrade feature comparison chart

### DIFF
--- a/source/install/ee-install.rst
+++ b/source/install/ee-install.rst
@@ -4,7 +4,7 @@
 Enterprise Install and Upgrade
 ===========================================
 
-Mattermost Enterprise Edition is free to use in "team mode" without enterprise features enabled. Enable enterprise features using a `trial license <https://about.mattermost.com/trial/>`__ or by `purchasing a license key <https://about.mattermost.com/pricing/>`__. There are two variants of Enterprise Edition, E10 and E20, and you can `compare their features online <https://about.mattermost.com/features/>`__.
+Mattermost Enterprise Edition is free to use in "team mode" without enterprise features enabled. Enable enterprise features using a `trial license <https://about.mattermost.com/trial/>`__ or by `purchasing a license key <https://about.mattermost.com/pricing/>`__. There are two variants of Enterprise Edition, E10 and E20, and you can `compare their features online <https://mattermost.com/pricing-feature-comparison/>`__.
 
 Installing Enterprise Edition
 -----------------------------


### PR DESCRIPTION
Apparently the link to the feature comparison of Team/Enterprise editions are broken in the docs, it took me a good 5 minutes to find the correct link on the site.