### PR TITLE
Proposal: Add new section for training & education, move legacy handbook to handbook.mattermost.com

### DIFF
--- a/source/guides/administrator.rst
+++ b/source/guides/administrator.rst
@@ -63,7 +63,6 @@ Learn how to host Mattermost to meet your networking requirements.
 
    /deployment/deployment.md
    /deployment/desktop-app-deployment*
-   /deployment/mobile-app-deployment*
    /mobile/mobile-appconfig.rst
    /administration/image-proxy*
    /administration/encryption*

--- a/source/guides/education.rst
+++ b/source/guides/education.rst
@@ -1,7 +1,7 @@
-Customer Education
+Training & Education
 =====================
 
-Educational material and best practices to get the most out of your Mattermost deployment.
+Training and educatinal material to get the most out of your Mattermost deployment.
 
 Deployment Guides
 -----------------

--- a/source/guides/education.rst
+++ b/source/guides/education.rst
@@ -1,7 +1,7 @@
 Training & Education
 =====================
 
-Training and educatinal material to get the most out of your Mattermost deployment.
+Training and educational material to help you get the most out of your Mattermost deployment.
 
 Deployment Guides
 -----------------

--- a/source/guides/education.rst
+++ b/source/guides/education.rst
@@ -1,5 +1,5 @@
-Training & Education
-=====================
+Training and Education
+=======================
 
 Training and educational material to help you get the most out of your Mattermost deployment.
 

--- a/source/guides/education.rst
+++ b/source/guides/education.rst
@@ -1,0 +1,10 @@
+Customer Education
+=====================
+
+Educational material and best practices to get the most out of your Mattermost deployment.
+
+Deployment Guides
+-----------------
+
+   /deployment/enterprise-deployment*
+   /deployment/mobile-app-deployment*

--- a/source/index.rst
+++ b/source/index.rst
@@ -20,5 +20,5 @@ Mattermost Documentation
    Administrator's Guide <guides/administrator>
    Integration Guide <guides/integration>
    Developer's Guide <https://developers.mattermost.com/>
-   Training & Education <guides/education>
+   Training and Education <guides/education>
    

--- a/source/index.rst
+++ b/source/index.rst
@@ -20,5 +20,5 @@ Mattermost Documentation
    Administrator's Guide <guides/administrator>
    Integration Guide <guides/integration>
    Developer's Guide <https://developers.mattermost.com/>
-   Core Team Handbook <guides/core>
+   Training & Education <guides/education>
    

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -13,7 +13,6 @@
 			<li><a href="https://developers.mattermost.com/">Developers</a></li>
 			<li><a href="https://mattermost.com/features/">Product</a></li>
 			<li><a href="https://mattermost.com/pricing/">Pricing</a></li>
-			<li><a href="https://handbook.mattermost.com/">Handbook</a></li>
 			<li><a href="https://mattermost.com/blog/">Blog</a></li>
 			<li><a href="https://mattermost.com/download/">Download</a></li>
 			<li><a href="https://mattermost.com/trial/">Trial</a></li>

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -11,11 +11,11 @@
 		</div>
 		<ul class="header__links">
 			<li><a href="https://developers.mattermost.com/">Developers</a></li>
-			<li><a href="https://about.mattermost.com/features/">Product</a></li>
+			<li><a href="https://mattermost.com/features/">Product</a></li>
 			<li><a href="https://mattermost.com/pricing/">Pricing</a></li>
-			<li><a href="https://docs.mattermost.com/">Docs</a></li>
+			<li><a href="https://handbook.mattermost.com/">Handbook</a></li>
 			<li><a href="https://mattermost.com/blog/">Blog</a></li>
-			<li><a href="https://about.mattermost.com/download/">Download</a></li>
+			<li><a href="https://mattermost.com/download/">Download</a></li>
 			<li><a href="https://mattermost.com/trial/">Trial</a></li>
 		</ul>
 		<div class="header__searchbar">


### PR DESCRIPTION
**SUMMARY**

I’m opening a PR to start the discussion on this proposal with relevant stakeholders. In summary, the proposal is to
1) add a section for customer education in docs.mattermost.com
2) move all handbook-related pages to handbook.mattermost.com.

**BLOCKERS**

1) Approval/sign-off from relevant stakeholders on this PR. Please note that feedback and questions are highly welcome. This PR is a proposal, not a decision.

2) Migrating individual handbook pages to handbook.mattermost.com. A separate spreadsheet to track progress has been created: https://docs.google.com/spreadsheets/d/1Yz93lett6y-vPqyxqBFZhL_43xBQ2eYRUwcVyEat-lo/edit#gid=0

**CONTEXT**

Why to add a section on customer education in docs.mattermost.com?

Technical product documentation differs from customer education content in several ways:

1 - Content
- **Product Docs**: focuses on solving issues or answering questions. It emphasizes information about the product itself, providing readers with access to knowledge (the ‘what’). E.g. ‘how to configure SAML 2.0’, or ‘how to install Mattermost on RHEL 8’. 
- **Customer Ed**: focuses on self-server training, particularly during customer onboarding journey. It emphasizes transferring knowledge, providing readers with ability to learn and develop skills to better understand the ‘why’ or ‘how’ in using the product. E.g. ‘how to deploy Mattermost to 100,000 users with disaster recovery systems in AWS’

2 - Audience
- **Product Docs**: primarily written for users (admins, developers, end users) who are either adopting Mattermost or actively using it
- **Customer Ed**: primarily a buyer, or a prospect, looking to either better understand the ‘why’ in, say, architecture recommendations, or how to maximize the value from the product

3 - Business impact / metrics
- **Product Docs**: Increased NPS (measured via docs NPS), increased 7-day server retention
- **Customer Ed**: Increased enterprise 90-day on boarding NPS, post-sales technical on boarding without R&D involvement, increased EE renewal rate

Thus, with the above, it is relatively common to have separate sections for product documentation and customer education.

Long-term, the plan is to build a more comprehensive site for publishing properties, that includes product docs, contributor docs, customer education and support materials. For more, see https://handbook.mattermost.com/operations/operations/publishing/web-properties

Short-term, the proposal is to add a section for customer education in docs.mattermost.com.


**This PR does the following:**

1. Top level navigation
 - Replaces “Docs” with “Handbook”. You can access “Docs” homepage by clicking the Mattermost icon in top left corner. It is also not standard to include the home page within the top navigation options.
 - Fixes links for Product and Download pages to point to mattermost.com, instead of about.mattermost.com

2. Tiles on home page, sections on LHS navigation
 - Replaces “Core Team Handbook” with “Training & Education”

3. New “Training & Education” section
 - Move “Mobile Applications Deployment Guide” there. Add unpublished but in progress “Enterprise Deployment Guide” there as well.
 - More content to be added, this acts as the first iteration for customer education content