### PR TITLE
Update Troubleshooting for Citrix Virtual Apps and Desktop

### DIFF
--- a/source/install/desktop.rst
+++ b/source/install/desktop.rst
@@ -176,7 +176,11 @@ Internal error: BrowserWindow 'unresponsive' event has been emitted
 
   1. Clear the cache via CTRL+SHIFT+R (or View > Clear Cache and Reload).
   2. Go to App Settings (via CTRL+COMMA or File > Settings) and unselect hardware acceleration.
+  
+Desktop App not responsive within Citrix Virtual Apps or Desktop Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Append ``Mattermost.exe;`` to the Registry Key ``HKLM\SYSTEM\CurrentControlSet\Services\CtxUvi\UviProcessExcludes`` and reboot the system.
 
 For additional troubleshooting tips, see the `troubleshooting guide <https://www.mattermost.org/troubleshoot/>`__.
 


### PR DESCRIPTION
After deploying the new Desktop App 4.4 i couldn't start the app on our Citrix Virtual Apps and Desktop Environment. It was unresponsive and using a lot of CPU. After adding the Mattermost.exe; as described everything was ok.

This entry is only relevant for cooperate environments. 