### PR TITLE
Correct Code Block Formatting for Transport Encryption (closes #3456)

### DIFF
--- a/source/install/transport-encryption/config-mattermost.rst
+++ b/source/install/transport-encryption/config-mattermost.rst
@@ -56,7 +56,7 @@ Once complete, open the file ``config.json`` and modify the values ``ConnectionS
 
 **Before**
 
-.. codeblock:: none
+.. code-block:: json
 
   {
       "ServiceSettings": {
@@ -67,10 +67,15 @@ Once complete, open the file ``config.json`` and modify the values ``ConnectionS
           "ConnectionSecurity": "",
           "TLSCertFile": "",
           "TLSKeyFile": "",
+          "...":"..."
+      },
+      "...":"..."
+  }
+
 
 **After**
 
-.. codeblock:: none
+.. code-block:: json
 
   {
       "ServiceSettings": {
@@ -83,6 +88,8 @@ Once complete, open the file ``config.json`` and modify the values ``ConnectionS
           "TLSKeyFile": "/opt/mattermost/config/key.pem",
           "...":"..."
       },
+      "...":"..."
+  }
 
 
 Restart the Mattermost server and ensure it's up and running:


### PR DESCRIPTION
#### Summary
This fixes the not working code block formatting on the Mattermost config page for transport encryption.

#### Ticket Link
https://github.com/mattermost/docs/issues/3456
