### PR TITLE
Moving Push Proxy related entry to developer documentation

### DIFF
--- a/source/mobile/mobile-faq.rst
+++ b/source/mobile/mobile-faq.rst
@@ -148,24 +148,7 @@ How do I receive mobile push notification if my IT policy requires the use of a 
 
 When your IT policy requires a corporate proxy to scan and audit all outbound traffic the following options are available:
 
-1 - Deploy Mattermost in a proxy-aware configuration with a pre-proxy relay
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The Mattermost push notification service is designed to send traffic directly to the `Apple Push Notification Service (APNS) <https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1>`_ and `Google Fire Cloud Messaging (FCM) <https://firebase.google.com/docs/cloud-messaging>`_ services. 
-
-In a proxy-aware configuration, a `pre-proxy relay <https://docs.mattermost.com/overview/faq.html#what-are-pre-proxy-and-post-proxy-relays>`_ accepts messages from the `Mattermost Push Proxy <https://developers.mattermost.com/contribute/mobile/push-notifications/service/>`_ and forwards them to a corporate proxy enforcing your internal IT requirements, before transmitting to their final destination.
-
-See a sample architectural overview below: 
-
-.. image:: ../images/mobile-pre-proxy-relay.png
-
-This enables the **pre-proxy relay** to act as the `APNS <https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1>`_ and to forward the request to its final destination via your corporate proxy, not requiring the APNS traffic to be proxy-aware. The APNS traffic is redirected to the pre-proxy relay via ``/etc/hosts`` entry. The entry uses a trusted CA that signs a certificate for the Mattermost Push Proxy to trust the pre-proxy relay.
-
-Google's `FCM traffic <https://firebase.google.com/docs/cloud-messaging>`_ is proxy-aware via environment variables, so no actions are required for it. 
-
-Moreover, APNS traffic requires HTTP/2, so your corporate proxy server must support HTTP/2 requests in order to send the push notifications to Apple devices. HTTP/2 support for the pre-proxy relay is also required.
-
-2 - Deploy Mattermost with connection restricted post-proxy relay in DMZ or a trusted cloud environment
+1 - Deploy Mattermost with connection restricted post-proxy relay in DMZ or a trusted cloud environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some legacy corporate proxy configurations may be incompatible with the requirements of modern mobile architectures, such as the requirement of HTTP/2 requests from Apple to send push notifications to iOS devices.
@@ -178,7 +161,7 @@ In place of a DMZ you can also host in a trusted cloud environment such as AWS o
 
 .. image:: ../images/mobile-post-proxy-relay.png
 
-3 - Whitelist Mattermost push notification proxy to bypass your corporate proxy server
+2 - Whitelist Mattermost push notification proxy to bypass your corporate proxy server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Depending on your internal IT policy and approved waivers/exceptions, you may choose to deploy the `Mattermost Push Proxy <https://developers.mattermost.com/contribute/mobile/push-notifications/service/>`_ to connect directly to `Apple Push Notification Service (APNS) <https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1>`_ without your corporate proxy.
@@ -188,7 +171,7 @@ You will need to `whitelist one subdomain and one port from Apple <https://devel
  - Development server: ``api.development.push.apple.com:443``
  - Production server: ``api.push.apple.com:443``
 
-4 - Run App Store versions of the Mattermost mobile apps
+3 - Run App Store versions of the Mattermost mobile apps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use the mobile applications hosted by Mattermost in the `Apple App Store <https://apps.apple.com/ca/app/mattermost/id1257222717>`_ or `Google Play Store <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ and connect with :doc:`Mattermost Hosted Push Notification Service (HPNS) <mobile-hpns>` through your corporate proxy.

