### PR TITLE
Update FAQ on video, audio and screenshare

### DIFF
--- a/source/overview/faq.rst
+++ b/source/overview/faq.rst
@@ -118,12 +118,9 @@ Video, Audio, and Screen Sharing
 What support is available for video and audio calling and screen sharing?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following open-source options are available:
+Our `Integrations Directory <https://integrations.mattermost.com>`_ has several integrations to connect by voice or video call, or to share your screen with team members in Mattermost.
 
-1. `Zoom plugin <https://docs.mattermost.com/integrations/zoom.html>`__ enables users to start and join voice, video and screensharing meetings using either Zoom’s self-hosted private cloud or on-prem solutions, or its vendor-hosted SaaS solution. The plugin is installed by default on all Mattermost servers.
-2. `BigBlueButton plugin <https://github.com/blindsidenetworks/mattermost-plugin-bigbluebutton>`__ for one-on-one video and audio calling, video conferencing and screenshare, created by Blindside Networks, available in Beta. A test install is provided to try out the feature on a Mattermost install. For production use, you can self-host a server running BigBlueButton, or reach out to Blindside Networks about hosting it for you.
-
-Support for other third-party video, audio, and screensharing solutions via plugins is planned. A plugin for WebEx is currently in development by the Mattermost community, with updates posted in the `WebEx Plugin community channel <https://community.mattermost.com/core/channels/webex-plugin>`__.
+For the most popular options, including self-hosted on-prem, self-hosted private cloud solutions, and vendor-hosted SaaS solutions, :doc:`learn more in our admin guide <video-and-audio-calling>`
 
 Note that you can also neatly link video, audio and screensharing solutions, like Zoom and Skype for Business, to channels by using markdown formatting in the channel header. Example: ``[Click for video call](https://link_to_solution)``.
 

--- a/source/overview/faq.rst
+++ b/source/overview/faq.rst
@@ -120,7 +120,7 @@ What support is available for video and audio calling and screen sharing?
 
 Our `Integrations Directory <https://integrations.mattermost.com>`_ has several integrations to connect by voice or video call, or to share your screen with team members in Mattermost.
 
-For the most popular options, including self-hosted on-prem, self-hosted private cloud solutions, and vendor-hosted SaaS solutions, :doc:`learn more in our admin guide <video-and-audio-calling>`
+For the most popular options, including self-hosted on-prem, self-hosted private cloud solutions, and vendor-hosted SaaS solutions, :doc:`learn more in our admin guide <video-and-audio-calling>`.
 
 Note that you can also neatly link video, audio and screensharing solutions, like Zoom and Skype for Business, to channels by using markdown formatting in the channel header. Example: ``[Click for video call](https://link_to_solution)``.
 


### PR DESCRIPTION
Sales team (via Philip) gave a heads up that this FAQ is outdated - linking to the admin page which has a summary of available integrations/plugins for video, audio and screenshare