### PR TITLE
Documenting how to change the default docker-compose network

### DIFF
--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -44,6 +44,18 @@ Production Docker Setup on Ubuntu
        sudo chown -R 2000:2000 ./volumes/app/mattermost/
        docker-compose up -d
 
+   The docker-compose network that is created by the above steps defaults to 172.18.0.0/16.  If you need to change the default network this `link <https://success.docker.com/article/how-do-i-configure-the-default-bridge-docker0-network-for-docker-engine-to-a-different-subnet>`__ provides guidelines on how to do that.  If the network is already set up with the above default, you need to run the following command to remove it, so that the a subsequent run will generate it again with the new network setting.
+   
+   .. code:: bash
+ 
+       docker network rm mattermost-server_mm-test
+	   
+   To verify the current docker network use the following command to list it (check out the options `here <https://docs.docker.com/engine/reference/commandline/network_ls/>`__):
+   
+   .. code:: bash
+   
+       docker network ls [OPTIONS]
+
 4. **Configure TLS** by following `the instructions <https://github.com/mattermost/mattermost-docker#install-with-ssl-certificate>`__.
 
 5. **Configure Email** by following the `SMTP email setup guide <http://docs.mattermost.com/install/smtp-email-setup.html>`__.

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -50,7 +50,7 @@ The ``docker-compose`` network that is created defaults to 172.18.0.0/16.  If yo
  
        docker network rm mattermost-server_mm-test
 	   
-   To verify the current docker network use the following command to list it (check out the options `here <https://docs.docker.com/engine/reference/commandline/network_ls/>`__):
+To verify the current Docker network use the following command to list it (you can access information about the options `here <https://docs.docker.com/engine/reference/commandline/network_ls/>`__):
    
    .. code:: bash
    

--- a/source/install/prod-docker.rst
+++ b/source/install/prod-docker.rst
@@ -44,7 +44,7 @@ Production Docker Setup on Ubuntu
        sudo chown -R 2000:2000 ./volumes/app/mattermost/
        docker-compose up -d
 
-   The docker-compose network that is created by the above steps defaults to 172.18.0.0/16.  If you need to change the default network this `link <https://success.docker.com/article/how-do-i-configure-the-default-bridge-docker0-network-for-docker-engine-to-a-different-subnet>`__ provides guidelines on how to do that.  If the network is already set up with the above default, you need to run the following command to remove it, so that the a subsequent run will generate it again with the new network setting.
+The ``docker-compose`` network that is created defaults to 172.18.0.0/16.  If you need to change the default network this `link <https://success.docker.com/article/how-do-i-configure-the-default-bridge-docker0-network-for-docker-engine-to-a-different-subnet>`__ provides guidelines on how to do that. If the network is already set up with the default, you need to run the following command to remove it. Then, run the command again to regenerate the default network to include the new network setting.
    
    .. code:: bash
  


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Addresses the following issue: Request for Documentation: Docker bridge network can interfere with the Mattermost VPN and DNS resolution for internal.mattermost.com (172.18.0.0/16) #459.

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-developer-documentation/issues/459

