### PR TITLE
Update config-settings.rst

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1407,7 +1407,7 @@ Enable Team Directory
 
 Teammate Name Display
 ^^^^^^^^^^^^^^^^^^^^^
-Specifies how names are displayed in the user interface by default. Please note that users can override this setting in **Account Settings > Display > Teammate Name Display**
+Specifies how names are displayed in the user interface by default. Please note that users can override this setting in **Account Settings > Display > Teammate Name Display**.
 
 **Show username**: Displays the user's username.
 


### PR DESCRIPTION
Update Teammate name description to explain how the Account setting "Teammate Name Display" overrides the config setting. Per issue: https://github.com/mattermost/docs/issues/2970 