### PR TITLE
MM-16938: update plugins HA docs

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -2262,7 +2262,7 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 #### Integrations
 
 - Added an option for an outgoing webhook to reply to the posted message as a comment.
-- JIRA plugin is now bundled as a prepackaged plugin manageable from the System Console > Plugins > Management.
+- JIRA plugin is now bundled as a pre-packaged plugin manageable from the System Console > Plugins > Management.
 - Added support for mentions with <@userid>, <!channel>, <!all> and <!here> in webhook posts.
 - Personal access tokens can now be temporarily deactivated in the Account Settings.
 

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -32,7 +32,7 @@ Set Up Guide
 
 To manage plugins, go to **System Console > Plugins > Plugin Management**. From here, you can:
 
- - Enable or disable prepackaged plugins.
+ - Enable or disable prepackaged plugins
  - Install and manage custom plugins
 
 .. note::

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -41,7 +41,7 @@ To manage plugins, go to **System Console > Plugins > Plugin Management**. From 
 
 Prepackaged Plugins
 ~~~~~~~~~~~~~~~~~~~
-Mattermost ships with a number of prepackaged plugins written and maintained by Mattermost. Instead of building these features directly into the product, you can selectively enable the functionality your installation requires. Prepackaged plugins cannot be removed via the System Console, but can be customized by modifying the `prepackaged_plugins` directory in your Mattermost installation.
+Mattermost ships with a number of prepackaged plugins written and maintained by Mattermost. Instead of building these features directly into the product, you can selectively enable the functionality your installation requires. Prepackaged plugins cannot be removed via the System Console, but can be customized by modifying the ``prepackaged_plugins`` directory in your Mattermost installation.
 
 Custom Plugins
 ~~~~~~~~~~~~~~

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -41,7 +41,7 @@ To manage plugins, go to **System Console > Plugins > Plugin Management**. From 
 
 Pre-packaged Plugins
 ~~~~~~~~~~~~~~~~~~~
-Mattermost ships with a number of pre-packaged plugins written and maintained by Mattermost. Instead of building these features directly into the product, you can selectively enable the functionality your installation requires. Prepackaged plugins cannot be removed via the System Console, but can be customized by modifying the ``prepackaged_plugins`` directory in your Mattermost installation.
+Mattermost ships with a number of pre-packaged plugins written and maintained by Mattermost. Instead of building these features directly into the product, you can selectively enable the functionality your installation requires. Pre-packaged plugins cannot be removed via the System Console, but can be customized by modifying the ``prepackaged_plugins`` directory in your Mattermost installation.
 
 Custom Plugins
 ~~~~~~~~~~~~~~

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -14,7 +14,7 @@ Consider using a plugin in the following scenarios:
 
 Plugins are fully supported by both Team and Enterprise Editions. Plugins may have one or both of the following parts:
 
- - **Webapp plugins (Beta)**: Customize the Mattermost user interface by adding to the channel header, overriding the `RHS`_, or even rendering a custom post type. All this is possible without having to fork the source code and rebase on every Mattermost release. For a sample plugin, see `our Zoom plugin <https://github.com/mattermost/mattermost-plugin-zoom>`__.
+ - **Webapp plugins (Beta)**: Customize the Mattermost user interface by adding to the channel header, overriding the ``RHS``, or even rendering a custom post type. All this is possible without having to fork the source code and rebase on every Mattermost release. For a sample plugin, see `our Zoom plugin <https://github.com/mattermost/mattermost-plugin-zoom>`__.
  - **Server plugins (Release Candidate)**: Run a Go process alongside the server, filtering messages or integrating with third-party systems such as Jira, GitLab or Jenkins. For a sample plugin, see `our Jira plugin <https://github.com/mattermost/mattermost-plugin-jira>`__.
 
 Browse available plugins at `https://integrations.mattermost.com/ <https://integrations.mattermost.com/>`__.

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -23,7 +23,7 @@ Security
 --------
 Plugins are intentionally powerful and not artificially sandboxed in any way. Server plugins can execute arbitrary code alongside your server. Webapp plugins can deploy arbitrary code in client browsers. Plugins effectively become part of the Mattermost server.
 
