### PR TITLE
Add link to mattermost.com/contribute in community overview page

### DIFF
--- a/source/process/community-overview.rst
+++ b/source/process/community-overview.rst
@@ -6,11 +6,11 @@ At Mattermost, we be believe workplace messaging will become a leading platform 
 
 We consider people who share these beliefs, and who seek to benefit from or influence the Mattermost open source project, to be part of the "Mattermost Community". 
 
-The success of Mattermost as an open source platform for messaging-based workflow and business process depends on empowering our community to build with us towards a shared vision. 
+The success of Mattermost as an open source platform for messaging-based workflow and business process depends on empowering our community to build with us towards a shared vision.
+
+The Mattermost community has two parts, Users and Contributors, detailed below.
 
 .. tip :: 
-  The Mattermost community has two parts, Users and Contributors, detailed below.
-  
   Interested to contribute to Mattermost? `Learn about all the ways to get involved with our community <https://mattermost.com/contribute/>`_.
 
 .. contents::

--- a/source/process/community-overview.rst
+++ b/source/process/community-overview.rst
@@ -11,7 +11,7 @@ The success of Mattermost as an open source platform for messaging-based workflo
 The Mattermost community has two parts, Users and Contributors, detailed below.
 
 .. tip :: 
-  Interested to contribute to Mattermost? `Learn about all the ways to get involved with our community <https://mattermost.com/contribute/>`_.
+  Interested in contributing to Mattermost? `Learn about all the ways to get involved with our community <https://mattermost.com/contribute/>`_.
 
 .. contents::
   :backlinks: top

--- a/source/process/community-overview.rst
+++ b/source/process/community-overview.rst
@@ -8,7 +8,10 @@ We consider people who share these beliefs, and who seek to benefit from or infl
 
 The success of Mattermost as an open source platform for messaging-based workflow and business process depends on empowering our community to build with us towards a shared vision. 
 
-The Mattermost community has two parts, Users and Contributors, detailed below. 
+.. tip :: 
+  The Mattermost community has two parts, Users and Contributors, detailed below.
+  
+  Interested to contribute to Mattermost? `Learn about all the ways to get involved with our community <https://mattermost.com/contribute/>`_.
 
 .. contents::
   :backlinks: top


### PR DESCRIPTION
We get 100+ page views a month, adding (+ highlighting) a link to https://mattermost.com/contribute/.

Intent is to make it easier for people to get started and getting involved with our community.

