### PR TITLE
Update note about Mattermost supporting mobile wrapping

### DIFF
--- a/source/mobile/mobile-faq.rst
+++ b/source/mobile/mobile-faq.rst
@@ -178,7 +178,7 @@ You will need to `whitelist one subdomain and one port from Apple <https://devel
 
 You can use the mobile applications hosted by Mattermost in the `Apple App Store <https://apps.apple.com/ca/app/mattermost/id1257222717>`_ or `Google Play Store <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ and connect with :doc:`Mattermost Hosted Push Notification Service (HPNS) <mobile-hpns>` through your corporate proxy.
 
-The use of hosted applications by Mattermost does not support wrapping in Enterprise Mobility Management solutions.
+The use of hosted applications by Mattermost :doc:`can be deployed with Enterprise Mobility Management solutions via AppConfig <mobile-appconfig>` but do not support wrapping.
 
 How do I white label the app and customize build settings?
 ----------------------------------------------------------

--- a/source/mobile/mobile-faq.rst
+++ b/source/mobile/mobile-faq.rst
@@ -178,7 +178,7 @@ You will need to `whitelist one subdomain and one port from Apple <https://devel
 
 You can use the mobile applications hosted by Mattermost in the `Apple App Store <https://apps.apple.com/ca/app/mattermost/id1257222717>`_ or `Google Play Store <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ and connect with :doc:`Mattermost Hosted Push Notification Service (HPNS) <mobile-hpns>` through your corporate proxy.
 
-The use of the hosted applications by Mattermost does not support wrapping in Enterprise Mobility Management solutions since applications are not compiled from source.
+The use of hosted applications by Mattermost does not support wrapping in Enterprise Mobility Management solutions.
 
 How do I white label the app and customize build settings?
 ----------------------------------------------------------


### PR DESCRIPTION
I had originally written the below, but then condensed it to just say 'we don't support it' for clarity. Didn't want to confuse a custom build is required even with AppConfig.

```
The use of hosted applications by Mattermost :doc:`can be deployed with Enterprise Mobility Management solutions via AppConfig <mobile-appconfig>` but do not support wrapping since each provider would require their own SDK and a custom build. Moreover, majority of the providers do not support WebSocket connections without using a mobile app provider like BlueCedar or AppDome.
```