### PR TITLE
Updates to Docker documentation

### DIFF
--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -1,7 +1,9 @@
 ..  _docker-local-machine:
 
-Production Docker Deployment
+Deploy Mattermost on Docker
 ==============================
+
+.. important:: This unofficial guide is maintained by the Mattermost community and this deployment configuration is not yet officially supported by Mattermost, Inc. Community testing, feedback and improvements are welcome and greatly appreciated. You can `edit this page on GitHub <https://github.com/mattermost/docs/blob/master/source/install/prod-docker.rst>`__.
 
 Deploy Mattermost using a multi-node production configuration with `Docker Compose <https://docs.docker.com/compose/>`__. Experience with Docker Compose is recommended.
 

--- a/source/process/bug-fix-release.md
+++ b/source/process/bug-fix-release.md
@@ -104,6 +104,7 @@ Review the [Release Features & Bugs Quality Gate Guidelines](https://docs.google
     - Review all `TODO` notes, including one for uncommenting upgrade code
     - Confirm all PRs in [`/enterprise`](https://github.com/mattermost/enterprise/pulls) repo have been merged.
     - Update Redux before each RC and Final build
+    - Update package version in [Mattermost DockerFile](https://github.com/mattermost/mattermost-server/blob/master/build/Dockerfile#L7)
     - Master is tagged and branched and `Release Candidate 1` is cut (e.g., 3.5.0-RC1) according to the Release Candidate Checklist in ``mattermost/process``
     - After branching, the database version in `sql_upgrade.go` on master is set to the next scheduled release version (e.g., 3.6.0)
     - CI servers are updated to the release branch

--- a/source/process/bug-fix-release.md
+++ b/source/process/bug-fix-release.md
@@ -102,7 +102,7 @@ Review the [Release Features & Bugs Quality Gate Guidelines](https://docs.google
     - After RC1 is cut: Lock Selenium server to RC1 and begin running all Selenium IDE tests
 4. Build:
     - Review all `TODO` notes, including one for uncommenting upgrade code
-    - Confirm all PRs in [`/enterprise`](https://github.com/mattermost/enterprise/pulls) repo have been merged.
+    - Confirm all PRs in [`/enterprise`](https://github.com/mattermost/enterprise/pulls) repo have been merged
     - Update Redux before each RC and Final build
     - Update package version in [Mattermost DockerFile](https://github.com/mattermost/mattermost-server/blob/master/build/Dockerfile#L7)
     - Master is tagged and branched and `Release Candidate 1` is cut (e.g., 3.5.0-RC1) according to the Release Candidate Checklist in ``mattermost/process``

--- a/source/process/feature-release.md
+++ b/source/process/feature-release.md
@@ -142,6 +142,7 @@ Day when Leads and PMs decide which major features are included in the release, 
     - Review all `TODO` notes, including one for uncommenting upgrade code
     - Confirm all PRs in [`/enterprise`](https://github.com/mattermost/enterprise/pulls) repo have been merged
     - Update Redux before each RC and Final build
+    - Update package version in [Mattermost DockerFile](https://github.com/mattermost/mattermost-server/blob/master/build/Dockerfile#L7)
     - Master is tagged and branched and `Release Candidate 1` is cut (e.g. 3.5.0-RC1) according to the Release Candidate Checklist in `mattermost/process`
     - After branching, the database version in `sql_upgrade.go` on master is set to the next scheduled release version (e.g., 3.6.0)
     - CI servers are updated to the release branch


### PR DESCRIPTION
1. @amyblais Add a release process step to update package version in Mattermost DockerFile.
2. @wiersgallak @justinegeffen Add a note that Docker deployment guide is unofficial, community-maintained.

A separate item to discuss ownership of Docker image queued for PM meeting.