### PR TITLE
MM-16389] Remove icon_emoji compatibility issue reference

### DIFF
--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -135,12 +135,11 @@ GitLab is the leading open-source alternative to GitHub and offers built-in inte
 Known Slack compatibility issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Using ``icon_emoji`` to override the username is not supported.
-2. Referencing  channels using <#CHANNEL_ID> does not link to the channel.
-3. ``<!everyone>`` and ``<!group>`` are not supported.
-4. Parameters "mrkdwn", "parse", and "link_names" are not supported. Mattermost converts Markdown by default and automatically links @mentions.
-5. Bold formatting as ``*bold*`` is not supported (must be done as ``**bold**``).
-6. Webhooks cannot direct message the user who created the webhook.
+1. Referencing  channels using <#CHANNEL_ID> does not link to the channel.
+2. ``<!everyone>`` and ``<!group>`` are not supported.
+3. Parameters "mrkdwn", "parse", and "link_names" are not supported. Mattermost converts Markdown by default and automatically links @mentions.
+4. Bold formatting as ``*bold*`` is not supported (must be done as ``**bold**``).
+5. Webhooks cannot direct message the user who created the webhook.
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
An icon_emoji parameter was added to incoming webhook requests, that overrides the profile icon and the icon_url parameter.

Fixes #11194

https://mattermost.atlassian.net/browse/MM-16389

Related PRs:
https://github.com/mattermost/mattermost-server/pull/11586
https://github.com/mattermost/mattermost-webapp/pull/3074
https://github.com/mattermost/mattermost-mobile/pull/2961
https://github.com/mattermost/mattermost-redux/pull/876
https://github.com/mattermost/mattermost-developer-documentation/pull/321