### PR TITLE
Fix mattermost binary paths and binary directory

### DIFF
--- a/source/administration/bulk-export.rst
+++ b/source/administration/bulk-export.rst
@@ -28,12 +28,12 @@ The export command runs in the `CLI <https://docs.mattermost.com/administration/
 
 To run the export command: 
 
-1.  Navigate to the directory where the Mattermost server is installed. On a default install of Mattermost, the directory is ``/opt/mattermost/bin``.
+1.  Navigate to the directory where the Mattermost server is installed. On a default install of Mattermost, the directory is ``/opt/mattermost``.
 2.  Run the following command to extract data from all teams on the server. Note that you can change the file name and specify an absolute or relative path to dictate where the file is exported. 
   
-  ``sudo ./mattermost export bulk file.json --all-teams``
+  ``sudo -u mattermost bin/mattermost export bulk file.json --all-teams``
 
-  ``sudo ./mattermost export bulk /home/user/bulk_data.json --all-teams``
+  ``sudo -u mattermost bin/mattermost export bulk /home/user/bulk_data.json --all-teams``
   
 3.  Retrieve your file from the location you specified.  
 

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -192,8 +192,8 @@ Description
  Examples
    .. code-block:: none
 
-      ./mattermost channel add 8soyabwthjnf9qibfztje5a36h user@example.com username
-      ./mattermost channel add myteam:mychannel user@example.com username
+      bin/mattermost channel add 8soyabwthjnf9qibfztje5a36h user@example.com username
+      bin/mattermost channel add myteam:mychannel user@example.com username
 
 mattermost channel archive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -214,8 +214,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost channel archive 8soyabwthjnf9qibfztje5a36h
-      ./mattermost channel archive myteam:mychannel
+      bin/mattermost channel archive 8soyabwthjnf9qibfztje5a36h
+      bin/mattermost channel archive myteam:mychannel
 
 mattermost channel create
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -236,8 +236,8 @@ Description
  Examples
    .. code-block:: none
 
-      ./mattermost channel create --team myteam --name mynewchannel --display_name "My New Channel"
-      ./mattermost channel create --team myteam --name mynewprivatechannel --display_name "My New Private Channel" --private
+      bin/mattermost channel create --team myteam --name mynewchannel --display_name "My New Channel"
+      bin/mattermost channel create --team myteam --name mynewprivatechannel --display_name "My New Private Channel" --private
 
  Options
    .. code-block:: none
@@ -263,8 +263,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost channel delete 8soyabwthjnf9qibfztje5a36h
-      ./mattermost channel delete myteam:mychannel
+      bin/mattermost channel delete 8soyabwthjnf9qibfztje5a36h
+      bin/mattermost channel delete myteam:mychannel
 
 mattermost channel list
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -285,7 +285,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost channel list myteam
+      bin/mattermost channel list myteam
 
 mattermost channel modify
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -301,7 +301,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost channel modify myteam:mychannel --username myusername --private
+      bin/mattermost channel modify myteam:mychannel --username myusername --private
 
   Options
     .. code-block:: none
@@ -328,8 +328,8 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost channel move newteam 8soyabwthjnf9qibfztje5a36h --username myusername
-      ./mattermost channel move newteam myteam:mychannel --username myusername
+      bin/mattermost channel move newteam 8soyabwthjnf9qibfztje5a36h --username myusername
+      bin/mattermost channel move newteam myteam:mychannel --username myusername
 
   Options
     .. code-block:: none
@@ -355,9 +355,9 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost channel remove 8soyabwthjnf9qibfztje5a36h user@example.com username
-      ./mattermost channel remove myteam:mychannel user@example.com username
-      ./mattermost channel remove myteam:mychannel --all-users
+      bin/mattermost channel remove 8soyabwthjnf9qibfztje5a36h user@example.com username
+      bin/mattermost channel remove myteam:mychannel user@example.com username
+      bin/mattermost channel remove myteam:mychannel --all-users
 
   Options
     .. code-block:: none
@@ -382,8 +382,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost channel rename 8soyabwthjnf9qibfztje5a36h newchannelname --display_name "New Display Name"
-      ./mattermost channel rename myteam:mychannel newchannelname --display_name "New Display Name"
+      bin/mattermost channel rename 8soyabwthjnf9qibfztje5a36h newchannelname --display_name "New Display Name"
+      bin/mattermost channel rename myteam:mychannel newchannelname --display_name "New Display Name"
 
   Options
     .. code-block:: none
@@ -408,8 +408,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost channel restore 8soyabwthjnf9qibfztje5a36h
-      ./mattermost channel restore myteam:mychannel
+      bin/mattermost channel restore 8soyabwthjnf9qibfztje5a36h
+      bin/mattermost channel restore myteam:mychannel
 
 mattermost channel search
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -429,9 +429,9 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost channel search mychannel
-      ./mattermost channel search --team myteam mychannel
-      ./mattermost channel search --team f1924a8db44ff3bb41c96424cdc20676 mychannel
+      bin/mattermost channel search mychannel
+      bin/mattermost channel search --team myteam mychannel
+      bin/mattermost channel search --team f1924a8db44ff3bb41c96424cdc20676 mychannel
 
   Options
     .. code-block:: none
@@ -470,7 +470,7 @@ Description
   Examples
     .. code-block:: none
 
-       ./mattermost command create myteam --title MyCommand --description "My Command Description" --trigger-word mycommand --url http://localhost:8000/my-slash-handler --creator myusername --response-username my-bot-username --icon http://localhost:8000/my-slash-handler-bot-icon.png --autocomplete --post
+       bin/mattermost command create myteam --title MyCommand --description "My Command Description" --trigger-word mycommand --url http://localhost:8000/my-slash-handler --creator myusername --response-username my-bot-username --icon http://localhost:8000/my-slash-handler-bot-icon.png --autocomplete --post
 
   Options
     .. code-block:: none
@@ -505,7 +505,7 @@ Description
   Examples
     .. code-block:: none
 
-       ./mattermost command delete commandID
+       bin/mattermost command delete commandID
 
 mattermost command list
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -526,7 +526,7 @@ Description
   Examples
     .. code-block:: none
 
-       ./mattermost command list myteam
+       bin/mattermost command list myteam
 
 mattermost command modify
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -546,7 +546,7 @@ mattermost command modify
   Examples
     .. code-block:: none
 
-       ./mattermost command modify commandID --title MyModifiedCommand --description "My Modified Command Description" --trigger-word mycommand --url http://localhost:8000/my-slash-handler --creator myusername --response-username my-bot-username --icon http://localhost:8000/my-slash-handler-bot-icon.png --autocomplete --post
+       bin/mattermost command modify commandID --title MyModifiedCommand --description "My Modified Command Description" --trigger-word mycommand --url http://localhost:8000/my-slash-handler --creator myusername --response-username my-bot-username --icon http://localhost:8000/my-slash-handler-bot-icon.png --autocomplete --post
 
   Options
     .. code-block:: none
@@ -577,8 +577,8 @@ mattermost command move
   Examples
     .. code-block:: none
 
-      ./mattermost command move newteam oldteam:command-trigger-word
-      ./mattermost command move newteam o8soyabwthjnf9qibfztje5a36h
+      bin/mattermost command move newteam oldteam:command-trigger-word
+      bin/mattermost command move newteam o8soyabwthjnf9qibfztje5a36h
 
 mattermost command show
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -594,7 +594,7 @@ mattermost command show
   Examples
     .. code-block:: none
 
-      ./mattermost command show commandID
+      bin/mattermost command show commandID
 
 mattermost config
 -----------------
@@ -628,7 +628,7 @@ Description
   Examples
     .. code-block:: none
 
-       ./mattermost config get SqlSettings.DriverName
+       bin/mattermost config get SqlSettings.DriverName
 
  Options
     .. code-block:: none
@@ -652,7 +652,7 @@ mattermost config migrate
   Examples
     .. code-block:: none
 
-       ./mattermost config migrate  path/to/config.json "postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+       bin/mattermost config migrate  path/to/config.json "postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
        
 mattermost config reset
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -668,7 +668,7 @@ mattermost config reset
   Examples
     .. code-block:: none
 
-       ./mattermost config reset SqlSettings.DriverName LogSettings
+       bin/mattermost config reset SqlSettings.DriverName LogSettings
        
    Options
     .. code-block:: none
@@ -689,7 +689,7 @@ mattermost config set
   Examples
     .. code-block:: none
 
-       ./mattermost config set SqlSettings.DriverName mysql
+       bin/mattermost config set SqlSettings.DriverName mysql
 
  Options
     .. code-block:: none
@@ -714,7 +714,7 @@ Description
   Examples
     .. code-block:: none
 
-       ./mattermost config show
+       bin/mattermost config show
 
 mattermost config validate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -734,7 +734,7 @@ mattermost config validate
     Example
       .. code-block:: none
 
-        ./mattermost config validate
+        bin/mattermost config validate
 
 mattermost export
 -----------------
@@ -763,7 +763,7 @@ mattermost export actiance
   Example
     .. code-block:: none
 
-      ./mattermost export actiance --exportFrom=1513102632
+      bin/mattermost export actiance --exportFrom=1513102632
 
   Options
     .. code-block:: none
@@ -784,7 +784,7 @@ mattermost export bulk
   Example
     .. code-block:: none
 
-      ./mattermost export bulk file.json --all-teams
+      bin/mattermost export bulk file.json --all-teams
 
   Options
     .. code-block:: none
@@ -805,7 +805,7 @@ mattermost export csv
   Example
     .. code-block:: none
 
-      ./mattermost export csv --exportFrom=1513102632
+      bin/mattermost export csv --exportFrom=1513102632
 
   Options
     .. code-block:: none
@@ -826,7 +826,7 @@ mattermost export global-relay-zip
   Example
     .. code-block:: none
 
-      ./mattermost export global-relay-zip --exportFrom=1513102632
+      bin/mattermost export global-relay-zip --exportFrom=1513102632
 
   Options
     .. code-block:: none
@@ -847,7 +847,7 @@ mattermost export schedule
   Example
     .. code-block:: none
 
-      ./mattermost export schedule --format=actiance --exportFrom=1513102632
+      bin/mattermost export schedule --format=actiance --exportFrom=1513102632
 
   Options
     .. code-block:: none
@@ -904,7 +904,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group channel enable myteam:mychannel
+      bin/mattermost group channel enable myteam:mychannel
 
 mattermost group channel disable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -924,7 +924,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group channel disable myteam:mychannel
+      bin/mattermost group channel disable myteam:mychannel
 
 mattermost group channel list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -944,7 +944,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group channel list myteam:mychannel
+      bin/mattermost group channel list myteam:mychannel
 
 
 mattermost group channel status
@@ -965,7 +965,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group channel status myteam:mychannel
+      bin/mattermost group channel status myteam:mychannel
 
 mattermost group team
 ------------------------
@@ -1004,7 +1004,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group team enable myteam
+      bin/mattermost group team enable myteam
 
 mattermost group team disable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1024,7 +1024,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group team disable myteam
+      bin/mattermost group team disable myteam
 
 mattermost group team list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1044,7 +1044,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group team list myteam
+      bin/mattermost group team list myteam
 
 
 mattermost group team status
@@ -1065,7 +1065,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost group team status myteam
+      bin/mattermost group team status myteam
 
 mattermost help
 ---------------
@@ -1109,7 +1109,7 @@ mattermost import bulk
   Example
     .. code-block:: none
 
-      ./mattermost import bulk bulk-file.jsonl
+      bin/mattermost import bulk bulk-file.jsonl
 
 mattermost import slack
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1125,7 +1125,7 @@ mattermost import slack
   Example
     .. code-block:: none
 
-      ./mattermost import slack myteam slack_export.zip
+      bin/mattermost import slack myteam slack_export.zip
 
 mattermost integrity
 --------------------
@@ -1141,7 +1141,7 @@ mattermost integrity
   Example
     .. code-block:: none
 
-      ./mattermost integrity --confirm --verbose
+      bin/mattermost integrity --confirm --verbose
 
   Options
     .. code-block:: none
@@ -1166,7 +1166,7 @@ mattermost jobserver
   Example
     .. code-block:: none
 
-      ./mattermost jobserver
+      bin/mattermost jobserver
 
 mattermost ldap
 ---------------
@@ -1199,7 +1199,7 @@ mattermost ldap idmigrate
   Example
     .. code-block:: none
 
-      ./mattermost ldap idmigrate objectGUID
+      bin/mattermost ldap idmigrate objectGUID
 
 mattermost ldap sync
 ~~~~~~~~~~~~~~~~~~~~
@@ -1219,7 +1219,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost ldap sync
+      bin/mattermost ldap sync
 
 mattermost license
 ------------------
@@ -1248,7 +1248,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost license upload /path/to/license/mylicensefile.mattermost-license
+      bin/mattermost license upload /path/to/license/mylicensefile.mattermost-license
 
 .. note::
   The Mattermost server needs to be restarted after uploading a license file for any changes to take effect. Also, for cluster setups the license file needs to be uploaded to every node.
@@ -1271,7 +1271,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost logs --logrus
+      bin/mattermost logs --logrus
 
   Options
     .. code-block:: none
@@ -1307,7 +1307,7 @@ mattermost permissions export
   Example
     .. code-block:: none
 
-      ./mattermost permissions export > my-permissions-export.jsonl
+      bin/mattermost permissions export > my-permissions-export.jsonl
 
 mattermost permissions import
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1324,7 +1324,7 @@ mattermost permissions import
   Example
     .. code-block:: none
 
-      ./mattermost permissions import my-permissions-export.jsonl
+      bin/mattermost permissions import my-permissions-export.jsonl
 
 mattermost permissions reset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1341,7 +1341,7 @@ mattermost permissions reset
   Example
     .. code-block:: none
 
-      ./mattermost permissions reset
+      bin/mattermost permissions reset
 
   Options
     .. code-block:: none
@@ -1379,7 +1379,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost plugin add hovercardexample.tar.gz pluginexample.tar.gz
+      bin/mattermost plugin add hovercardexample.tar.gz pluginexample.tar.gz
 
 mattermost plugin delete
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1399,7 +1399,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost plugin delete hovercardexample pluginexample
+      bin/mattermost plugin delete hovercardexample pluginexample
 
 mattermost plugin disable
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1419,7 +1419,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost plugin disable hovercardexample pluginexample
+      bin/mattermost plugin disable hovercardexample pluginexample
 
 mattermost plugin enable
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1439,7 +1439,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost plugin enable hovercardexample pluginexample
+      bin/mattermost plugin enable hovercardexample pluginexample
 
 mattermost plugin list
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1459,7 +1459,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost plugin list
+      bin/mattermost plugin list
 
 mattermost reset
 ----------------
@@ -1501,7 +1501,7 @@ mattermost roles member
   Example
     .. code-block:: none
 
-      ./mattermost roles member user1
+      bin/mattermost roles member user1
 
 mattermost roles system\_admin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1517,7 +1517,7 @@ mattermost roles system\_admin
   Example
     .. code-block:: none
 
-      ./mattermost roles system_admin user1
+      bin/mattermost roles system_admin user1
 
 mattermost sampledata
 ---------------------
@@ -1536,7 +1536,7 @@ mattermost sampledata
   Example
     .. code-block:: none
 
-      ./mattermost sampledata --seed 10 --teams 4 --users 30
+      bin/mattermost sampledata --seed 10 --teams 4 --users 30
 
   Options
     .. code-block:: none
@@ -1614,7 +1614,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost team add myteam user@example.com username
+      bin/mattermost team add myteam user@example.com username
 
 mattermost team archive
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1635,7 +1635,7 @@ Description
   Examples
     .. code-block:: none
 
-       ./mattermost team archive team1
+       bin/mattermost team archive team1
 
 mattermost team create
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1655,8 +1655,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost team create --name mynewteam --display_name "My New Team"
-      ./mattermost teams create --name private --display_name "My New Private Team" --private
+      bin/mattermost team create --name mynewteam --display_name "My New Team"
+      bin/mattermost teams create --name private --display_name "My New Private Team" --private
 
   Options
     .. code-block:: none
@@ -1684,7 +1684,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost team delete myteam
+      bin/mattermost team delete myteam
 
   Options
     .. code-block:: none
@@ -1711,7 +1711,7 @@ mattermost team list
   Example
     .. code-block:: none
 
-      ./mattermost team list
+      bin/mattermost team list
 
 mattermost team modify
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1727,8 +1727,8 @@ mattermost team modify
   Example
     .. code-block:: none
 
-      ./mattermost team myteam --private
-      ./mattermost team myteam --public
+      bin/mattermost team myteam --private
+      bin/mattermost team myteam --public
 
 mattermost team remove
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1748,7 +1748,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost team remove myteam user@example.com username
+      bin/mattermost team remove myteam user@example.com username
 
 mattermost team rename
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1768,7 +1768,7 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost team rename myteam newteamname --display_name "New Display Name"
+      bin/mattermost team rename myteam newteamname --display_name "New Display Name"
 
   Options
     .. code-block:: none
@@ -1789,7 +1789,7 @@ mattermost team restore
   Example
     .. code-block:: none
 
-      ./mattermost team restore myteam
+      bin/mattermost team restore myteam
 
 mattermost team search
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1809,7 +1809,7 @@ Description
   Examples
     .. code-block:: none
 
-       ./mattermost team search team1
+       bin/mattermost team search team1
 
 mattermost user
 ---------------
@@ -1853,8 +1853,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost user activate user@example.com
-      ./mattermost user activate username1 username2
+      bin/mattermost user activate user@example.com
+      bin/mattermost user activate username1 username2
 
 mattermost user convert
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1872,9 +1872,9 @@ mattermost user convert
   Examples
     .. code-block:: none
 
-      ./mattermost user convert user@example.com --bot
-      ./mattermost user convert username1 username2 --bot
-      ./mattermost user convert old_bot --user --email real_user@example.com --password Password1
+      bin/mattermost user convert user@example.com --bot
+      bin/mattermost user convert username1 username2 --bot
+      bin/mattermost user convert old_bot --user --email real_user@example.com --password Password1
 
 
   Options
@@ -1902,8 +1902,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost user create --email user@example.com --username userexample --password Password1
-      ./mattermost user create --firstname Joe --system_admin --email joe@example.com --username joe --password Password1
+      bin/mattermost user create --email user@example.com --username userexample --password Password1
+      bin/mattermost user create --firstname Joe --system_admin --email joe@example.com --username joe --password Password1
 
   Options
     .. code-block:: none
@@ -1935,8 +1935,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost user deactivate user@example.com
-      ./mattermost user deactivate username
+      bin/mattermost user deactivate user@example.com
+      bin/mattermost user deactivate username
 
   .. note::
     Users deactivated via this CLI command can continue to use Mattermost, if they are already logged in, until the user cache is manually purged or automatically after 30 minutes. Users who are deactivated when they're not logged in will not be able to log in to Mattermost again.
@@ -1961,7 +1961,7 @@ mattermost user delete
   Example
     .. code-block:: none
 
-      ./mattermost user delete user@example.com
+      bin/mattermost user delete user@example.com
 
   Options
     .. code-block:: none
@@ -1984,7 +1984,7 @@ mattermost user deleteall
   Example
     .. code-block:: none
 
-      ./mattermost user deleteall
+      bin/mattermost user deleteall
 
   Options
     .. code-block:: none
@@ -2010,7 +2010,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost user email user@example.com newuser@example.com
+      bin/mattermost user email user@example.com newuser@example.com
 
 mattermost user invite
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -2031,8 +2031,8 @@ Description
   Examples
     .. code-block:: none
 
-      ./mattermost user invite user@example.com myteam
-      ./mattermost user invite user@example.com myteam1 myteam2
+      bin/mattermost user invite user@example.com myteam
+      bin/mattermost user invite user@example.com myteam1 myteam2
 
 mattermost user migrate_auth
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2059,7 +2059,7 @@ mattermost user migrate_auth
   Example
     .. code-block:: none
 
-      ./mattermost user migrate_auth email ldap email
+      bin/mattermost user migrate_auth email ldap email
   Options
     .. code-block:: none
 
@@ -2186,7 +2186,7 @@ mattermost user migrate_auth
   Example
     .. code-block:: none
 
-      ./mattermost user migrate_auth email saml users.json
+      bin/mattermost user migrate_auth email saml users.json
 
   Options
     .. code-block:: none
@@ -2213,7 +2213,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost user password user@example.com Password1
+      bin/mattermost user password user@example.com Password1
 
 mattermost user resetmfa
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2234,7 +2234,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost user resetmfa user@example.com
+      bin/mattermost user resetmfa user@example.com
 
 mattermost user search
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -2255,7 +2255,7 @@ Description
   Example
     .. code-block:: none
 
-      ./mattermost user search user1@example.com user2@example.com
+      bin/mattermost user search user1@example.com user2@example.com
 
 mattermost user verify
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -2271,7 +2271,7 @@ mattermost user verify
   Example
     .. code-block:: none
 
-      ./mattermost user verify user1
+      bin/mattermost user verify user1
 
 mattermost version
 ------------------
@@ -2319,7 +2319,7 @@ mattermost webhook create-incoming
   Examples
     .. code-block:: none
 
-       ./mattermost webhook create-incoming --channel [channelID] --user [userID] --display-name [display-name] --description [webhookDescription] --lock-to-channel --icon [iconURL]
+       bin/mattermost webhook create-incoming --channel [channelID] --user [userID] --display-name [display-name] --description [webhookDescription] --lock-to-channel --icon [iconURL]
 
   Options
     .. code-block:: none
@@ -2345,9 +2345,9 @@ mattermost webhook create-outgoing
   Examples
     .. code-block:: none
 
-       ./mattermost webhook create-outgoing --team myteam --channel mychannel --user myusername --display-name mywebhook --description "My cool webhook" --trigger-when start --trigger-word "build" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json"
+       bin/mattermost webhook create-outgoing --team myteam --channel mychannel --user myusername --display-name mywebhook --description "My cool webhook" --trigger-when start --trigger-word "build" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json"
 
-       ./mattermost webhook create-outgoing --team myotherteam --channel mychannel --user myusername --display-name myotherwebhook --description "My cool webhook" --trigger-when exact --trigger-word "build" --trigger-word "test" --trigger-word "third-trigger" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --url http://example.com --content-type "application/json"
+       bin/mattermost webhook create-outgoing --team myotherteam --channel mychannel --user myusername --display-name myotherwebhook --description "My cool webhook" --trigger-when exact --trigger-word "build" --trigger-word "test" --trigger-word "third-trigger" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --url http://example.com --content-type "application/json"
 
   Options
     .. code-block:: none
@@ -2378,7 +2378,7 @@ mattermost webhook delete
    Examples
      .. code-block:: none
 
-        ./mattermost webhook delete ggwpz8c1oj883euk98wfm9n1cr
+        bin/mattermost webhook delete ggwpz8c1oj883euk98wfm9n1cr
 
 mattermost webhook list
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -2394,8 +2394,8 @@ mattermost webhook list
   Examples
     .. code-block:: none
 
-       ./mattermost webhook list team1
-       ./mattermost webhook list
+       bin/mattermost webhook list team1
+       bin/mattermost webhook list
 
   Options
     .. code-block:: none
@@ -2416,7 +2416,7 @@ mattermost webhook modify-incoming
   Examples
     .. code-block:: none
 
-       ./mattermost webhook modify-incoming [webhookID] --channel [channelID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL]
+       bin/mattermost webhook modify-incoming [webhookID] --channel [channelID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL]
 
   Options
     .. code-block:: none
@@ -2441,7 +2441,7 @@ mattermost webhook modify-outgoing
   Examples
     .. code-block:: none
 
-       ./mattermost webhook modify-outgoing [webhookId] --channel [channelId] --display-name [displayName] --description "New webhook description" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json" --trigger-word test --trigger-when start`
+       bin/mattermost webhook modify-outgoing [webhookId] --channel [channelId] --display-name [displayName] --description "New webhook description" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json" --trigger-word test --trigger-when start`
 
   Options
     .. code-block:: none
