### PR TITLE
Docs: Add firewall open port guide for debian

### DIFF
--- a/source/install/install-debian-mattermost.rst
+++ b/source/install/install-debian-mattermost.rst
@@ -117,7 +117,7 @@ Assume that the IP address of this server is 10.10.10.2.
 
     ``curl http://localhost:8065``
 
-    You should see the HTML that's returned by the Mattermost server.
+    You should see the HTML that's returned by the Mattermost server. Note: in case firewall is used, external requests to port 8065 may be blocked. Use ``sudo ufw allow 8065`` to open port 8065.
 
   g. Set Mattermost to start on machine start up.
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Added a note about `sudo ufw allow 8065` to open port for external connectivity, since I've forgot to do this myself and thought something didn't work. Hope this will help.