--- a/source/mobile/mobile-faq.rst
+++ b/source/mobile/mobile-faq.rst
@@ -143,41 +143,6 @@ First, you can use the :doc:`Mattermost Hosted Push Notification Service (HPNS) 
 2. deploy your own push notification service, or
 3. repackage the mobile apps with BlueCedar or AppDome, which some organizations have successfully deployed with but is not officially supported.
 
-How do I receive mobile push notification if my IT policy requires the use of a corporate proxy server?
---------------------------------------------------------------------------------------------------------------------
-
-When your IT policy requires a corporate proxy to scan and audit all outbound traffic the following options are available:
-
-1 - Deploy Mattermost with connection restricted post-proxy relay in DMZ or a trusted cloud environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Some legacy corporate proxy configurations may be incompatible with the requirements of modern mobile architectures, such as the requirement of HTTP/2 requests from Apple to send push notifications to iOS devices.
-
-In this case, a `post-proxy relay <https://docs.mattermost.com/overview/faq.html#what-are-pre-proxy-and-post-proxy-relays>`_ can be deployed to take messages from the Mattermost server passing through your corporate IT proxy in the incompatible format, e.g. HTTP/1.1, transform it to HTTP/2 and relay it to its final destination, either to the `Apple Push Notification Service (APNS) <https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1>`_ and `Google Fire Cloud Messaging (FCM) <https://firebase.google.com/docs/cloud-messaging>`_ services. 
-
-Ths **post-proxy relay** `can be configured using the Mattermost Push Proxy installation guide <https://developers.mattermost.com/contribute/mobile/push-notifications/service/>`_ with connection restrictions to meet your custom security and compliance requirements.
-
-In place of a DMZ you can also host in a trusted cloud environment such as AWS or Azure depending on your internal approvals and policies. 
-
-.. image:: ../images/mobile-post-proxy-relay.png
-
-2 - Whitelist Mattermost push notification proxy to bypass your corporate proxy server
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Depending on your internal IT policy and approved waivers/exceptions, you may choose to deploy the `Mattermost Push Proxy <https://developers.mattermost.com/contribute/mobile/push-notifications/service/>`_ to connect directly to `Apple Push Notification Service (APNS) <https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1>`_ without your corporate proxy.
-
-You will need to `whitelist one subdomain and one port from Apple <https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1>`_ for this option:
-
- - Development server: ``api.development.push.apple.com:443``
- - Production server: ``api.push.apple.com:443``
-
-3 - Run App Store versions of the Mattermost mobile apps
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can use the mobile applications hosted by Mattermost in the `Apple App Store <https://apps.apple.com/ca/app/mattermost/id1257222717>`_ or `Google Play Store <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ and connect with :doc:`Mattermost Hosted Push Notification Service (HPNS) <mobile-hpns>` through your corporate proxy.
-
-The use of hosted applications by Mattermost :doc:`can be deployed with Enterprise Mobility Management solutions via AppConfig <mobile-appconfig>` but do not support wrapping.
-
 How do I white label the app and customize build settings?
 ----------------------------------------------------------
 

--- a/source/mobile/mobile-faq.rst
+++ b/source/mobile/mobile-faq.rst
@@ -143,6 +143,11 @@ First, you can use the :doc:`Mattermost Hosted Push Notification Service (HPNS) 
 2. deploy your own push notification service, or
 3. repackage the mobile apps with BlueCedar or AppDome, which some organizations have successfully deployed with but is not officially supported.
 
+How do I receive mobile push notification if my IT policy requires the use of a corporate proxy server?
+-------------------------------------------------------------------------------------------------------
+
+See our `developer documentation about Push Notification Service with Corporate Proxy <https://developers.mattermost.com/contribute/mobile/push-notifications/corporate-proxy>`_.
+
 How do I white label the app and customize build settings?
 ----------------------------------------------------------
 

--- a/source/overview/faq.rst
+++ b/source/overview/faq.rst
@@ -435,14 +435,6 @@ The following chart highlights the end user features of Mattermost and their sup
 * X - Full Support
 * O - Partial support
 
-..  _pre-post-proxy:
-What are pre-proxy and post-proxy relays?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A pre-proxy relay accepts network traffic from a source and forwards it to a corporate proxy such as NGINX. The corporate proxy then transmits the traffic to the final destination.
-
-A post-proxy relay accepts network traffic from a corporate proxy such as NGINX, and transmits it to the final destination.
-
 High Trust Questions
 ----------------------
 


### PR DESCRIPTION
#### Summary
Moving the section `How do I receive mobile push notification if my IT policy requires the use of a corporate proxy server?` from the docs FAQ to `https://developers.mattermost.com/contribute/mobile/push-notifications/service/` and removing the untested `Deploy Mattermost in a proxy-aware configuration with a pre-proxy relay` section completly

#### Ticket Link
This has no ticket # as it was an internal decision.

