### PR TITLE
No image proxy for preview of plaintext URLs

### DIFF
--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -13,7 +13,7 @@ also helps preserve posts by protecting them from dead images.
 
 When enabled, the image proxy needs to be publicly accessible to both the Mattermost client and server.
 
-Currently the image proxy on the server side only works for Markdown embedded images and not for `image preview of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
+The Mattermost clients will use the image proxy to load all external images. The Mattermost server will use the image proxy when possible, but it will not use it when requesting content that may not be an image, such as for `image previews of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
 
 You may alternatively use `atmos/camo <https://github.com/atmos/camo>`_ http proxy to route images through SSL:
 

--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -3,7 +3,7 @@
 Image Proxy
 ================================
 
-Using image proxies means that users make only secure requests. By allowing image requests to go straight to third-party
+Using image proxies means that users make only secure requests for Markdown embedded images. By allowing image requests to go straight to third-party
 servers, tracking pixels is allowed. Users can put invisible images in posts that logs time and location data
 for every user that views the post. An image proxy protects user privacy by eliminating this direct interaction with 
 third-party servers.
@@ -12,6 +12,8 @@ Proxy servers also provide a layer of caching, and can be made faster and more r
 also helps preserve posts by protecting them from dead images.
 
 When enabled, the image proxy needs to be publicly accessible to both the Mattermost client and server.
+
+Currently the image proxy only works for Markdown embedded images and not `image preview of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
 
 You may alternatively use `atmos/camo <https://github.com/atmos/camo>`_ http proxy to route images through SSL:
 

--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -3,7 +3,7 @@
 Image Proxy
 ================================
 
-Using image proxies means that users make only secure requests for Markdown embedded images. By allowing image requests to go straight to third-party
+Using image proxies means that clients make only secure requests. By allowing image requests to go straight to third-party
 servers, tracking pixels is allowed. Users can put invisible images in posts that logs time and location data
 for every user that views the post. An image proxy protects user privacy by eliminating this direct interaction with 
 third-party servers.
@@ -13,7 +13,7 @@ also helps preserve posts by protecting them from dead images.
 
 When enabled, the image proxy needs to be publicly accessible to both the Mattermost client and server.
 
-Currently the image proxy only works for Markdown embedded images and not for `image preview of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
+Currently the image proxy on the server side only works for Markdown embedded images and not for `image preview of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
 
 You may alternatively use `atmos/camo <https://github.com/atmos/camo>`_ http proxy to route images through SSL:
 

--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -13,7 +13,7 @@ also helps preserve posts by protecting them from dead images.
 
 When enabled, the image proxy needs to be publicly accessible to both the Mattermost client and server.
 
-Currently the image proxy only works for Markdown embedded images and not `image preview of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
+Currently the image proxy only works for Markdown embedded images and not for `image preview of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
 
 You may alternatively use `atmos/camo <https://github.com/atmos/camo>`_ http proxy to route images through SSL:
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Document https://github.com/mattermost/mattermost-server/issues/11857
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

