### PR TITLE
add examples for id attribute in ldap section

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -2189,7 +2189,7 @@ ID Attribute
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The attribute in the AD/LDAP server used as a unique identifier in Mattermost. It should be an AD/LDAP attribute with a value that does not change.
 
-If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one. Therefore we recommend setting this to a unique attribute like ``objectGUID`` in Active Directory and ``entryUUID`` in LDAP. 
+If a user's ID Attribute changes, a new Mattermost account (unassociated with the previous one) is created. To prevent this, it's recommended that a unique attribute such as ``objectGUID`` in Active Directory and ``entryUUID`` in LDAP be used instead. 
 Before making any changes confirm with your LDAP provider whether these attributes are available in your environment.
 
 If you need to change this field after users have already logged in, use the `mattermost ldap idmigrate <https://about.mattermost.com/default-platform-ldap-idmigrate>`__ CLI tool.

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -2190,7 +2190,7 @@ ID Attribute
 The attribute in the AD/LDAP server used as a unique identifier in Mattermost. It should be an AD/LDAP attribute with a value that does not change.
 
 If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one. Therefore we recommend setting this to a unique attribute like ``objectGUID`` in Active Directory and ``entryUUID`` in LDAP. 
-Please check with your LDAP provider first to see if these attributes are available in your environment.
+Before making any changes confirm with your LDAP provider whether these attributes are available in your environment.
 
 If you need to change this field after users have already logged in, use the `mattermost ldap idmigrate <https://about.mattermost.com/default-platform-ldap-idmigrate>`__ CLI tool.
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -2189,7 +2189,8 @@ ID Attribute
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The attribute in the AD/LDAP server used as a unique identifier in Mattermost. It should be an AD/LDAP attribute with a value that does not change.
 
-If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one.
+If a user's ID Attribute changes, it will create a new Mattermost account unassociated with their old one. Therefore we recommend setting this to a unique attribute like ``objectGUID`` in Active Directory and ``entryUUID`` in LDAP. 
+Please check with your LDAP provider first to see if these attributes are available in your environment.
 
 If you need to change this field after users have already logged in, use the `mattermost ldap idmigrate <https://about.mattermost.com/default-platform-ldap-idmigrate>`__ CLI tool.
 


### PR DESCRIPTION
this comes up quite a lot and i hope that adding this additional note might lead to people using objectguid or entryuuid more often to prevent issues that might come up when using ldap sync.