### PR TITLE
Remove Oracle from Bitnami packages

### DIFF
--- a/source/install/deploy-bitnami.rst
+++ b/source/install/deploy-bitnami.rst
@@ -11,6 +11,6 @@ Deployment options include:
 - `Microsoft Azure <https://about.mattermost.com/deploy-azure>`__
 - `Google Cloud Platform <https://about.mattermost.com/deploy-googlecloud>`__
 
-Alternatively, you may also deploy to `Debian 8 VMware or Oracle VirtualBox virtual machines <https://about.mattermost.com/deploy-debianvirtualmachine>`__.
+Alternatively, you may also deploy to `Debian 8 VMware virtual machines <https://about.mattermost.com/deploy-debianvirtualmachine>`__.
 
 If you migrate from Bitnami to a self-hosted installation with MySQL database, read these notes in our migration guide: `Migrating from Bitnami <../administration/migrating.html#migrating-from-bitnami>`__

--- a/source/install/deploy-bitnami.rst
+++ b/source/install/deploy-bitnami.rst
@@ -11,6 +11,6 @@ Deployment options include:
 - `Microsoft Azure <https://about.mattermost.com/deploy-azure>`__
 - `Google Cloud Platform <https://about.mattermost.com/deploy-googlecloud>`__
 
-Alternatively, you may also deploy to `Debian 8 VMware virtual machines <https://about.mattermost.com/deploy-debianvirtualmachine>`__.
+Alternatively, you may also deploy to `Debian 9 VMware virtual machines <https://about.mattermost.com/deploy-debianvirtualmachine>`__.
 
 If you migrate from Bitnami to a self-hosted installation with MySQL database, read these notes in our migration guide: `Migrating from Bitnami <../administration/migrating.html#migrating-from-bitnami>`__

--- a/source/install/deploy-bitnami.rst
+++ b/source/install/deploy-bitnami.rst
@@ -8,7 +8,6 @@ Deploy your Mattermost Team Edition server in the cloud with one simple click us
 Deployment options include:
 
 - `Amazon Web Services <https://about.mattermost.com/deploy-aws>`__
-- `Oracle Cloud Platform <https://about.mattermost.com/deploy-oraclecloud>`__
 - `Microsoft Azure <https://about.mattermost.com/deploy-azure>`__
 - `Google Cloud Platform <https://about.mattermost.com/deploy-googlecloud>`__
 


### PR DESCRIPTION
 - Remove the Oracle mention since Bitnami no longer offers their images on Oracle 
 - Change " you may also deploy to Debian 8 VMware or Oracle VirtualBox virtual machines." to " you may also deploy to Debian 9 VMware virtual machines". 