@@ -2469,7 +2469,7 @@ mattermost webhook move-outgoing
   Examples
     .. code-block:: none
 
-       ./mattermost webhook move-outgoing newteam oldteam:[webhookId] --channel [channelId or channelName]
+       bin/mattermost webhook move-outgoing newteam oldteam:[webhookId] --channel [channelId or channelName]
 
   Options
     .. code-block:: none
@@ -2491,7 +2491,7 @@ mattermost webhook show
   Examples
     .. code-block:: none
 
-       ./mattermost webhook show [webhookId]
+       bin/mattermost webhook show [webhookId]
 
 Mattermost 3.5 and earlier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/administration/config-in-database.rst
+++ b/source/administration/config-in-database.rst
@@ -14,13 +14,13 @@ To start using configuration in database, pass the database connection string vi
 
   .. code-block:: text
   
-    ./mattermost --config="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable\u0026connect_timeout=10"
+    bin/mattermost --config="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable\u0026connect_timeout=10"
 
 To migrate an existing config.json into the database, use the ``config migrate`` `command <https://docs.mattermost.com/administration/command-line-tools.html#mattermost-config-migrate>`_. For example:
 
   .. code-block:: text
 
-    ./mattermost config migrate  path/to/config.json "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+    bin/mattermost config migrate  path/to/config.json "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
 
 Any existing SAML certificates and private keys will also be migrated to the database.
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -141,7 +141,7 @@ The address and port to which to bind and listen. Specifying ":8065" will bind t
 
 If you choose a port of a lower level (called "system ports" or "well-known ports", in the range of 0-1023), you must have permissions to bind to that port.
 
