### PR TITLE
Update bulk-export-data.rst with post prop information

### DIFF
--- a/source/administration/bulk-export-data.rst
+++ b/source/administration/bulk-export-data.rst
@@ -489,14 +489,14 @@ Post object
       <td>The message that the post contains.</td>
     </tr>
     <tr class="row-odd">
-      <td valign="middle">create_at</td>
-      <td valign="middle">int</td>
-      <td>The timestamp for the post, in milliseconds since the Unix epoch.</td>
-    </tr>
-    <tr class="row-odd">
       <td valign="middle">props</td>
       <td valign="middle">object</td>
       <td>The props for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://docs.mattermost.com/developer/message-attachments.html">message attachments documentation</a>.</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">create_at</td>
+      <td valign="middle">int</td>
+      <td>The timestamp for the post, in milliseconds since the Unix epoch.</td>
     </tr>
     <tr class="row-odd">
       <td valign="middle">reactions</td>

--- a/source/administration/bulk-export-data.rst
+++ b/source/administration/bulk-export-data.rst
@@ -493,7 +493,12 @@ Post object
       <td valign="middle">int</td>
       <td>The timestamp for the post, in milliseconds since the Unix epoch.</td>
     </tr>
-        <tr class="row-odd">
+    <tr class="row-odd">
+      <td valign="middle">props</td>
+      <td valign="middle">string</td>
+      <td>The props or attachments for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://docs.mattermost.com/developer/message-attachments.html">message attachments documentation</a>.</td>
+    </tr>
+    <tr class="row-odd">
       <td valign="middle">reactions</td>
       <td valign="middle">array</td>
       <td>The emoji reactions to this post. Will be an array of Reaction objects.</td>

--- a/source/administration/bulk-export-data.rst
+++ b/source/administration/bulk-export-data.rst
@@ -495,8 +495,8 @@ Post object
     </tr>
     <tr class="row-odd">
       <td valign="middle">props</td>
-      <td valign="middle">string</td>
-      <td>The props or attachments for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://docs.mattermost.com/developer/message-attachments.html">message attachments documentation</a>.</td>
+      <td valign="middle">object</td>
+      <td>The props for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://docs.mattermost.com/developer/message-attachments.html">message attachments documentation</a>.</td>
     </tr>
     <tr class="row-odd">
       <td valign="middle">reactions</td>

--- a/source/deployment/bulk-loading-data-format.rst
+++ b/source/deployment/bulk-loading-data-format.rst
@@ -1062,6 +1062,12 @@ For clarity, the object is shown using regular JSON formatting, but in the data 
       "channel": "channel-name",
       "user": "username",
       "message": "The post message",
+      "props": {
+        "attachments": [{
+          "pretext": "This is the attachment pretext.",
+          "text": "This is the attachment text."
+        }]
+      },
       "create_at": 140012340013,
       "flagged_by": [
         "username1",
@@ -1144,6 +1150,13 @@ Fields of the Post object
       <td valign="middle">message</td>
       <td valign="middle">string</td>
       <td>The message that the post contains.</td>
+      <td align="center" valign="middle">Yes</td>
+      <td align="center" valign="middle">Yes</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">props</td>
+      <td valign="middle">object</td>
+      <td>The props for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://docs.mattermost.com/developer/message-attachments.html">message attachments documentation</a>.</td>
       <td align="center" valign="middle">Yes</td>
       <td align="center" valign="middle">Yes</td>
     </tr>


### PR DESCRIPTION
This PR updates the table for the post object with info on the new props attribute introduced in v5.22.

Related Issue: #3472 

PR for bulk exporter changes: https://github.com/mattermost/mattermost-server/pull/14034