### PR TITLE
Include year factor in example storage calculation

### DIFF
--- a/source/install/requirements.rst
+++ b/source/install/requirements.rst
@@ -180,6 +180,6 @@ File usage per user varies significantly across industries. The below benchmarks
 -  **High usage teams** - (25-100 MB/user/month) 
 	- Heaviest utlization comes from teams uploading a high number of large files into Mattermost on a regular basis. Examples include creative teams who share and store artwork and media with tags and commentary in a pipeline production process.
 
-*Example:* A 30-person team with medium usage (5-25 MB/user/month) with a safety factor of 2x would require between 300 MB (30 users \* 5 MB \* 2x safety factor) and 1500 MB (30 users \* 25 MB \* 2x safety factor) of free space in the next year.
+*Example:* A 30-person team with medium usage (5-25 MB/user/month) with a safety factor of 2x would require between 3.5 GB (30 users \* 5 MB \* 12 months \* 2x safety factor) and 17.6 GB (30 users \* 25 MB \* 12 months \* 2x safety factor) of free space in the next year.
 
 It's recommended to review storage utilization at least quarterly to ensure adequate free space is available.


### PR DESCRIPTION
The 12 months is missing in the example storage calculation in order to represent the free space in the next year as described.

As values have increased quite a bit, I switched from MB to GB.