### PR TITLE
Hint to `"skip_slack_parsing"` to ignore Slack-compatibility logic

### DIFF
--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -313,6 +313,19 @@ Like Slack, actions are specified in an **Actions** list within the message atta
 
 However, the schema for these objects is slightly different given Slack requires a Slack App and action URL to be pre-configured beforehand. Mattermost instead allows an integration to create an interactive message without pre-configuration.
 
+If your `ephemeral_text` gets incorrectly handled by the Slack-compatibility logic, send ``"skip_slack_parsing":true` along your `ephemeral_text`.
+
+.. code-block:: text
+
+  {
+    "update": {
+      "message": "Updated!"
+    },
+    "ephemeral_text": "You updated the post!",
+    "skip_slack_parsing":true
+  }
+
+
 Frequently Asked Questions
 ----------------------------------
 

--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -322,7 +322,7 @@ If your `ephemeral_text` gets incorrectly handled by the Slack-compatibility log
       "message": "Updated!"
     },
     "ephemeral_text": "You updated the post!",
-    "skip_slack_parsing":true
+    "skip_slack_parsing": true
   }
 
 

--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -313,7 +313,7 @@ Like Slack, actions are specified in an **Actions** list within the message atta
 
 However, the schema for these objects is slightly different given Slack requires a Slack App and action URL to be pre-configured beforehand. Mattermost instead allows an integration to create an interactive message without pre-configuration.
 
-If your `ephemeral_text` gets incorrectly handled by the Slack-compatibility logic, send ``"skip_slack_parsing":true` along your `ephemeral_text` to bypass said logic.
+If your `ephemeral_text` gets incorrectly handled by the Slack-compatibility logic, send ``"skip_slack_parsing":true`` along your `ephemeral_text` to bypass it.
 
 .. code-block:: text
 

--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -313,7 +313,7 @@ Like Slack, actions are specified in an **Actions** list within the message atta
 
 However, the schema for these objects is slightly different given Slack requires a Slack App and action URL to be pre-configured beforehand. Mattermost instead allows an integration to create an interactive message without pre-configuration.
 
-If your `ephemeral_text` gets incorrectly handled by the Slack-compatibility logic, send ``"skip_slack_parsing":true` along your `ephemeral_text`.
+If your `ephemeral_text` gets incorrectly handled by the Slack-compatibility logic, send ``"skip_slack_parsing":true` along your `ephemeral_text` to bypass said logic.
 
 .. code-block:: text
 


### PR DESCRIPTION
#### Summary
Docs related to https://github.com/mattermost/mattermost-server/pull/13976 change.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/13968
MM-22825