### PR TITLE
Fix the name of settings

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1453,7 +1453,7 @@ Allow Users to View Archived Channels (Beta)
 **False**: Users are unable to view, share or search for content of channels that have been archived.
 
 +-------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ViewArchivedChannels": false`` with options ``true`` and ``false``.                                      |
+| This feature's ``config.json`` setting is ``"ExperimentalViewArchivedChannels": false`` with options ``true`` and ``false``.                                      |
 +-------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Show Email Address

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -1453,7 +1453,7 @@ Allow Users to View Archived Channels (Beta)
 **False**: Users are unable to view, share or search for content of channels that have been archived.
 
 +-------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ExperimentalViewArchivedChannels": false`` with options ``true`` and ``false``.                                      |
+| This feature's ``config.json`` setting is ``"ExperimentalViewArchivedChannels": false`` with options ``true`` and ``false``.                          |
 +-------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Show Email Address

--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -96,7 +96,7 @@ When a channel is archived, it is removed from the user interface, but a copy ex
 
 Moreover, when a channel is archived, the contents cannot be viewed, shared or searched by default. If you want to be able to view or search the channel later, either
 
-1. Ask your System Administrator to set ``ViewArchivedChannels`` to ``true`` in config.json to allow users to view, share and search for content of channels that have been archived; or
+1. Ask your System Administrator to set ``ExperimentalViewArchivedChannels`` to ``true`` in config.json to allow users to view, share and search for content of channels that have been archived; or
 2. Leave the channel open, but post a message in the channel saying it's considered archived, such as ``# This channel is archived.``
 
 Converting Public Channels to Private (and vice versa)


### PR DESCRIPTION
## Summary
Fix the name of settings for viewing archived channels.

In the document, the settings for viewing archived channels is named as `ViewArchivedChannels`
https://docs.mattermost.com/administration/config-settings.html#allow-users-to-view-archived-channels-beta
> This feature’s config.json setting is "ViewArchivedChannels": false with options true and false.

However, `config.json` in my environment doesn't have `ViewArchivedChannels`. Should its name be `ExperimentalViewArchivedChannels`?

FYI.
mattermost-server doesn't have `ViewArchivedChannels`, instead has `ExperimentalViewArchivedChannels`.
https://github.com/mattermost/mattermost-server/blob/be3e008dcab517ce1e9bb3a6c95de00ba7353b8a/model/config.go#L1525


#### Ticket Link
N/A