### PR TITLE
Add step to set SiteURL.

### DIFF
--- a/source/install/install-rhel-6-mattermost.rst
+++ b/source/install/install-rhel-6-mattermost.rst
@@ -47,7 +47,9 @@ Assume that the IP address of this server is 10.10.10.2
     2.  Set ``"DataSource"`` to the following value, replacing ``<mmuser-password>``  and ``<host-name-or-IP>`` with the appropriate values. Also make sure that the database name is ``mattermost`` instead of ``mattermost_test``:
       ``"mmuser:<mmuser-password>@tcp(<host-name-or-IP>:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"``
 
-8. Test the Mattermost server to make sure everything works.
+8. Also set ``"SiteURL"`` to the full base URL of the site (e.g. ``"https://mattermost.example.com"``).
+
+9. Test the Mattermost server to make sure everything works.
 
     a. Change to the ``mattermost`` directory:
       ``cd /opt/mattermost``
@@ -57,7 +59,7 @@ Assume that the IP address of this server is 10.10.10.2
 
   When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 
-9. Setup Mattermost to use the Upstart daemon which handles supervision of the Mattermost process.
+10. Setup Mattermost to use the Upstart daemon which handles supervision of the Mattermost process.
 
   a. Create the Mattermost configuration file:
 

--- a/source/install/install-rhel-7-mattermost.rst
+++ b/source/install/install-rhel-7-mattermost.rst
@@ -47,7 +47,9 @@ Assume that the IP address of this server is 10.10.10.2
     2.  Set ``"DataSource"`` to the following value, replacing ``<mmuser-password>`` and ``<host-name-or-IP>`` with the appropriate values. Also make sure that the database name is ``mattermost`` instead of ``mattermost_test``:
       ``"mmuser:<mmuser-password>@tcp(<host-name-or-IP>:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"``
 
-8. Test the Mattermost server to make sure everything works.
+8. Also set ``"SiteURL"`` to the full base URL of the site (e.g. ``"https://mattermost.example.com"``).
+
+9. Test the Mattermost server to make sure everything works.
 
     a. Change to the ``mattermost`` directory:
       ``cd /opt/mattermost``
@@ -57,7 +59,7 @@ Assume that the IP address of this server is 10.10.10.2
 
   When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 
-9. Set up Mattermost to use the systemd init daemon which handles
+10. Set up Mattermost to use the systemd init daemon which handles
    supervision of the Mattermost process.
 
   a. Create the Mattermost configuration file:
@@ -86,7 +88,7 @@ Assume that the IP address of this server is 10.10.10.2
 
     .. note::
       If you are using MySQL, replace ``postgresql-9.4.service`` by ``mysqld.service`` in the ``[unit]`` section.
-     
+
   c. Make the service executable.
 
     ``sudo chmod 664 /etc/systemd/system/mattermost.service``

--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -50,7 +50,9 @@ Assume that the IP address of this server is 10.10.10.2.
     2.  Set ``"DataSource"`` to the following value, replacing ``<mmuser-password>``  and ``<host-name-or-IP>`` with the appropriate values. Also make sure that the database name is ``mattermost`` instead of ``mattermost_test``:
       ``"mmuser:<mmuser-password>@tcp(<host-name-or-IP>:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"``
 
-8. Test the Mattermost server to make sure everything works.
+8. Also set ``"SiteURL"`` to the full base URL of the site (e.g. ``"https://mattermost.example.com"``).
+
+9. Test the Mattermost server to make sure everything works.
 
     a. Change to the ``mattermost`` directory:
       ``cd /opt/mattermost``
@@ -59,7 +61,7 @@ Assume that the IP address of this server is 10.10.10.2.
 
   When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 
-9. Setup Mattermost to use *systemd* for starting and stopping.
+10. Setup Mattermost to use *systemd* for starting and stopping.
 
   a. Create a *systemd* unit file:
     ``sudo touch /lib/systemd/system/mattermost.service``
@@ -92,10 +94,10 @@ Assume that the IP address of this server is 10.10.10.2.
 
   .. note::
     If you have installed MySQL or PostgreSQL on a dedicated server, then you need to
-     
-      - remove ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section, and 
+
+      - remove ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section, and
       - replace the ``WantedBy=postgresql.service`` or ``WantedBy=mysql.service`` line in the ``[Install]`` section with ``WantedBy=multi-user.target``
-    
+
     or the Mattermost service will not start.
 
   .. note::


### PR DESCRIPTION
Added a step to include setting `SiteURL` in `config.json`

> 8. Also set ``"SiteURL"`` to the full base URL of the site (e.g. ``"https://mattermost.example.com"``).

The mattermost instance won't start if the SiteURL isn't set. I figured it would be easier to read ahead of time instead of reading the logs to figure out what went wrong.