-On Linux you can use: ``sudo setcap cap_net_bind_service=+ep ./bin/mattermost`` to allow Mattermost to bind to well-known ports.
+On Linux you can use: ``sudo setcap cap_net_bind_service=+ep /opt/mattermost/bin/mattermost`` to allow Mattermost to bind to well-known ports.
 
 +-------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"ListenAddress": ":8065"`` with string input. |

--- a/source/deployment/bulk-loading-data.rst
+++ b/source/deployment/bulk-loading-data.rst
@@ -9,23 +9,23 @@ Before running the bulk loading command, you must first create a `JSONL
 **To bulk load data**:
 
 1. Create the `JSONL
-<http://jsonlines.org>`__ data file in your Mattermost ``bin`` directory. The file can have any name, but in this procedure it's called ``data.jsonl``. The format of the file is described in the :ref:`data-format` section.
+<http://jsonlines.org>`__ data file in your Mattermost directory. The file can have any name, but in this procedure it's called ``data.jsonl``. The format of the file is described in the :ref:`data-format` section.
 
 2. Validate that the file is correct:
 
-  a. Change to the Mattermost ``bin`` directory.
+  a. Change to the Mattermost directory.
 
-    ``cd /opt/mattermost/bin`` (the location might be different on your system)
+    ``cd /opt/mattermost`` (the location might be different on your system)
 
   b. Run the following command:
 
