### PR TITLE
Migrate remaining marketing-related items from legacy handbook

### DIFF
--- a/source/process/asset-guidelines.rst
+++ b/source/process/asset-guidelines.rst
@@ -1,6 +1,8 @@
-============================================================
 Mattermost Asset Guidelines
 ============================================================
+
+.. note::
+  This page is largely out-of-date and is stored for record-keeping purposes. For latest marketing processes and guidelines, see the `Mattermost Handbook <https://handbook.mattermost.com/operations/messaging-and-math>`_.
 
 The following guidelines are intended to help queue and prepare marketing assets for community projects by the Mattermost core committers and the Mattermost community.
 

--- a/source/process/marketing-guidelines.rst
+++ b/source/process/marketing-guidelines.rst
@@ -1,6 +1,8 @@
-============================================================
 Mattermost Community Content Guidelines
 ============================================================
+
+.. note::
+  This page is largely out-of-date and is stored for record-keeping purposes. For latest marketing processes and guidelines, see the `Mattermost Handbook <https://handbook.mattermost.com/operations/messaging-and-math>`_.
 
 The following guidelines are intended to help community members contribute guest blog posts or propose Twitter content, as well as for staff at Mattermost, Inc. interacting with the community. 
 
@@ -65,31 +67,3 @@ Guidelines: 12 tips for sparkling content
  10. **Edit ruthlessly**. Use the first draft to get your thoughts together. Then leave it for a few hours (or even days). Shorten, delete, and rewrite anything that does not add to the meaning. Run a spelling and grammar check.
  11. **Ask a colleague**. Still not 100% happy? A colleague should review the text and tell you if anything is unclear or if you could express yourself better. They might offer some useful fresh insights.
  12. **Now, relax**. If you are in the wrong frame of mind you will either get writer's block or your writing will be stiff and unnatural. Take your time. Remove any distractions. Keep things simple. 
-
-Guidelines for Twitter accounts
----------------------------------------------------------
-
-Composing Tweets: 
-
-1. **Embody the Mattermost brand personality and voice**. Be professional, strategic, vigilant, solution-oriented, forward-thinking, concise and empathetic. Be welcoming and use inviting and inclusive language. For example, when asking someone to take action, use “Would you be open to” instead of “Would you like to”.
-2. **Use the active voice**. Avoid words and phrases like “has”, “was” and “have been” when possible. For example, say “Our hackathon starts now!” instead of “Our hackathon has started”. 
-3. **Include one link in each tweet**. Provide a clear call to action by placing a link at the end of each tweet. (Note: May not apply to retweets and responses.)
-4. **Don’t tweet about sensitive topics**. Avoid controversy. Sensitive topics include, but are not limited to, unflattering news about our competitors, items that disparage governments, companies, people or other entities, and political/religious content. Not sure if a certain topic is sensitive? Leave it alone. 
-5. **Don’t disparage other open source projects**. We fully support the open source community.
-6. **Write so an international audience can understand you**. Avoid colloquialisms, hyperbole, slang and jargon. Use simple language. Avoid acronyms when possible. For example, say “pull request” instead of “PR” since only a subset of tweet readers are active GitHub users.
-7. **Use exclamation marks sparingly**. An exclamation mark can be used when an announcement is exciting, but should be avoided when it can be confused with a signal to panic, e.g., “Security update released!”. 
-8. **Try to avoid putting anything in a negative light**. Be an optimist. For example, instead of writing “APIv3 is deprecated,” write “APIv4 has officially replaced APIv3”. Instead of writing “bug fixes,” write “performance improvements”.  
-9. **Post during the workday when possible**. The best time to post to Twitter during the workweek is between 11 a.m. to 1 p.m. local time. (The official Mattermost account considers the Eastern Time Zone local time.) Avoid posting to Twitter on the weekend or on holidays unless it’s urgent.
-10. **Add images to tweets when possible/it makes sense**. Images increase engagement. When prompted by Twitter, click the icon in the lower left-hand corner to add an image to your tweet. As a general rule, avoid GIFs, as they tend to be unprofessional.
-   
-Guidelines for release announcements
----------------------------------------------------------
-
-Composing blog posts: 
-
-1. **Include [RELEASE] [HEADLINE] in title**. Use titles that draw in IT audiences. E.g. "Mattermost 4.1: Integration enhancements with personal access tokens and streamlined apps, starting with JIRA". Focus the title on 1 to 2 key features of the release.
-2. **Use Twitter banners for images**. Use Twitter banners to make visuals consistently high-quality throughout the release announcement. Also allows the marketing team use the images for tweets.
-3. **Include a clear theme**. Decide what theme to focus on throughout the release announcement. E.g. in `4.1 release announcement the focus was placed on integrations <https://about.mattermost.com/mattermost-4-1/>`__.
-4. **Emphasize benefit**. Always start each section with the benefit - the benefit should be clear in the first 1 or 2 sentences. IT audiences are typically more interested in the business benefits of technology than technical features. Emphasize benefit also in screenshots and image captions. 
-5. **Know your audience**. Consider the audience you are writing this announcement for. E.g. admins who upgrade the Mattermost server, customers making a decision about purchasing the Enterprise Edition, end-users, or other.
-6. **Test on mobile**. Before you publish a blog post, make sure that it is mobile-friendly by testing it on smartphone and tablet platforms.


### PR DESCRIPTION
1 - Add notes about out-of-date pages kept for record-keeping purposes
2 - Migrate Twitter guidelines
3 - Remove release announce guideines -- @amyblais please review and include any valuable ones in https://handbook.mattermost.com/operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-release-announcements. I think it's mostly there except maybe the last point about testing on mobile.

Related handbook PR: https://github.com/mattermost/mattermost-handbook/pull/197