### PR TITLE
update link to new jira dooks

### DIFF
--- a/source/integrations/jira.rst
+++ b/source/integrations/jira.rst
@@ -3,6 +3,6 @@
 Jira Plugin 
 ================================
 
-The Jira/Mattermost plugin documentation is currently being updated and relocated to a new location: https://mattermost.gitbook.io/jira-plugin/.
+The Jira/Mattermost plugin documentation is currently being updated and relocated to a `new location <https://mattermost.gitbook.io/jira-plugin/>`.
 
 Learn more about how to integrate with your other `Atlassian tools <https://docs.mattermost.com/deployment/atlassian-integrations.html>`.

--- a/source/integrations/jira.rst
+++ b/source/integrations/jira.rst
@@ -3,6 +3,6 @@
 Jira Plugin 
 ================================
 
-Documentation has moved to `Jira plugin repository <https://github.com/mattermost/mattermost-plugin-jira>`_.
+The Jira/Mattermost plugin documentation is currently being updated and relocated to a new location: https://mattermost.gitbook.io/jira-plugin/
 
 Learn more about how to integrate with your other `Atlassian tools <https://docs.mattermost.com/deployment/atlassian-integrations.html>`.

--- a/source/integrations/jira.rst
+++ b/source/integrations/jira.rst
@@ -3,6 +3,6 @@
 Jira Plugin 
 ================================
 
-The Jira/Mattermost plugin documentation is currently being updated and relocated to a `new location <https://mattermost.gitbook.io/jira-plugin/>`.
+The Jira/Mattermost plugin documentation is currently being updated and relocated to a `new location <https://mattermost.gitbook.io/jira-plugin/>`_.
 
-Learn more about how to integrate with your other `Atlassian tools <https://docs.mattermost.com/deployment/atlassian-integrations.html>`.
+Learn more about how to integrate with your other `Atlassian tools <https://docs.mattermost.com/deployment/atlassian-integrations.html>`_.

--- a/source/integrations/jira.rst
+++ b/source/integrations/jira.rst
@@ -3,6 +3,6 @@
 Jira Plugin 
 ================================
 
-The Jira/Mattermost plugin documentation is currently being updated and relocated to a new location: https://mattermost.gitbook.io/jira-plugin/
+The Jira/Mattermost plugin documentation is currently being updated and relocated to a new location: https://mattermost.gitbook.io/jira-plugin/.
 
 Learn more about how to integrate with your other `Atlassian tools <https://docs.mattermost.com/deployment/atlassian-integrations.html>`.


### PR DESCRIPTION
saves a click and avoids more confusion as this page is the first one that comes up on google.