### PR TITLE
Add the Korean explanation to i18n.rst

### DIFF
--- a/source/install/i18n.rst
+++ b/source/install/i18n.rst
@@ -102,7 +102,7 @@ Postgres:
 이 문제에 대한 논의는 이 `이슈 <https://github.com/mattermost/mattermost-server/issues/2033>`_ 에서 시작되었습니다.
 
 
-한국어 버전 이용 시 문제점을 발견하면 `Localization 채널 <https://community-release.mattermost.com/core/channels/localization>`__ 또는 `한국어 채널 <https://community-release.mattermost.com/core/channels/i18n-korean>`__ 에서 의견을 제시할 수 있습니다.
+한국어 버전 이용 시 문제점을 발견하면 `Localization 채널 <https://community.mattermost.com/core/channels/localization>`__ 또는 `한국어 채널 <https://community.mattermost.com/core/channels/i18n-korean>`__ 에서 의견을 제시할 수 있습니다.
 
 
 검색을 위한 데이터베이스 설정

--- a/source/install/i18n.rst
+++ b/source/install/i18n.rst
@@ -95,3 +95,63 @@ Postgres:
     SELECT to_tsvector('simple_zh_cfg', '开始全面整修道路');
     SELECT to_tsvector('simple_zh_cfg', '开始全面整修道路') @@ to_tsquery('simple_zh_cfg', '全面');
     SELECT * FROM Posts WHERE Message @@ to_tsquery('simple_zh_cfg', '全面');
+    
+한국어 / Korean
+-------------------
+
+이 문제에 대한 논의는 이 `이슈 <https://github.com/mattermost/mattermost-server/issues/2033>`_ 에서 시작되었습니다.
+
+
+한국어 버전 이용 시 문제점을 발견하면 `Localization 채널 <https://community-release.mattermost.com/core/channels/localization>`__ 또는 `한국어 채널 <https://community-release.mattermost.com/core/channels/i18n-korean>`__ 에서 의견을 제시할 수 있습니다.
+
+
+검색을 위한 데이터베이스 설정
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PostegreSQL : PostegreSQl 데이터베이스에서는 특별한 문제가 없기 때문에 설정이 필요하지 않습니다.
+
+MySQl : MySQL에서는 full-text 검색문제를 해결하기 위해서 추가적인 작업이 필요합니다.
+
+
+
+MySQL 해결 방법
+~~~~~~~~~~~~
+
+1. `Ngram parser <https://mysqlserverteam.com/innodb-%EC%A0%84%EB%AC%B8-%EA%B2%80%EC%83%89-n-gram-parser/>`__ 를 이용하기 위해서는 MySQL 5.7.6버전 이상이어야 합니다.
+
+2. Mysql의 구성파일에서 ngram의 최소 토큰 크기를 다음과 같이 설정해줍니다.
+
+.. code:: sql
+
+    [mysqld]
+    ft_min_word_len = 2
+    innodb_ft_min_word_len = 2
+
+
+
+3. 데이터 베이스를 재시작 합니다. (이 과정은 매우 중요합니다.)
+
+
+4. 일부 테이블의 full-text 인덱스를 다음과 같이 리빌드합니다.
+
+
+- 게시물 검색을 위한 설정 ( `참조 <https://github.com/mattermost/mattermost-server/issues/2033#issuecomment-182336690>`__ )
+
+
+.. code:: sql
+
+    DROP INDEX idx_posts_message_txt ON Posts;
+    CREATE FULLTEXT INDEX idx_posts_message_txt ON Posts (Message) WITH PARSER ngram;
+
+
+
+- 해시태그 검색을 위한 설정  ( `참조 <https://github.com/mattermost/mattermost-server/pull/4555>`__ )
+
+.. code:: sql
+
+    DROP INDEX idx_posts_hashtags_txt ON Posts;
+    CREATE FULLTEXT INDEX idx_posts_hashtags_txt ON Posts (Hashtags) WITH PARSER ngram;
+
+
+- 사용자 검색을 위한 설정
+
+  ``Users.idx_users_txt_all`` 과 ``Users.idx_users_names_all`` 를 ngram 없이 리빌드합니다.


### PR DESCRIPTION
There was no Korean explanation  about special configuration for database. So I added Korean guide for this [request](https://github.com/mattermost/docs/issues/3159)