### PR TITLE
MM-18659 Improve documentation for outgoing proxy and link previews

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1654,7 +1654,12 @@ Posts
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Enable Link Previews
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-**True**: Enables users to display a preview of website content, image links and YouTube links below the message when available. When true, website previews can be enabled from **Account Settings > Display > Website Link Previews**. Link previews are requested by the server, meaning the server must be connected to the internet and have access through the firewall (if applicable) to the websites from which previews are expected, such as https://gfycat.com/, https://www.youtube.com/, https://imgur.com/ and any other websites that users may share frequently. 
+
+Link previews are previews of linked website content, image links, and YouTube videos that are displayed below posts when available. 
+
+Link previews are requested by the server, meaning the Mattermost server must be connected to the internet for previews to be displayed. This connection can be through a `firewall or outbound proxy <https://docs.mattermost.com/install/outbound-proxy.html>`__ in environments where applicable.
+
+**True**: Website link previews, image link previews and YouTube previews are enabled on the server. Users can enable or disable website previews for themselves from **Account Settings > Display > Website Link Previews**.
 
 **False**: Website link previews, image link previews and YouTube previews are disabled. The server does not request metadata for any links sent in messages. 
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1657,7 +1657,7 @@ Enable Link Previews
 
 Link previews are previews of linked website content, image links, and YouTube videos that are displayed below posts when available. 
 
-Link previews are requested by the server, meaning the Mattermost server must be connected to the internet for previews to be displayed. This connection can be through a `firewall or outbound proxy <https://docs.mattermost.com/install/outbound-proxy.html>`__ in environments where applicable.
+Link previews are requested by the server, meaning the Mattermost server must be connected to the internet for previews to be displayed. This connection can made be through a `firewall or outbound proxy <https://docs.mattermost.com/install/outbound-proxy.html>`__ in environments where applicable.
 
 **True**: Website link previews, image link previews and YouTube previews are enabled on the server. Users can enable or disable website previews for themselves from **Account Settings > Display > Website Link Previews**.
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1657,7 +1657,7 @@ Enable Link Previews
 
 Link previews are previews of linked website content, image links, and YouTube videos that are displayed below posts when available. 
 
-Link previews are requested by the server, meaning the Mattermost server must be connected to the internet for previews to be displayed. This connection can made be through a `firewall or outbound proxy <https://docs.mattermost.com/install/outbound-proxy.html>`__ in environments where applicable.
+Link previews are requested by the server, meaning the Mattermost server must be connected to the internet for previews to be displayed. This connection can be established through a `firewall or outbound proxy <https://docs.mattermost.com/install/outbound-proxy.html>`__ in environments where direct internet connectivity is not given or security policies make this necessary.
 
 **True**: Website link previews, image link previews and YouTube previews are enabled on the server. Users can enable or disable website previews for themselves from **Account Settings > Display > Website Link Previews**.
 

--- a/source/install/outbound-proxy.rst
+++ b/source/install/outbound-proxy.rst
@@ -3,8 +3,34 @@
 Using an Outbound Proxy
 =======================
 
-To use Mattermost behind a proxy, you need to set the ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables to the URL for your proxy server. To set these when running the Mattermost server via ``systemd``, modify the ``mattermost.service`` like this:
-  
+In some scenarios, you may wish to use Mattermost behind a proxy. This can be used to do things such as monitoring outbound traffic from Mattermost or controlling which websites can appear in link previews and other embedded content.
+
+Configuration
+-------------
+
+Mattermost's use of a proxy is configured using the ``HTTP_PROXY``, ``HTTPS_PROXY`` and ``NO_PROXY`` environment variables.
+
+``HTTP_PROXY`` and ``HTTPS_PROXY``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables store the address of the proxy server for HTTP and HTTPS requests respectively. This value should include the protocol and port of the proxy such as ``http://192.168.4.5:3128``.
+
+If you wish to have Mattermost authenticate with your proxy, it supports HTTP basic authentication by specifying the address of the proxy such as ``http://mattermost:password@192.168.4.5:3128``.
+
+Note that when proxying HTTPS resources, you will need to configure your Mattermost server with the root certificate of the proxy. Otherwise, Mattermost will refuse any response from the proxy as it will detect that its connection has been intercepted.
+
+``NO_PROXY``
+~~~~~~~~~~~~
+
+The ``NO_PROXY`` environment variable can be set to prevent certain requests from going through the proxy, such as those to an SSO provider (such as GitLab or SAML) or to intranet sites that should be accessible in link previews. It can be configured as a set of comma-separted IP addresses (e.g. 1.2.3.4), IP address ranges specified in CIDR notation (e.g. 1.2.3.4/8), or domain names. An IP address or domain name can also include a port number.
+
+When specifying a domain name, that domain name also matches its sub domains as well. A domain name with a leading ``.`` matches only sub domains. For example, ``example.com`` matches both ``example.com`` as well as ``sub.example.com`` while ``.example.com`` only matches the latter.
+
+Sample Configuration
+--------------------
+
+To set these environment variables while running the Mattermost server via ``systemd``, modify the ``mattermost.service`` like this:
+
   .. note::
     Be sure to replace `127.0.0.1:3128` with the correct values for your proxy servers.
 
@@ -26,8 +52,9 @@ To use Mattermost behind a proxy, you need to set the ``HTTP_PROXY`` and ``HTTPS
     User=mattermost
     Group=mattermost
     LimitNOFILE=49152
-    Environment=HTTP_PROXY=http://127.0.0.1:3128
-    Environment=HTTPS_PROXY=http://127.0.0.1:3128
+    Environment=HTTP_PROXY=http://mattermost:password@127.0.0.1:3128
+    Environment=HTTPS_PROXY=https://mattermost:password@127.0.0.1:3128
+    Environment=NO_PROXY=1.2.3.4:567,.internal.example.com,login.example.com
 
     [Install]
     WantedBy=postgresql.service

--- a/source/install/outbound-proxy.rst
+++ b/source/install/outbound-proxy.rst
@@ -22,7 +22,7 @@ Note that when proxying HTTPS resources, you will need to configure your Matterm
 ``NO_PROXY``
 ~~~~~~~~~~~~
 
-The ``NO_PROXY`` environment variable can be set to prevent certain requests from going through the proxy, such as those to an SSO provider (such as GitLab or SAML) or to intranet sites that should be accessible in link previews. It can be configured as a set of comma-separted IP addresses (e.g. 1.2.3.4), IP address ranges specified in CIDR notation (e.g. 1.2.3.4/8), or domain names. An IP address or domain name can also include a port number.
+The ``NO_PROXY`` environment variable can be set to prevent certain requests from going through the proxy, such as to an SSO provider (such as GitLab or SAML) or to intranet sites that should be accessible in link previews. It can be configured as a set of comma-separted IP addresses (e.g. 1.2.3.4), IP address ranges specified in CIDR notation (e.g. 1.2.3.4/8), or domain names. An IP address or domain name can also include a port number.
 
 When specifying a domain name, that domain name also matches its sub domains as well. A domain name with a leading ``.`` matches only sub domains. For example, ``example.com`` matches both ``example.com`` as well as ``sub.example.com`` while ``.example.com`` only matches the latter.
 


### PR DESCRIPTION
Adds more documentation on how to configure an outgoing proxy including answers to some questions we ran into when configuring the proxy for a few customers. I also added a link from the Enable Link Preview setting to the proxy documentation

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18659