### PR TITLE
Update security-release.md

### DIFF
--- a/source/process/security-release.md
+++ b/source/process/security-release.md
@@ -6,17 +6,17 @@ If a security fix release is required, run through the below steps.
 
 Notes:
 - All cut-off dates are based on 10am ([San Francisco Time](http://everytimezone.com/)) on the day stated.
-- T-minus counts are measured in "working days" (weekdays other than major holidays concurrent in US and Canada) prior to release day.
+- T-minus counts are measured in "working days" (weekdays, Monday through Friday, excluding [statutory holidays](https://docs.mattermost.com/process/working-at-mattermost.html#holidays)) prior to release day.
 
 ### A. (T-minus 4 working days) Code complete
 
 1. Release Manager:
     - Once the list of security issues to be fixed is finalized, post this checklist in Release Checklist channel
-    - Notify community about upcoming security release through a Twitter announcement and in changelog with links to approved fixes and a date tagged as "TBD"
+    - Notify community about upcoming security release through a Twitter announcement and in Changelog with links to approved fixes and a date tagged as "TBD"
     - Email GitLab release team about upcoming security release.
     - Work with a developer to submit GitLab MR [following this process](https://docs.mattermost.com/process/gitlab-process.html#merge-requests) and [test the upgrade](https://docs.google.com/document/d/1mbeu2XXwCpbz3qz7y_6yDIYBToyY2nW0NFZq9Gdei1E/edit#heading=h.ncq9ltn04isg) once the GitLab MR is merged and included in their RC.
-     - Open a ticket to [submit Gitlab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-10365)
-    - Make a post in Announcements channel announcing the security release to the rest of the team with links to approved tickets and include a link to the ticket to submit the GitLab MR
+     - Open a ticket to [submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-10365)
+    -  Make a post in Announcements channel announcing the security release to the rest of the team with links to approved tickets and include a link to the ticket to submit the GitLab MR
 2. Dev:
     - PRs for hotfixes are made to release branch
     - Review PRs made from release branch and merge changes into the release branch as required and merge the release branch back into master once per day
@@ -40,11 +40,11 @@ Notes:
 Once security fix release is ready to cut:
 
 1. Dev:
-    - Tag a new release (e.g. 1.1.1) and run an official build
+    - Tag a new release (e.g., 1.1.1) and run an official build
     - Verify hashes and GPG signatures are correct, once build is cut
     - Delete RCs after final version is shipped
 2. Release Manager:
-     - Update the changelog
+     - Update the Changelog
      - Update the [version archive](https://docs.mattermost.com/administration/version-archive.html)
      - Update the [ESR documentation](https://docs.mattermost.com/administration/extended-support-release.html#what-are-the-current-supported-esr-versions)
      - Update [Mattermost server download page](https://mattermost.org/download) with the links to the EE and TE bits

--- a/source/process/security-release.md
+++ b/source/process/security-release.md
@@ -6,7 +6,7 @@ If a security fix release is required, run through the below steps.
 
 Notes:
 - All cut-off dates are based on 10am ([San Francisco Time](http://everytimezone.com/)) on the day stated.
-- T-minus counts are measured in "working days" (weekdays, Monday through Friday, excluding [statutory holidays](https://docs.mattermost.com/process/working-at-mattermost.html#holidays)) prior to release day.
+- T-minus counts are measured in "working days" (weekdays, Monday through Friday, excluding [the listed statutory holidays](https://docs.mattermost.com/process/working-at-mattermost.html#holidays)) prior to release day.
 
 ### A. (T-minus 4 working days) Code complete
 


### PR DESCRIPTION
Updated phrasing around working days in line with mattermost/mattermost-developer-documentation#442 but retained working days as opposed to business days for consistency across the doc.
