### PR TITLE
Update config-in-database.rst

### DIFF
--- a/source/administration/config-in-database.rst
+++ b/source/administration/config-in-database.rst
@@ -14,13 +14,13 @@ To start using configuration in database, pass the database connection string vi
 
   .. code-block:: text
   
-    ./mattermost --config="postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable\u0026connect_timeout=10"
+    ./mattermost --config="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable\u0026connect_timeout=10"
 
 To migrate an existing config.json into the database, use the ``config migrate`` `command <https://docs.mattermost.com/administration/command-line-tools.html#mattermost-config-migrate>`_. For example:
 
   .. code-block:: text
 
-    ./mattermost config migrate  path/to/config.json "postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+    ./mattermost config migrate  path/to/config.json "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
 
 Any existing SAML certificates and private keys will also be migrated to the database.
 


### PR DESCRIPTION
Update config in database documentation to remove use of `dockerhost` in favour of `localhost`, since we've long since deprecated the former. It might be good to do a full sweep of this.