### PR TITLE
Move PM hiring process to the handbook

### DIFF
--- a/source/process/product-manager-hiring.rst
+++ b/source/process/product-manager-hiring.rst
@@ -2,34 +2,4 @@
 Product Manager Hiring Process
 ====================================
 
-As a Product Manager (PM) at Mattermost, you are responsible for one of the world's largest and most popular open source projects. Your work impacts thousands of organizations who depend on Mattermost for daily operations, from high tech (Intel, Samsung, Micron), to healthcare (Medtronic, Epic, Bristol-Myers Squibb), to public sector (U.S. Department of Defense, U.S. Department of Energy), to education (University of California, National University of Singapore), and consumer brands (Urban Outfitters, Wargaming.net). 
-
-This document summarizes the hiring process of Product Managers employed by Mattermost, Inc.
-
-Hiring Process
--------------------------
-
-Candidates for PM roles on the Mattermost staff can expect the hiring process to follow the order below. Please keep in mind that applicants can be declined from the position at any stage of the process.
-
-Both declined and accepted candidates will be invited to share feedback on their hiring experience so we can continually improve our process.
-
-- **Application/Email - Review of resume** - Recruiter and at least one member of the Product Management team reviews your resume and assesses your experience, skills and application questions.
-- **Video call - Screening interview** - Selected candidates will be invited for a 25-minute screening call with a recruiter.
-- **Video call - PM-skills discussion** - Next, candidates will be invited to schedule a 50-minute interview with a Product Manager to assess product management skills and for the candidate to learn more about the role.
-- **Video call - Soft-skills discussion** - Next, candidates will be invited to schedule a 50-minute interview with a Lead Developer to assess soft skills and for the candidate to learn more about the role.
-- **Video call - PM-skills and thought process discussion** - Next, candidates will be invited to schedule a 50-minute interview with Head of Product to assess product management skills, thought process and for the candidate to learn more about the role.
-- **Audition** - Candidates who appear technically strong and culturally fit may be offered a real-world "try out" project with Mattermost team members to simulate the types of problems they will be working on.
-- **Video call - Audition review** - Candidates are invited to a 50-minute interview with a senior member of our team to review the audition.
-- **Video call - CTO interview** - Finally, candidates will have a 45-minute interview with our CTO.
-- **Email - Offer** - Successful candidates will receive an offer via email. Mattermost offers compensation competitive with a candidate's local market opportunities.
-
-Audition
--------------------------------
-
-For the benefit of candidates and the company, Mattermost offers real-world “try out” projects with Mattermost team members to simulate what it would be like to work at the company prior to hiring. The practice of auditions in open source companies was pioneered by Automattic (creators of WordPress) and detailed by `Harvard Business Review in 2014 <https://hbr.org/2014/04/the-ceo-of-automattic-on-holding-auditions-to-build-a-strong-team>`__. This practice has been a vital part of Mattermost culture.
-
-Candidates who show strong potential for technical and cultural fit are invited to work on a project designed by their potential manager. While you’re working with us, you can join the Mattermost community site `here <https://community.mattermost.com/core/>`__.
-
-Once signed-in, feel free to join channels to observe how our core staff and community members work together. Observing these public channels as you work will give you a good sense of what it is like to work at Mattermost in a full time capacity to ensure that joining the company aligns to your interests and desired career direction.
-
-During the tryout, candidates will submit invoices for up to 40 hours of work (example `here <https://docs.google.com/spreadsheets/d/1Lx1f3nX64pJTJOttW_QoJwrfRekh0ISjmIwZ7_ePG1g/edit#gid=1>`__). All candidates will be paid $25/hour, regardless of position. Mattermost uses a `standard consulting agreement template <https://docs.google.com/document/d/1G4wFLq_wHHEDJ-hrv5Kmu022mFJgh3rJ4-glM0W6riI/edit?usp=sharing>`__ and provides instructions for invoicing at the start of the tryout. Note that the hourly rate is not necessarily representative of the final offer that would be extended to a successful candidate.
+This page has moved to the `Mattermost Handbook <https://handbook.mattermost.com/contributors/join-us/staff-recruiting/product-manager-hiring>`_.


### PR DESCRIPTION
Have reviewed with @lfbrock, she has approved the migration.

Adding `Do Not Merge` label until the corresponding handbook PR is merged: https://github.com/mattermost/mattermost-handbook/pull/160