### PR TITLE
Troubleshooting note for plugins with x509 certificate error

### DIFF
--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -102,6 +102,6 @@ To fix this, set the AppDirectory of your service using ``nssm set mattermost Ap
 ``x509: certificate signed by unknown authority``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are seeing ``x509: certificate signed by unknown authority`` in your server logs, it usually means that your self-signed certificate hasn't been added to your local trusted CA of the Mattermost server.
+If you are seeing ``x509: certificate signed by unknown authority`` in your server logs, it usually means that the CA for a self-signed certificate for a server your plugin is trying to access has not been added to your local trust store of the machine the Mattermost server is running on.
 
 You can add one in Linux `following instructions in this StackExchange article <https://unix.stackexchange.com/questions/90450/adding-a-self-signed-certificate-to-the-trusted-list>`_, or set up a load balancer like NGINX per :doc:`production install guide <config-ssl-http2-nginx>` to resolve the issue.


### PR DESCRIPTION
Re-writing PR from the GitLab repo https://github.com/mattermost/mattermost-plugin-gitlab/pull/94/files

No PM review assigned, as it was already done in https://github.com/mattermost/mattermost-plugin-gitlab/pull/94/files

**Context**:

When a self-signed certificate wasn't added to a trusted list, `/gitlab connect` failed producing the x509 certificate error message in the Server Logs, and also a similar error message in the UI.

Hanzei mentioned he's seen a similar error with other plugins in such a case, including Matterpoll.

So I created a troubleshooting section for it, since it appears to be a recurring issue. 