### PR TITLE
Update image proxy documentation

### DIFF
--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -12,7 +12,7 @@ When enabled, the image proxy needs to be publicly accessible to both the Matter
 
 Mattermost clients will use the image proxy to load all external images. The Mattermost server will use the image proxy when possible, but it will not use it when requesting content that may not be an image, such as for `image previews of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
 
-An image proxy may be configured from the **Environment > Image Proxy** section of the System Console or the **Files > Storage** in versions of Mattermost prior to 5.12.
+An image proxy may be configured from the **Environment > Image Proxy** section of the System Console in recent version of Mattermost or the **Files > Storage** section in versions prior to 5.12.
 
 Local Image Proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -29,7 +29,7 @@ atmos/camo Image Proxy
 
 The `atmos/camo <https://github.com/atmos/camo>`_ image proxy is a standalone image proxy that can be deployed separately from the Mattermost server. It provides additional configuration options over the built-in image proxy, and it can also be used if isolation between the Mattermost server and image proxy is desired.
 
-Once you've deployed an ``atmos/camo`` (https://github.com/atmos/camo) instance, you must specify the **Remote Image Proxy URL** and **Remote Image Proxy Options** settings. The **Remote Image Proxy Options** should be set to the to image-proxy.mattermost.com and update the image proxy's shared key which is specified with the ``CAMO_KEY`` environment variable used when setting up the image proxy.
+Once you've deployed an ``atmos/camo`` (https://github.com/atmos/camo) instance, you must specify the **Remote Image Proxy URL** and **Remote Image Proxy Options** settings. The **Remote Image Proxy Options** should be set to the image proxy's shared key which would have been specified with the ``CAMO_KEY`` environment variable used when setting up the image proxy.
 
 For example, if the image proxy was located at ``https://image-proxy.mattermost.com``, you would configure it as below:
 

--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -3,21 +3,21 @@
 Image Proxy
 ================================
 
-Using an image proxy makes it so that all requests for images made by Mattermost clients will go through the proxy instead of contacting third-party servers directly. This helps protect user privacy by preventing third-party servers from tracking who views an image. This also prevents the use of tracking pixels, invisible images that do the same thing without the user even seeing an image.
+Using an image proxy means that all requests for images made by Mattermost clients will go through the proxy instead of contacting third-party servers directly. This helps protect user privacy by preventing third-party servers from tracking who views an image. This also prevents the use of tracking pixels (invisible images that do the same thing without the user even seeing an image).
 
 Certain proxy servers also provide a layer of caching which can make loading images faster and more reliable. This caching 
 also helps preserve posts by protecting them from dead images.
 
 When enabled, the image proxy needs to be publicly accessible to both the Mattermost client and server.
 
-Mattermost clients will use the image proxy to load all external images. The Mattermost server will use the image proxy when possible, but it will not use it when requesting content that may not be an image, such as for `image previews of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
+Mattermost clients will use the image proxy to load all external images. The Mattermost server will use the image proxy when possible, but will not use it when requesting content that may not be an image, such as for `image previews of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
 
-An image proxy may be configured from the **Environment > Image Proxy** section of the System Console in recent version of Mattermost or the **Files > Storage** section in versions prior to 5.12.
+An image proxy can be configured in **System Console > Environment > Image Proxy** (or **System Console < Files > Storage** in versions prior to 5.12).
 
 Local Image Proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The local image proxy is available as part of the Mattermost server itself. When using the local image proxy, images will be served to clients through the server which helps anonymize users and provides a secure connection if SSL is enabled on the server. This method does not offer any caching behavior.
+The local image proxy is available as part of the Mattermost server deployment. When using the local image proxy, images are served to clients through the server which helps anonymize users. If SSL is enabled on the server it provides a secure connection. This method does not offer any caching behavior.
 
 .. note:: 
    With the local image proxy enabled, requests for images hosted on the local network are now affected by the ``AllowUntrustedInternalConnections`` setting. See `documentation <https://docs.mattermost.com/administration/config-settings.html#allow-untrusted-internal-connections-to>`_ for more information or if you are seeing unintentionally blocked images.