-While this power enables deep customization and integration, it can be abused in the wrong hands. Plugins have full access to your server configuration and thus your Mattermost database. Plugins can read any message in any channel, or perform any action on behalf of any user in the webapp.
+While this power enables deep customization and integration, it can be abused in the wrong hands. Plugins have full access to your server configuration and thus also to your Mattermost database. Plugins can read any message in any channel, or perform any action on behalf of any user in the webapp.
 
 You should only install custom plugins from sources you trust to avoid compromising the security of your installation.
 

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -30,7 +30,7 @@ You should only install custom plugins from sources you trust to avoid compromis
 Set Up Guide
 ------------
 
-To manage plugins, go to **System Console > Plugins > Plugin Management**. Fom here, you can:
+To manage plugins, go to **System Console > Plugins > Plugin Management**. From here, you can:
 
  - Enable or disable prepackaged plugins.
  - Install and manage custom plugins

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -4,110 +4,62 @@ Plugins (Beta)
 .. note::
   This is the admin documentation for plugins. If you're a developer looking to build a plugin, see `our developer documentation <https://developers.mattermost.com/extend/plugins>`__.
 
-Mattermost supports plugins, which allow users to customize and extend the platform by adding specific features. See our `demo plugin <https://github.com/mattermost/mattermost-plugin-demo>`__ that demonstrates the capabilities of a Mattermost plugin. For a starting point to write a Mattermost plugin, see our `sample plugin <https://github.com/mattermost/mattermost-plugin-sample>`__.
+Mattermost supports plugins to customize and extend the platform. See our `demo plugin <https://github.com/mattermost/mattermost-plugin-demo>`__ that illustrates the potential for a Mattermost plugin. To start writing your own plugin, consult our `starter template <https://github.com/mattermost/mattermost-plugin-starter-template>`__.
 
-There are three scenarios in which you would consider using a plugin:
+Consider using a plugin in the following scenarios:
 
  - When you want to customize the Mattermost user interface
  - When you want to extend Mattermost functionality to meet a specific, complex requirement
  - When you want to build integrations that are managed by your Mattermost server
 
-There are two main types of plugins, both of which are supported in Team and Enterprise Editions:
+Plugins are fully supported by both Team and Enterprise Editions. Plugins may have one or both of the following parts:
 
- - **Webapp plugins (Beta)**: Allows you to customize the Mattermost user interface, by overriding elements such as the profile popover, channel header or the sidebar. For a sample plugin, see `our Zoom plugin <https://github.com/mattermost/mattermost-plugin-zoom>`__.
- - **Server plugins (Release Candidate)**: Makes it easier to integrate with third-party systems such as JIRA, GitLab or Jenkins. A sample plugin for a video and audio call system with Zoom `is available here <https://github.com/mattermost/mattermost-plugin-zoom>`__. A sample plugin that auto-censors restricted words and intercepts them `is described here <https://forum.mattermost.org/t/coming-soon-apiv4-mattermost-post-intercept/4982>`__.
+ - **Webapp plugins (Beta)**: Customize the Mattermost user interface by adding to the channel header, overriding the `RHS`_, or even rendering a custom post type. All this is possible without having to fork the source code and rebase on every Mattermost release. For a sample plugin, see `our Zoom plugin <https://github.com/mattermost/mattermost-plugin-zoom>`__.
+ - **Server plugins (Release Candidate)**: Run a Go process alongside the server, filtering messages or integrating with third-party systems such as Jira, GitLab or Jenkins. For a sample plugin, see `our Jira plugin <https://github.com/mattermost/mattermost-plugin-jira>`__.
 
-Later in upcoming releases, the `Enterprise Edition <https://about.mattermost.com/pricing>`__ will also support plugins that enable you to extend Mattermost functionality to meet a specific, complex requirement such as profiling performance metrics, and to implement highly customized compliance rules for `information barriers <http://www.17a-4.com/supervision-information-barriers/>`__.
-
-For a list of available plugins, including those for auto-linking, auto-censoring and anti-virus scanning, as well as third-party plugins with JIRA, Zoom, GitHub and more, see the `Mattermost plugins repo <https://github.com/mattermost/mattermost-plugins>`__. 
+Browse available plugins at `https://integrations.mattermost.com/ <https://integrations.mattermost.com/>`__.
 
 Security
 --------