-    ``sudo ./mattermost import bulk data.jsonl --validate``
+    ``sudo -u mattermost bin/mattermost import bulk data.jsonl --validate``
 
 3. Resolve any errors that are reported, and validate the file again. Do not go to the next step until you can run the validate command without errors.
 
 4. Run the bulk load command in apply mode:
 
-  ``sudo ./mattermost import bulk data.jsonl --apply``
+  ``sudo -u mattermost bin/mattermost import bulk data.jsonl --apply``
 
 5. When the bulk load command completes, clear all caches. Open the System Console, and click **General > Configuration > Purge All Caches** in prior versions or **System Console** > **Environment** > **Web Server** in versions after 5.12.
 

--- a/source/deployment/on-boarding.rst
+++ b/source/deployment/on-boarding.rst
@@ -45,7 +45,7 @@ Common Tasks
 ------------
 
 **Creating System Admin account from the command line**
- - If the System Admin leaves the organization or is otherwise unavailable, you can use the command line interface to assign the *system_admin* role to an existing user. In the ``mattermost/bin`` directory, type ``sudo ./mattermost roles system_admin {user-name}``, where *{user-name}* is the username of the person with the new role. For more information about using the command line interface, see `Command Line Tools <https://docs.mattermost.com/administration/command-line-tools.html>`_.
+ - If the System Admin leaves the organization or is otherwise unavailable, you can use the command line interface to assign the *system_admin* role to an existing user. In the ``/opt/mattermost`` directory, type ``sudo -u mattermost bin/mattermost roles system_admin {user-name}``, where *{user-name}* is the username of the person with the new role. For more information about using the command line interface, see `Command Line Tools <https://docs.mattermost.com/administration/command-line-tools.html>`_.
  - The user needs to log out and log back in before the *system_admin* role is applied.
   
 **Migrating to AD/LDAP or SAML from email-based authentication**

