### PR TITLE
updated definitions of DAU and MAU to exclude bots

### DIFF
--- a/source/administration/statistics.rst
+++ b/source/administration/statistics.rst
@@ -27,10 +27,10 @@ Total Posts
     The total number of posts made in all the teams on your system, including deleted posts and posts made using automation.
 
 Daily Active Users
-  The total number of users who viewed the Mattermost site in the last 24 hours.
+  The total number of users who viewed the Mattermost site in the last 24 hours. Excludes bot users.
 
 Monthly Active Users
-  The total number of users who viewed the Mattermost site in the last 30 days.
+  The total number of users who viewed the Mattermost site in the last 30 days. Excludes bot users.
 
 Total Posts (graph)
     The total number of posts made on a certain day in all the teams on your system, including deleted posts and posts made using automation.


### PR DESCRIPTION
- Updated definitions to explicitly mention they (no longer) include bot users in the counts
- Question: Should I mention this is from 5.14 going forward?