### PR TITLE
Update prod-docker to use sudo for chown

### DIFF
--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -39,7 +39,7 @@ Production Docker Setup on Ubuntu
        cd mattermost-docker
        docker-compose build
        mkdir -pv ./volumes/app/mattermost/{data,logs,config,plugins,client-plugins}
-       chown -R 2000:2000 ./volumes/app/mattermost/
+       sudo chown -R 2000:2000 ./volumes/app/mattermost/
        docker-compose up -d
 
 4. **Configure TLS** by following `the instructions <https://github.com/mattermost/mattermost-docker#install-with-ssl-certificate>`__.


### PR DESCRIPTION
## Summary

Fixes the *Production Docker Deployment* instructions to use `sudo` for `chown`.

#### Ticket Link

(No corresponding ticket/issue.)