--- a/source/install/install-debian-mattermost.rst
+++ b/source/install/install-debian-mattermost.rst
@@ -52,10 +52,10 @@ Assume that the IP address of this server is 10.10.10.2.
 
 8. Test the Mattermost server to make sure everything works.
 
-    a. Change to the ``bin`` directory:
+    a. Change to the Mattermost directory:
       ``cd /opt/mattermost``
     b. Start the Mattermost server as the user mattermost:
-      ``sudo -u mattermost ./bin/mattermost``
+      ``sudo -u mattermost bin/mattermost``
 
   When the server starts, it shows some log information and the text ``Server is listening on :8065``. You can stop the server by pressing CTRL+C in the terminal window.
 

--- a/source/install/trouble_mysql.rst
+++ b/source/install/trouble_mysql.rst
@@ -3,8 +3,8 @@ MySQL Installation Troubleshooting
 
 Before you can run the Mattermost server, you must first install and
 configure a database. You can start Mattermost by navigating to the
-``/opt/mattermost/bin`` directory and entering the command
-``sudo -u mattermost ./platform``. If the Mattermost server cannot
+``/opt/mattermost`` directory and entering the command
+``sudo -u mattermost bin/mattermost``. If the Mattermost server cannot
 connect to the database, it will fail to start. This section deals with
 MySQL database issues that you may encounter when you start up
 Mattermost for the first time.
