### PR TITLE
Document API perf monitoring metrics (for 5.18)

### DIFF
--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -115,6 +115,10 @@ Custom Mattermost Metrics
 
 The following is a list of custom Mattermost metrics that can be used to monitor your system's performance:
 
+API Metrics:
+
+    - ``mattermost_api_total``: The total time in seconds to execute a given API handler.
+
 Caching Metrics:
 
     - ``mattermost_cache_etag_hit_total``: The total number of ETag cache hits for a specific cache.

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -117,7 +117,7 @@ The following is a list of custom Mattermost metrics that can be used to monitor
 
 API Metrics:
 
-    - ``mattermost_api_total``: The total time in seconds to execute a given API handler.
+    - ``mattermost_api_time``: The total time in seconds to execute a given API handler.
 
 Caching Metrics:
 


### PR DESCRIPTION
@jespino Wondering if you'd be open to help add the two new metrics (DB store time, and API time) to our sample Grafana dashboard? https://github.com/mattermost/docs/blob/master/source/samples/grafana-dashboards/server-perf-monitoring-set2.json

We should also consider merging https://github.com/mattermost/docs/blob/master/source/samples/grafana-dashboards/server-perf-monitoring-set1.json with https://github.com/mattermost/docs/blob/master/source/samples/grafana-dashboards/server-perf-monitoring-set2.json because the two dashboards have different metrics, but it's not clear why not just have them in one (I made the decision 3 years ago to separate the metrics into two based on the importance of metrics, but disagree with that decision now in favor of consolidation :) )