-Plugins are powerful. You should only install plugins that you've thoroughly reviewed as they have the potential to compromise the security of your installation.
+Plugins are intentionally powerful and not artificially sandboxed in any way. Server plugins can execute arbitrary code alongside your server. Webapp plugins can deploy arbitrary code in client browsers. Plugins effectively become part of the Mattermost server.
 
-Server Considerations
-~~~~~~~~~~~~~~~~~~~~~
-Plugins have the ability to execute arbitrary code on your server. They can do just about *anything*. For example, they could read your config file to get your database password, connect to your database, then exfiltrate sensitive user information.
+While this power enables deep customization and integration, it can be abused in the wrong hands. Plugins have full access to your server configuration and thus your Mattermost database. Plugins can read any message in any channel, or perform any action on behalf of any user in the webapp.
 
-Web App Considerations
-~~~~~~~~~~~~~~~~~~~~~~
-Plugins have the ability to execute arbitrary code in client browsers. They have the ability to perform nearly any action on behalf of anyone using the web app.
+You should only install custom plugins from sources you trust to avoid compromising the security of your installation.
 
 Set Up Guide
---------------
+------------
 
-To enable plugins, go to **System Console > Plugins > Plugin Management** in versions after 5.12, or follow these two steps in prior versions:
+To manage plugins, go to **System Console > Plugins > Plugin Management**. Fom here, you can:
 
-1) Go to **System Console > Plugins (Beta) > Configuration**. Here you can enable plugins.
-2) Go to **System Console > Plugins (Beta) > Management** to manage your plugins, including:
+ - Enable or disable prepackaged plugins.
+ - Install and manage custom plugins
 
- - Activating or deactivating pre-packaged Mattermost plugins.
- - Upload and install a plugin for your Mattermost server, or remove them.
+.. note::
+  In prior versions, go to **System Console > Plugins (Beta) > Configuration**.
 
-For more information on building your own plugin, see our `developer documentation <https://developers.mattermost.com/extend/plugins/>`__.
 
-Plugin Uploads
-~~~~~~~~~~~~~~~~~~
+Prepackaged Plugins
+~~~~~~~~~~~~~~~~~~~
+Mattermost ships with a number of prepackaged plugins written and maintained by Mattermost. Instead of building these features directly into the product, you can selectively enable the functionality your installation requires. Prepackaged plugins cannot be removed via the System Console, but can be customized by modifying the `prepackaged_plugins` directory in your Mattermost installation.
 
-Mattermost supports plugin uploads by System Admins, which allow you to customize and extend the platform in ways that would otherwise not be available. These plugins are not pre-packaged in Mattermost, and have either been developed by the community or by a Mattermost staff member.
+Custom Plugins
+~~~~~~~~~~~~~~
+As noted above, installing a custom plugin introduces some risk. As a result, plugin uploads are disabled by default and cannot be enabled via the System Console or REST API.
 
-By default, plugin uploads are disabled on your server. To enable them, set **PluginSettings > EnableUploads** to ``true`` in your ``config.json`` file. You can disable plugin uploads anytime to control which plugins are installed on your server. This action won't disable plugins already installed on your server.
+To enable plugin uploads, manually set **PluginSettings > EnableUploads** to ``true`` in your configuration and restart your server. You can disable plugin uploads at any time without affecting previously uploaded plugins.
 
-Once enabled, install plugins in one of the following ways. The steps assume you previously generated a ``plugin.tar.gz`` file.
+With plugin uploads enabled, navigate to **System Console > Plugins > Management** and upload a plugin bundle. Plugin bundles are `*.tar.gz` files containing the server executables and webapp resources for the plugin. You may also specify a URL to install a plugin bundle from a remote source.
 
-1) Through System Console UI:
- - Log in to Mattermost as a System Admin.
- - Navigate to **Plugins > Management** and upload ``plugin.tar.gz``.
- - Click "Activate" under the plugin after it has uploaded.
+Custom plugins may also be installed via the `command line interface <https://docs.mattermost.com/administration/command-line-tools.html#mattermost-plugin>`__.
 