@@ -87,8 +87,8 @@ If you accidentally created a database with the wrong name, you can
 remove it by issuing the command: :samp:`drop database {misnamed};`.
 
 After creating of the database, attempt to restart the Mattermost server
-by navigating to the ``/opt/mattermost/bin`` directory and entering the
-command ``sudo -u mattermost ./platform``.
+by navigating to the ``/opt/mattermost`` directory and entering the
+command ``sudo -u mattermost bin/mattermost``.
 
 **The mattermost Database Exists**
 
@@ -105,8 +105,8 @@ You should also confirm that ``DriverName`` element (found immediately
 above the ``DataSource`` element) is set to ``mysql``.
 
 If you correct an error, restart the Mattermost server by navigating to
-the ``/opt/mattermost/bin`` directory and entering the command
-``sudo -u mattermost ./platform``.
+the ``/opt/mattermost`` directory and entering the command
+``sudo -u mattermost bin/mattermost``.
 
 The Database User
 -----------------
@@ -183,8 +183,8 @@ file and search for ``DataSource``. Its value should be:
      "mmuser:*mmuser-password*@tcp(*host-name-or-IP*:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
 
 If you correct an error, restart the Mattermost server by navigating to
-the ``/opt/mattermost/bin`` directory and issuing the command:
-``sudo -u mattermost ./platform``.
+the ``/opt/mattermost`` directory and issuing the command:
+``sudo -u mattermost bin/mattermost``.
 
 The User Password
 -----------------
