### PR TITLE
Update training.rst

### DIFF
--- a/source/process/training.rst
+++ b/source/process/training.rst
@@ -433,7 +433,7 @@ Procedure:
 ::
 
    #### @channel A reminder to prepare your items for R&D meeting [DATE]:
-   1. @[name], @[name] and @[name] - you're up for ice-breaker
+   1. @[name], @[name] and @[name] - you're up for `ice-breaker <https://docs.mattermost.com/process/training.html#ice-breaker>`__
    2. Reminder for team member responsible for this week's team update to include it [in the notes](LINK)
    3. If you'll be giving a demo, please queue it [in the meeting notes](link) 
    ##### Everyone is encouraged to bring up items for discussion. If the discussion is `time-copped` during the meeting, please be sure to add a `next step` to the notes and post a link to where the conversation can be continued. ~platform channel is usually a good place to continue discussions.
@@ -454,8 +454,8 @@ Meeting Agenda:
 - **Ice-breaker** - see Meeting Elements > Ice-breaker below for examples
 - **Roadmap check-in** - Review of roadmap status in current and next release
 - **Team updates** - Each development team gives a short update on their current top priorities
-- **Demos (optional)** - Team members show highlights of what's been completed this week. Relevant follow-ups noted
-- **Blind spots, Inspiration, Knowledge Share** - Colleagues share areas of concern and ask questions
+- **Demos** - Team members show highlights of what's been completed this week. Relevant follow-ups noted
+- **Blind spots, Inspiration, Knowledge Share** - Colleagues share areas of concern and ask questions. Items for discussion can be queued here.
 
 Post Meeting:
 
@@ -484,6 +484,7 @@ Blind spots, Inspiration, Knowledge Share
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Exercise to find blindspots in team thinking at the end of a meeting
+- Items for team discussion can also be queued in this section
 - Colleagues share areas of concern and ask questions which invariably disclose blind-spots or are an opportunity to improve communication.
 - Examples of questions:
 

--- a/source/process/training.rst
+++ b/source/process/training.rst
@@ -456,7 +456,7 @@ Meeting Agenda:
 - **Announcements** - Short announcements that the entire team needs to know about
 - **Team updates** - Each team lists a short update of their current top priorities which can be read by meeting attendees (not actually reviewed during the meeting)
 - **Demos** - Team members show highlights of what's been completed this week. Relevant follow-ups noted
-- **Blind spots, Inspiration, Knowledge Share** - Colleagues share areas of concern and ask questions. Proposals for items that have already been discussed outside of the meeting can also be queued here.
+- **Blind spots, Inspiration, Knowledge Share** - Colleagues share areas of concern and ask questions. Proposals for items that have already been discussed outside of the meeting can also be queued here
 
 Post Meeting:
 

--- a/source/process/training.rst
+++ b/source/process/training.rst
@@ -452,10 +452,11 @@ Procedure:
 Meeting Agenda:
 
 - **Ice-breaker** - see Meeting Elements > Ice-breaker below for examples
-- **Roadmap check-in** - Review of roadmap status in current and next release
-- **Team updates** - Each development team gives a short update on their current top priorities
+- **Release updates** - Overview of current release status
+- **Announcements** - Short announcements that the entire team needs to know about
+- **Team updates** - Each team lists a short update of their current top priorities which can be read by meeting attendees (not actually reviewed during the meeting)
 - **Demos** - Team members show highlights of what's been completed this week. Relevant follow-ups noted
-- **Blind spots, Inspiration, Knowledge Share** - Colleagues share areas of concern and ask questions. Items for discussion can be queued here.
+- **Blind spots, Inspiration, Knowledge Share** - Colleagues share areas of concern and ask questions. Proposals for items that have already been discussed outside of the meeting can also be queued here.
 
 Post Meeting:
 


### PR DESCRIPTION
Updated R&D meeting section to clarify where items for team discussion can be queued in the meeting notes. Also removed `optional` from demos as they're now required.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

