### PR TITLE
Replace subscribers@mattermost.com with link to EE support page

### DIFF
--- a/source/mobile/mobile-troubleshoot.rst
+++ b/source/mobile/mobile-troubleshoot.rst
@@ -67,7 +67,7 @@ Some distributions also ship without ``mailcap`` which can result in missing or 
 None of these solve my problem!
 -------------------------------
 
-For more troubleshooting help, `open a new topic in our forums <https://forum.mattermost.org/c/trouble-shoot>`__ with steps to reproduce your issue. If you're an Enterprise Edition subscriber, you can also email subscribers@mattermost.com for support.
+For more troubleshooting help, `open a new topic in our forums <https://forum.mattermost.org/c/trouble-shoot>`__ with steps to reproduce your issue. If you're an Enterprise Edition subscriber, visit the `Enterprise Edition Support page <https://about.mattermost.com/support/>`_ for additional options.
 
 To help us narrow down whether it’s a server configuration issue, device specific issue, or an issue with the app, please try the following things and include the results in your support request:
 

--- a/source/mobile/mobile-troubleshoot.rst
+++ b/source/mobile/mobile-troubleshoot.rst
@@ -67,7 +67,7 @@ Some distributions also ship without ``mailcap`` which can result in missing or 
 None of these solve my problem!
 -------------------------------
 
-For more troubleshooting help, `open a new topic in our forums <https://forum.mattermost.org/c/trouble-shoot>`__ with steps to reproduce your issue. If you're an Enterprise Edition subscriber, visit the `Enterprise Edition Support page <https://about.mattermost.com/support/>`_ for additional options.
+For more troubleshooting help, `open a new topic in our forums <https://forum.mattermost.org/c/trouble-shoot>`__ with steps to reproduce your issue. If you're an Enterprise Edition subscriber, visit the `Enterprise Edition Support page <https://mattermost.zendesk.com/hc/en-us/requests/new>`_ for additional options.
 
 To help us narrow down whether it’s a server configuration issue, device specific issue, or an issue with the app, please try the following things and include the results in your support request:
 


### PR DESCRIPTION
Credit for @justinegeffen for finding this, @lfbrock can you help confirm the EE support page (https://about.mattermost.com/support/) is where we should direct customers to?