### PR TITLE
Fix link to Cloudron demo

### DIFF
--- a/source/install/deploy-cloudron.rst
+++ b/source/install/deploy-cloudron.rst
@@ -24,7 +24,7 @@ The Mattermost app will be configured with MySQL and SMTP email notifications se
 Demo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A demo is available `here <https://my-demo.cloudron.me>`__ (username: ``cloudron``, password: ``cloudron``).
+A demo is available `here <https://my.demo.cloudron.io>`__ (username: ``cloudron``, password: ``cloudron``).
 
 Package Source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We recently changed our demo location to https://my.demo.cloudron.io