@@ -29,9 +29,9 @@ atmos/camo Image Proxy
 
 The `atmos/camo <https://github.com/atmos/camo>`_ image proxy is a standalone image proxy that can be deployed separately from the Mattermost server. It provides additional configuration options over the built-in image proxy, and it can also be used if isolation between the Mattermost server and image proxy is desired.
 
-Once you've deployed an ``atmos/camo`` (https://github.com/atmos/camo) instance, you must specify the **Remote Image Proxy URL** and **Remote Image Proxy Options** settings. The **Remote Image Proxy Options** should be set to the image proxy's shared key which would have been specified with the ``CAMO_KEY`` environment variable used when setting up the image proxy.
+Once you've deployed an ``atmos/camo`` (https://github.com/atmos/camo) instance, you must specify the **Remote Image Proxy URL** and **Remote Image Proxy Options** settings. The **Remote Image Proxy Options** should be set to the image proxy's shared key which is specified with the ``CAMO_KEY`` environment variable used when setting up the image proxy.
 
-For example, if the image proxy was located at ``https://image-proxy.mattermost.com``, you would configure it as below:
+For example, if the image proxy is located at ``https://image-proxy.mattermost.com``, it would be configured as follows:
 
  - **Image Proxy Type**: ``atmos/camo``
  - **Remote Image Proxy URL**: ``https://image-proxy.mattermost.com``

--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -5,8 +5,7 @@ Image Proxy
 
 Using an image proxy means that all requests for images made by Mattermost clients will go through the proxy instead of contacting third-party servers directly. This helps protect user privacy by preventing third-party servers from tracking who views an image. This also prevents the use of tracking pixels (invisible images that do the same thing without the user even seeing an image).
 
-Certain proxy servers also provide a layer of caching which can make loading images faster and more reliable. This caching 
-also helps preserve posts by protecting them from dead images.
+Certain proxy servers also provide a layer of caching which can make loading images faster and more reliable. This caching also helps preserve posts by protecting them from dead images.
 
 When enabled, the image proxy needs to be publicly accessible to both the Mattermost client and server.
 
@@ -17,7 +16,7 @@ An image proxy can be configured in **System Console > Environment > Image Proxy
 Local Image Proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The local image proxy is available as part of the Mattermost server deployment. When using the local image proxy, images are served to clients through the server which helps anonymize users. If SSL is enabled on the server it provides a secure connection. This method does not offer any caching behavior.
+The local image proxy is available as part of the Mattermost server deployment. When using the local image proxy, images are served to clients through the server which helps anonymize users. If SSL is enabled on the server, it provides a secure connection. This method does not offer any caching behavior.
 
 .. note:: 
    With the local image proxy enabled, requests for images hosted on the local network are now affected by the ``AllowUntrustedInternalConnections`` setting. See `documentation <https://docs.mattermost.com/administration/config-settings.html#allow-untrusted-internal-connections-to>`_ for more information or if you are seeing unintentionally blocked images.

--- a/source/administration/image-proxy.rst
+++ b/source/administration/image-proxy.rst
@@ -3,24 +3,21 @@
 Image Proxy
 ================================
 
-Using image proxies means that clients make only secure requests. By allowing image requests to go straight to third-party
-servers, tracking pixels is allowed. Users can put invisible images in posts that logs time and location data
-for every user that views the post. An image proxy protects user privacy by eliminating this direct interaction with 
-third-party servers.
+Using an image proxy makes it so that all requests for images made by Mattermost clients will go through the proxy instead of contacting third-party servers directly. This helps protect user privacy by preventing third-party servers from tracking who views an image. This also prevents the use of tracking pixels, invisible images that do the same thing without the user even seeing an image.
 
