### PR TITLE
Update Performance Tracing to include Plugin API

### DIFF
--- a/source/administration/performance-alerting-guide.rst
+++ b/source/administration/performance-alerting-guide.rst
@@ -118,7 +118,7 @@ Here’s how it’s set on our community server:
 Plugin Hooks
 -------------
 
-Number of PLugin hooks called per second...
+Number of Plugin hooks called per second...?
 
 
 Other Alerts


### PR DESCRIPTION
Recently we aded the ability to trace Plugin API calls and Hooks with prometheus.   We should add an example graph of some possible bottlenecking Hooks or API calls that an admin might want to be aware of when troublehsooting or monitoring their server's performance.  

We wanted to be able to take plugins out of beta, and getting a better sense of performance hits from how plugins interact with the API is an important step forward.

https://github.com/mattermost/enterprise/pull/574
https://github.com/mattermost/mattermost-server/pull/13825