### PR TITLE
Updated few broken links w.r.t Contribution Guidelines

### DIFF
--- a/source/process/help-wanted.rst
+++ b/source/process/help-wanted.rst
@@ -4,7 +4,7 @@ Help Wanted Tickets
 
 Thank you for your interest in contributing! `Join our "Contributors" community channel <https://community.mattermost.com/core/channels/tickets>`__ where you can discuss questions with community members and the Mattermost core team.
 
-Per the `Code Contribution Guidelines <http://docs.mattermost.com/developer/contribution-guide.html#choose-a-ticket>`__, other than small bug fixes and incremental improvements, only pull requests referencing `Help Wanted GitHub issues <https://mattermost.com/pl/help-wanted-mattermost-server>`__ should be submitted to Mattermost projects. This ensures:
+Per the `Code Contribution Guidelines <https://developers.mattermost.com/contribute/getting-started/>`__, other than small bug fixes and incremental improvements, only pull requests referencing `Help Wanted GitHub issues <https://mattermost.com/pl/help-wanted-mattermost-server>`__ should be submitted to Mattermost projects. This ensures:
 
 1. Proposed changes have been unambiguously specified 
 2. The change meets the `fast, obvious, forgiving <http://www.mattermost.org/design-principles/>`__ design principle for the project

--- a/source/process/overview.rst
+++ b/source/process/overview.rst
@@ -63,12 +63,12 @@ Key contributors might also pick up tickets, or through conversations with the c
 Community Contributions
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Community members following the `Contribution Guidelines <http://docs.mattermost.com/developer/contribution-guide.html#code-contribution-guidelines>`__ might also submit pull requests. Pull requests that significantly change the user experience are opened `via the feature ideas process <http://www.mattermost.org/feature-requests/>`__.
+Community members following the `Contribution Guidelines <https://developers.mattermost.com/contribute/getting-started/>`__ might also submit pull requests. Pull requests that significantly change the user experience are opened `via the feature ideas process <http://www.mattermost.org/feature-requests/>`__.
 
 Bug Fixes
 ^^^^^^^^^
 
-If you see an obvious bug and want to submit a fix, pull requests following the `contribution guidelines <http://docs.mattermost.com/developer/contribution-guide.html#code-contribution-guidelines>`__ are gladly accepted.
+If you see an obvious bug and want to submit a fix, pull requests following the `contribution guidelines <https://developers.mattermost.com/contribute/getting-started/>`__ are gladly accepted.
 
 Examples: 
 


### PR DESCRIPTION
Updated the documentation links from http://docs.mattermost.com/developer/contribution-guide.html#choose-a-ticket to https://developers.mattermost.com/contribute/getting-started/  w.r.t issue #3090