### PR TITLE
Update copyright year to '2015-2020'

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Mattermost'
-copyright = u'2015-2019 Mattermost'
+copyright = u'2015-2020 Mattermost'
 author = u'Mattermost'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
@justinegeffen Not sure how to track for future, but can you take an action time - perhaps a Jira ticket - to update copyright on Jan 2, 2021 next year? Thanks!