-2) Manually:
- - Extract ``plugin.tar.gz`` to a folder with the same name as the plugin id you specified in ``plugin.json``.
- - Add the plugin to the directory set by **PluginSettings > Directory** in your ``config.json`` file. If none is set, defaults to ``./plugins`` relative to your Mattermost installation directory.
- - Restart the Mattermost server.
-
-Once installed, your plugins directory should look similar to:
-
-.. code-block:: none
-
-  plugins
-  ├── com.mattermost.demo-plugin
-  │   ├── plugin.json
-  │   ├── server
-  │   │   ├── plugin-darwin-amd64
-  │   │   ├── plugin-linux-amd64
-  │   │   └── plugin-windows-amd64.exe
-  │   └── webapp
-  │       └── main.js
-  ├── jira
-  │   ├── plugin.exe
-  │   └── plugin.yaml
-  ├── zoom
-  │   ├── plugin.json
-  │   ├── server
-  │   │   └── plugin.exe
-  │   └── webapp
-  │       └── zoom_bundle.js
-
-It is recommended that you automate plugin deployment as part of your Mattermost deployment jobs.
+While no longer recommended, plugins may also be installed manually by unpacking the plugin bundle inside the `plugins` directory of a Mattermost installation.
 
 Plugin Uploads in High Availability Mode
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Prior to Mattermost 5.14, Mattermost servers configured for `High Availability mode <https://docs.mattermost.com/deployment/cluster.html>`_ required plugins to be installed manually. As of Mattermost 5.14, plugin uploaded via the System Console or the command line interface are persisted to the configured file store and automatically installed on all servers that join the cluster. 
 
-If you run your Mattermost server in `High Availability mode <https://docs.mattermost.com/deployment/cluster.html>`_, you must manually extract the plugin package into the Mattermost server plugins directory on each server. The steps assume you previously generated a ``plugin.tar.gz`` file:
-
-1. Extract ``plugin.tar.gz`` to a folder with the same name as the plugin id specified in ``plugin.json``.
-2. Add the plugin to the directory set by **PluginSettings > Directory** in your ``config.json`` file. If none is set, defaults to ``./plugins`` relative to your Mattermost installation directory. The resulting directory structure should look something like:
-
-.. code-block:: none
-
-  mattermost/
-      plugins/
-          com.mattermost.server-hello-world/
-              plugin.json
-              plugin.exe
-
-3. Repeat step 2 for each server.
-4. Restart each Mattermost server.
+Manually installed plugins remain supported, but must be installed on each server in the cluster.
 
 Frequently Asked Questions (FAQ)
 ---------------------------------
@@ -115,25 +67,22 @@ Frequently Asked Questions (FAQ)
 Where can I share feedback on plugins?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can share feedback in our `forums <https://forum.mattermost.org>`__ by creating a new forum post or by replying to `our open issue <https://forum.mattermost.org/t/mattermost-plugins-in-beta/4123>`__.
-
-All feedback is highly welcome!
+Join our community server discussion in the `Toolkit channel <https://community.mattermost.com/core/channels/developer-toolkit>`__.
 
 Troubleshooting
 -----------------
 
 Plugin uploads fail even though uploads are enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 If plugin uploads fail and you see "permissions denied" errors in **System Console > Logs**  such as 
 
 .. code-block:: text
 
   [2017/11/13 20:42:18 UTC] [EROR] failed to start up plugins: mkdir /home/ubuntu/mattermost/client/plugins: permission denied
 
-you don't have proper permissions for uploading plugins. To resolve it, apply write access to the ``mattermost/client`` directory.
+the Mattermost server doesn't have the necessary permissions for uploading plugins. Ensure the Mattermost server has write access to the ``mattermost/client`` directory.
 
-Another potential cause is that the working directory for the service running Mattermost is not correct. On Ubuntu you might see
+It may also be the case that the working directory for the service running Mattermost is not correct. On Ubuntu you might see
 
 .. code-block:: text
 
@@ -141,11 +90,10 @@ Another potential cause is that the working directory for the service running Ma
 
 This can be fixed on Ubuntu 16.04 and RHEL by opening the service configuration file and setting WorkingDirectory to the path to Mattermost, often ``/opt/mattermost``.
 
-Or on Windows
+A similar problen can occur on Windows:
 
 .. code-block:: text
 
     [EROR] failed to start up plugins: mkdir ./client/plugins: The system cannot find the path specified.
 
 To fix this, set the AppDirectory of your service using ``nssm set mattermost AppDirectory c:\mattermost``.
