### PR TITLE
Added --remove-deactivated-users flag to channel move

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -299,6 +299,7 @@ mattermost channel move
     .. code-block:: none
 
           --username [REQUIRED] Username of the user who is moving the team.
+          --remove-deactivated-users [OPTIONAL] When moving the channel, remove any users who have been deactivated who may be preventing the move
 
 mattermost channel remove
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -299,7 +299,7 @@ mattermost channel move
     .. code-block:: none
 
           --username [REQUIRED] Username of the user who is moving the team.
-          --remove-deactivated-users [OPTIONAL] When moving the channel, remove any users who have been deactivated who may be preventing the move
+          --remove-deactivated-users [OPTIONAL] When moving the channel, remove any users who have been deactivated who may be preventing the move.
 
 mattermost channel remove
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This was added in [5.4](https://mattermost.atlassian.net/browse/MM-12251) but wasn't added to the docs

Signed-off-by: Paul Rothrock <paul@movetoiceland.com>