### PR TITLE
Education content fixes

### DIFF
--- a/source/guides/core.rst
+++ b/source/guides/core.rst
@@ -13,15 +13,7 @@ Development Process
    :maxdepth: 2
    :glob:
 
-   /process/overview*
-   /process/deprecated-features*
-   /process/software-requirements*
-   /developer/style*
-   /developer/fx*
-   /developer/localization*
-   /process/definitions*
-   /process/new-bug-tickets*
-   /process/bug-severity-guidelines*
+This section has moved to the `Mattermost Handbook <https://handbook.mattermost.com/operations/research-and-development/product/development-process>`__.
    
 Release Process
 -------------------
@@ -47,8 +39,7 @@ Product Management Handbook
    :maxdepth: 2
    :glob:
 
-   /process/product-manager-hiring*
-   /process/pm-faq*
+This section has moved to the `Mattermost Handbook <https://handbook.mattermost.com/operations/research-and-development/product/product-management-team-handbook>`__.
 
 Core Developer Handbook
 -----------------------
@@ -91,12 +82,7 @@ Marketing
    :maxdepth: 2
    :glob:
 
-   /process/casestudy*
-   /process/guest-article*
-   /process/marketing-guidelines*
-   /process/asset-guidelines*
-   /process/end-user-documentation*
-   /process/integrations-directory*
+This section has moved to the `Mattermost Handbook <https://handbook.mattermost.com/operations/messaging-and-math>`__.
 
    
 Partners

--- a/source/guides/education.rst
+++ b/source/guides/education.rst
@@ -3,8 +3,18 @@ Training and Education
 
 Training and educational material to help you get the most out of your Mattermost deployment.
 
+Training
+-----------------
+
+   - `System Admin courses <https://academy.mattermost.com/>`_ to help administrators set up, configure and extend Mattermost
+   - `User training videos <https://www.youtube.com/channel/UCNR05H72hi692y01bWaFXNA/videos>`_ for System Admins and Users to get the most value out of Mattermost
+   - `Developer talks <https://www.youtube.com/channel/UCNR05H72hi692y01bWaFXNA/search?query=dev>`_ about the architecture, design principles, and tools used for the open source Mattermost project
+
 Deployment Guides
 -----------------
 
-   /deployment/enterprise-deployment*
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
    /deployment/mobile-app-deployment*

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -200,7 +200,7 @@
                 <p class="tile-description">Contributing to the open source project</p>
             </a>
             <a class="tile" href="guides/education.html">
-                <h2 class="tile-title">Training and Support</h2>
+                <h2 class="tile-title">Training and Education</h2>
                 <div class="tile-divider"></div>
                 <p class="tile-description">Get the most out of your Mattermost deployment</p>
             </a>

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -199,10 +199,10 @@
                 <div class="tile-divider"></div>
                 <p class="tile-description">Contributing to the open source project</p>
             </a>
-            <a class="tile" href="guides/core.html">
-                <h2 class="tile-title">Core Team Handbook</h2>
+            <a class="tile" href="guides/education.html">
+                <h2 class="tile-title">Training and Support</h2>
                 <div class="tile-divider"></div>
-                <p class="tile-description">Joining the Mattermost core team</p>
+                <p class="tile-description">Get the most out of your Mattermost deployment</p>
             </a>
         </div>
     </div>


### PR DESCRIPTION
1. Update home page tile from "Core Team Handbook" to "Training and Education"
2. Update TOC for "Training and Education"
3. Link old legacy handbook sections to their appropriate handbook.mattermost.com pages