### PR TITLE
Update creating-teams.rst

### DIFF
--- a/source/help/getting-started/creating-teams.rst
+++ b/source/help/getting-started/creating-teams.rst
@@ -46,7 +46,7 @@ the system domain, ``https://domain.com/teamurl/``.
 -  It must start with a letter and cannot end in a dash.
 -  It must be 2–15 characters in length.
 -  It cannot start with the following restricted words: ``signup``,
-   ``login``, ``admin``, ``channel``, ``post``, ``api``, ``oauth``, ``plugins``
+   ``login``, ``admin``, ``channel``, ``post``, ``api``, ``oauth``, ``plugins``, ``error``, ``help``
    
 Best Practices for Using a Single Team vs. Multiple Teams
 -----------------------------------------------------------------

--- a/source/help/getting-started/creating-teams.rst
+++ b/source/help/getting-started/creating-teams.rst
@@ -46,7 +46,7 @@ the system domain, ``https://domain.com/teamurl/``.
 -  It must start with a letter and cannot end in a dash.
 -  It must be 2–15 characters in length.
 -  It cannot start with the following restricted words: ``signup``,
-   ``login``, ``admin``, ``channel``, ``post``, ``api``, ``oauth``
+   ``login``, ``admin``, ``channel``, ``post``, ``api``, ``oauth``, ``plugins``
    
 Best Practices for Using a Single Team vs. Multiple Teams
 -----------------------------------------------------------------


### PR DESCRIPTION
Added ``plugins``, ``error`` and ``help`` as reserved words for naming teams which was fixed in https://github.com/mattermost/mattermost-webapp/pull/4647

