### PR TITLE
s/Requires=/BindsTo=/g to let Mattermost hold the state the db holds

### DIFF
--- a/source/install/install-debian-mattermost.rst
+++ b/source/install/install-debian-mattermost.rst
@@ -71,7 +71,7 @@ Assume that the IP address of this server is 10.10.10.2.
     Description=Mattermost
     After=network.target
     After=postgresql.service
-    Requires=postgresql.service
+    BindsTo=postgresql.service
 
     [Service]
     Type=notify
@@ -91,7 +91,7 @@ Assume that the IP address of this server is 10.10.10.2.
     If you are using MySQL, replace ``postgresql.service`` with ``mysql.service`` in 2 places in the ``[Unit]`` section.
     
   .. note::
-    If you have installed MySQL or PostgreSQL on a dedicated server then you need to remove the ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section or the Mattermost service will not start.
+    If you have installed MySQL or PostgreSQL on a dedicated server then you need to remove the ``After=postgresql.service`` and ``BindsTo=postgresql.service`` or ``After=mysql.service`` and ``BindsTo=mysql.service`` lines in the ``[Unit]`` section or the Mattermost service will not start.
 
   c. Make systemd load the new unit.
 

--- a/source/install/install-ubuntu-1604-mattermost.rst
+++ b/source/install/install-ubuntu-1604-mattermost.rst
@@ -73,7 +73,7 @@ Assume that the IP address of this server is 10.10.10.2.
     Description=Mattermost
     After=network.target
     After=postgresql.service
-    Requires=postgresql.service
+    BindsTo=postgresql.service
 
     [Service]
     Type=notify
@@ -95,7 +95,7 @@ Assume that the IP address of this server is 10.10.10.2.
   .. note::
     If you have installed MySQL or PostgreSQL on a dedicated server, then you need to
 
-      - remove ``After=postgresql.service`` and ``Requires=postgresql.service`` or ``After=mysql.service`` and ``Requires=mysql.service`` lines in the ``[Unit]`` section, and
+      - remove ``After=postgresql.service`` and ``BindsTo=postgresql.service`` or ``After=mysql.service`` and ``BindsTo=mysql.service`` lines in the ``[Unit]`` section, and
       - replace the ``WantedBy=postgresql.service`` or ``WantedBy=mysql.service`` line in the ``[Install]`` section with ``WantedBy=multi-user.target``
 
     or the Mattermost service will not start.

--- a/source/install/outbound-proxy.rst
+++ b/source/install/outbound-proxy.rst
@@ -40,7 +40,7 @@ To set these environment variables while running the Mattermost server via ``sys
     Description=Mattermost
     After=network.target
     After=postgresql.service
-    Requires=postgresql.service
+    BindsTo=postgresql.service
 
     [Service]
     Type=notify


### PR DESCRIPTION
With `Requires=` Mattermost will stop if the db service stops but it will not start again because it does not hold the active and inactive state from service it requires. With BindTo Mattermost will be stopped and started and therefore holds the state the db holds. db needs update -> db stops -> mattermost stops -> db updates -> db starts -> mattermost starts.
