### PR TITLE
Change recommendation around jobserver and schedulers.

### DIFF
--- a/source/deployment/cluster.rst
+++ b/source/deployment/cluster.rst
@@ -291,7 +291,7 @@ Mattermost runs periodic tasks via the `job server <https://docs.mattermost.com/
  - Compliance exports
  - Elasticsearch indexing
 
-:ref:`Make sure you have set ``JobSettings.RunScheduler`` to ``true`` in config.json for all app and job servers in the cluster. The cluster leader will then be responsible for scheduling recurring jobs.
+Make sure you have set ``JobSettings.RunScheduler`` to ``true`` in config.json for all app and job servers in the cluster. The cluster leader will then be responsible for scheduling recurring jobs.
 
 Plugins and High Availability
 ^^^^^^^^^^^^^^^^

--- a/source/deployment/cluster.rst
+++ b/source/deployment/cluster.rst
@@ -291,7 +291,7 @@ Mattermost runs periodic tasks via the `job server <https://docs.mattermost.com/
  - Compliance exports
  - Elasticsearch indexing
 
-:ref:`Run all job servers <command-line-tools-mattermost-jobserver>` with ``--noschedule flag``, then set ``JobSettings.RunScheduler`` to ``true`` in config.json for all app servers in the cluster. The cluster leader will then be responsible for scheduling recurring jobs.
+:ref:`Make sure you have set ``JobSettings.RunScheduler`` to ``true`` in config.json for all app and job servers in the cluster. The cluster leader will then be responsible for scheduling recurring jobs.
 
 Plugins and High Availability
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The code changed some time in the past (I can't figure out exactly when)
such that job servers are fully-fledged members of the cluster. This is
necessary and unavoidable, therefore they can also become the cluster
leader. Because of this, they need to have the possibility of running
the schedulers, since without that, there could be no server running the
schedulers if the job server is elected cluster leader, meaning no jobs
get scheduled. Given the only use of cluster leader status in the
codebase now is job scheduling, this change should have no side effects
on any other functionality.

@wiersgallak since this is a significant change to our recommendations for enterprise cluster setup, adding you to the PR to ensure this gets noted in relevant places and communicated effectively to existing customers and our SA and CS teams.

**Note: there is no corresponding code change to this PR, it is simply a configuration recommendation change. It is compatible with all currently supported versions of Mattermost.**