-

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -57,7 +57,7 @@ While no longer recommended, plugins may also be installed manually by unpacking
 
 Plugin Uploads in High Availability Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Prior to Mattermost 5.14, Mattermost servers configured for `High Availability mode <https://docs.mattermost.com/deployment/cluster.html>`_ required plugins to be installed manually. As of Mattermost 5.14, plugin uploaded via the System Console or the command line interface are persisted to the configured file store and automatically installed on all servers that join the cluster. 
+Prior to Mattermost 5.14, Mattermost servers configured for `High Availability mode <https://docs.mattermost.com/deployment/cluster.html>`_ required plugins to be installed manually. As of Mattermost 5.14, plugins uploaded via the System Console or the command line interface are persisted to the configured file store and automatically installed on all servers that join the cluster. 
 
 Manually installed plugins remain supported, but must be installed on each server in the cluster.
 

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -90,7 +90,7 @@ It may also be the case that the working directory for the service running Matte
 
 This can be fixed on Ubuntu 16.04 and RHEL by opening the service configuration file and setting WorkingDirectory to the path to Mattermost, often ``/opt/mattermost``.
 
-A similar problen can occur on Windows:
+A similar problem can occur on Windows:
 
 .. code-block:: text
 

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -32,16 +32,16 @@ Set Up Guide
 
 To manage plugins, go to **System Console > Plugins > Plugin Management**. From here, you can:
 
- - Enable or disable prepackaged plugins
+ - Enable or disable pre-packaged plugins
  - Install and manage custom plugins
 
 .. note::
   In prior versions, go to **System Console > Plugins (Beta) > Configuration**.
 
 
-Prepackaged Plugins
+Pre-packaged Plugins
 ~~~~~~~~~~~~~~~~~~~
-Mattermost ships with a number of prepackaged plugins written and maintained by Mattermost. Instead of building these features directly into the product, you can selectively enable the functionality your installation requires. Prepackaged plugins cannot be removed via the System Console, but can be customized by modifying the ``prepackaged_plugins`` directory in your Mattermost installation.
+Mattermost ships with a number of pre-packaged plugins written and maintained by Mattermost. Instead of building these features directly into the product, you can selectively enable the functionality your installation requires. Prepackaged plugins cannot be removed via the System Console, but can be customized by modifying the ``prepackaged_plugins`` directory in your Mattermost installation.
 
 Custom Plugins
 ~~~~~~~~~~~~~~

--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -49,7 +49,7 @@ As noted above, installing a custom plugin introduces some risk. As a result, pl
 
 To enable plugin uploads, manually set **PluginSettings > EnableUploads** to ``true`` in your configuration and restart your server. You can disable plugin uploads at any time without affecting previously uploaded plugins.
 
-With plugin uploads enabled, navigate to **System Console > Plugins > Management** and upload a plugin bundle. Plugin bundles are `*.tar.gz` files containing the server executables and webapp resources for the plugin. You may also specify a URL to install a plugin bundle from a remote source.
+With plugin uploads enabled, navigate to **System Console > Plugins > Management** and upload a plugin bundle. Plugin bundles are ``*.tar.gz`` files containing the server executables and webapp resources for the plugin. You may also specify a URL to install a plugin bundle from a remote source.
 
 Custom plugins may also be installed via the `command line interface <https://docs.mattermost.com/administration/command-line-tools.html#mattermost-plugin>`__.
 

--- a/source/integrations/net-promoter-score.rst
+++ b/source/integrations/net-promoter-score.rst
@@ -12,7 +12,7 @@ Administration
 --------------
 Is the survey enabled by default?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The user satisfaction survey is a prepackaged plugin, and surveys are enabled by default on all servers when upgrading to v5.12 or later. However, the plugin will not be activated on any servers that have `Error and Diagnostic Reporting <https://docs.mattermost.com/administration/telemetry.html>`_ disabled, meaning no surveys or data collection occurs.
+The user satisfaction survey is a pre-packaged plugin, and surveys are enabled by default on all servers when upgrading to v5.12 or later. However, the plugin will not be activated on any servers that have `Error and Diagnostic Reporting <https://docs.mattermost.com/administration/telemetry.html>`_ disabled, meaning no surveys or data collection occurs.
 
 How can surveys be disabled?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Reflect the 5.14 changes to upload plugins to the file store, simplifying deployment in HA environments. Simplify the overall dialogue of the page, updating some legacy links and terminology.