### PR TITLE
Clarified that an API call needs to be made for ephemeral posts

### DIFF
--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -120,7 +120,7 @@ The following payload gives an example that uses message menus.
     ]
   }
 
-The integration can respond with an update to the original post, or with an ephemeral message:
+The integration can then perform a separate API call with an update to the original post, or with an ephemeral message:
 
 .. code-block:: text
 

--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -299,12 +299,13 @@ Considerations
 
 When developing different types of integrations, one thing to keep in mind is whether the server will evaluate response bodies or not. 
 
-
-| Integration Type | Server will evaluate the response body |
-| --- | --- |
-| Slash Commands | Yes |
-| Incoming Webhooks| Yes |
-| POSTs from interactive controls | No - Response body is ignored |
+=====  =====  
+Integration Type | Will Server will evaluate the response body?
+=====  =====  
+Slash Commands | Yes 
+Incoming Webhooks | Yes 
+POSTs from interactive controls | No - Response body is ignored
+=====  =====  
   
 
 Tips and Best Practices

--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -299,14 +299,13 @@ Considerations
 
 When developing different types of integrations, one thing to keep in mind is whether the server will evaluate response bodies or not. 
 
-=====  =====  
-Integration Type | Will Server will evaluate the response body?
-=====  =====  
-Slash Commands | Yes 
-Incoming Webhooks | Yes 
-POSTs from interactive controls | No - Response body is ignored
-=====  =====  
-  
+.. csv-table::
+    :header: "Integration Type", "Will Server will evaluate the response body?"
+
+    "Slash Commands", "Yes"
+    "Incoming Webhooks", "Yes"
+    "POSTs from interactive controls", "No - Response body is ignored"
+
 
 Tips and Best Practices
 ------------------------

--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -292,6 +292,20 @@ Context
       }
 
   Then, when the integration receives the request, it can act based on the action id.
+  
+
+Considerations
+-----------------------
+
+When developing different types of integrations, one thing to keep in mind is whether the server will evaluate response bodies or not. 
+
+
+| Integration Type | Server will evaluate the response body |
+| --- | --- |
+| Slash Commands | Yes |
+| Incoming Webhooks| Yes |
+| POSTs from interactive controls | No - Response body is ignored |
+  
 
 Tips and Best Practices
 ------------------------


### PR DESCRIPTION
This was prompted by a conversation in the forum: https://forum.mattermost.org/t/response-from-interactive-button-post-is-ignored/7757/6