@@ -209,8 +209,8 @@ file references the ``mmuser`` password. Open this file and search for
      "mmuser:*mmuser-password*@tcp(*host-name-or-IP*:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
 
 Check that the password is correct. If you correct an error, restart the
-Mattermost server by navigating to ``/opt/mattermost/bin`` and issuing
-the command: ``sudo -u mattermost ./platform``.
+Mattermost server by navigating to ``/opt/mattermost`` and issuing
+the command: ``sudo -u mattermost bin/mattermost``.
 
 **Unsure of Password**
 
@@ -281,5 +281,5 @@ exit from MySQL and then log in again as root. Issue the command
 all rights on ``mattermost`` to ``mmuser``.
 
 Restart the Mattermost server by navigating to the
-``/opt/mattermost/bin`` directory and entering the command
-``sudo -u mattermost ./platform``.
+``/opt/mattermost`` directory and entering the command
+``sudo -u mattermost bin/mattermost``.

--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -75,7 +75,7 @@ If email sign-in was turned off before the System Administrator switched sign-in
 
   .. code-block:: none
 
-    $ sudo ./mattermost roles system_admin {username}
+    $ sudo -u mattermost bin/mattermost roles system_admin {username}
 
 4. Replace ``{username}`` with the name of the user you'd like to promote to an admin.
 


### PR DESCRIPTION
This PR should fix all occurences of the mattermost binary being called in the documentation as well as all references to the "mattermost binary directory". Both of these caused a lot of confusion in the past as the mattermost binary has to be called from the MM root directory (/opt/mattermost/) as well as being executed by the mattermost user. 

This PR changes references to `./mattermost` to `bin/mattermost` as well as changing `sudo` to `sudo -u mattermost`.