### PR TITLE
Remove GitLab RC check from release process

### DIFF
--- a/source/process/bug-fix-release.md
+++ b/source/process/bug-fix-release.md
@@ -254,8 +254,6 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - Upgrade dependancies for webapp, server, and Redux
         - Week after release (for GitLab dev owner)
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
-        - Week after release (for GitLab dev owner)
-            - [Confirm the relevant GitLab RC has the correct Mattermost version post-merge](https://mattermost.atlassian.net/browse/MM-22061)
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
     - Contact owners of [community installers](https://www.mattermost.org/installation/) or submit PRs to update install version number
       - For Puppet, Heroku, and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/fgjqthmn67nujjtx4fcrn1hd9a).

--- a/source/process/feature-release.md
+++ b/source/process/feature-release.md
@@ -296,8 +296,6 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - Upgrade dependancies for webapp, server, and Redux
        - Week after release (for GitLab dev owner)
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
-       - Week after release (for GitLab dev owner)
-            - [Confirm the relevant GitLab RC has the correct Mattermost version post-merge](https://mattermost.atlassian.net/browse/MM-22061)
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
     - Contact owners of [community installers](http://www.mattermost.org/installation/) or submit PRs to update install version number
       - For Puppet, Heroku, and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/fgjqthmn67nujjtx4fcrn1hd9a)


### PR DESCRIPTION
For context: GitLab doesn't publish their RCs and they said they'll ensure Mattermost is included in future releases.

There isn't a way for us to verify the correct Mattermost release is shipping, so removing this step.