-Proxy servers also provide a layer of caching, and can be made faster and more reliable than third-party sites. This caching 
+Certain proxy servers also provide a layer of caching which can make loading images faster and more reliable. This caching 
 also helps preserve posts by protecting them from dead images.
 
 When enabled, the image proxy needs to be publicly accessible to both the Mattermost client and server.
 
-The Mattermost clients will use the image proxy to load all external images. The Mattermost server will use the image proxy when possible, but it will not use it when requesting content that may not be an image, such as for `image previews of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
+Mattermost clients will use the image proxy to load all external images. The Mattermost server will use the image proxy when possible, but it will not use it when requesting content that may not be an image, such as for `image previews of plaintext URLs <https://github.com/mattermost/mattermost-server/issues/11857>`_.
 
-You may alternatively use `atmos/camo <https://github.com/atmos/camo>`_ http proxy to route images through SSL:
+An image proxy may be configured from the **Environment > Image Proxy** section of the System Console or the **Files > Storage** in versions of Mattermost prior to 5.12.
 
 Local Image Proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The local image proxy is enabled on the Mattermost server by default. When using the local image proxy, Mattermost apps will download external images through the Mattermost server itself.
+The local image proxy is available as part of the Mattermost server itself. When using the local image proxy, images will be served to clients through the server which helps anonymize users and provides a secure connection if SSL is enabled on the server. This method does not offer any caching behavior.
 
 .. note:: 
    With the local image proxy enabled, requests for images hosted on the local network are now affected by the ``AllowUntrustedInternalConnections`` setting. See `documentation <https://docs.mattermost.com/administration/config-settings.html#allow-untrusted-internal-connections-to>`_ for more information or if you are seeing unintentionally blocked images.
@@ -32,21 +29,13 @@ atmos/camo Image Proxy
 
 The `atmos/camo <https://github.com/atmos/camo>`_ image proxy is a standalone image proxy that can be deployed separately from the Mattermost server. It provides additional configuration options over the built-in image proxy, and it can also be used if isolation between the Mattermost server and image proxy is desired.
 
-This guide gives an example of how to set up an image proxy using ``atmos/camo``:
+Once you've deployed an ``atmos/camo`` (https://github.com/atmos/camo) instance, you must specify the **Remote Image Proxy URL** and **Remote Image Proxy Options** settings. The **Remote Image Proxy Options** should be set to the to image-proxy.mattermost.com and update the image proxy's shared key which is specified with the ``CAMO_KEY`` environment variable used when setting up the image proxy.
 
-Deploy an ``atmos/camo`` (https://github.com/atmos/camo) instance to image-proxy.mattermost.com and update the 
-configuration in **System Console > Files > Storage** in prior versions or **System Console > Environment > Image Proxy** in versions after 5.12. For example:
+For example, if the image proxy was located at ``https://image-proxy.mattermost.com``, you would configure it as below:
+
  - **Image Proxy Type**: ``atmos/camo``
  - **Remote Image Proxy URL**: ``https://image-proxy.mattermost.com``
  - **Remote Image Proxy Options**: ``CAMO_KEY``, which is the secret string used for the sample ``atmos/camo`` deployment.
 
 .. image:: ../images/image-proxy.png
-
-The URL will be replaced with something similar to the following (see `https://github.com/atmos/camo <https://github.com/atmos/camo>`__ for details):
-
-.. code-block:: text
-
-  https://image-proxy.mattermost.com/d7b4022717e8d015440cd70183b81196298b9453/687474703a2f2f692e726564642e69742f36636f687964636b6b363530312e6a7067
   
-Next, if you post a message with an image, you will get a proxied image in your post. This will ensure that every image
-is downloaded via HTTPS.


### PR DESCRIPTION
The current documentation has some awkward wording, particularly in the section for configuring the atmos/camo proxy, so hopefully this should clear up any confusing parts that have ended up in the documentation over time.

