### PR TITLE
Fix descriptions in child commands of plugin

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -1351,8 +1351,8 @@ mattermost plugin
   Child Commands
     -  `mattermost plugin add`_ - Add plugins to your Mattermost server.
     -  `mattermost plugin delete`_ - Delete previously uploaded plugins.
-    -  `mattermost plugin enable`_ - Enable plugins for use.
     -  `mattermost plugin disable`_ - Disable plugins.
+    -  `mattermost plugin enable`_ - Enable plugins for use.
     -  `mattermost plugin list`_ - List plugins installed on your Mattermost server.
 
 mattermost plugin add

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -1351,8 +1351,8 @@ mattermost plugin
   Child Commands
     -  `mattermost plugin add`_ - Add plugins to your Mattermost server.
     -  `mattermost plugin delete`_ - Delete previously uploaded plugins.
-    -  `mattermost plugin disable`_ - Enable plugins for use.
-    -  `mattermost plugin enable`_ - Disable plugins.
+    -  `mattermost plugin enable`_ - Enable plugins for use.
+    -  `mattermost plugin disable`_ - Disable plugins.
     -  `mattermost plugin list`_ - List plugins installed on your Mattermost server.
 
 mattermost plugin add


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes a typo in https://docs.mattermost.com/administration/command-line-tools.html#mattermost-plugin, which had the descriptions for `mattermost plugin`'s child commands `enable` and `disable` swapped.
