### PR TITLE
Add documentation links for webapp message syntax

### DIFF
--- a/source/developer/localization.rst
+++ b/source/developer/localization.rst
@@ -69,6 +69,12 @@ Alpha
 
 An official language may be changed back to Beta or Alpha if the specified requirements are not met for a release. Similarly, Beta-quality language may be dropped back to Alpha.
 
+Message Syntax 
+-----------------
+
+To format localized messages, `mattermost-webapp <https://github.com/mattermost/mattermost-webapp>`_ uses the `react-intl <https://formatjs.io/docs/react-intl>`_ library from `FormatJS <https://formatjs.io/>`_ using the `ICU Message syntax <https://formatjs.io/docs/icu-syntax>`_. Follow the links to read about placeholders and arguments, or experiment with one of their `live editors <https://formatjs.io/docs/intl-messageformat>`_.
+
+
 Test Translations
 -----------------
 


### PR DESCRIPTION
#### Summary

Translators may not be familiar with the various translation message syntaxes used in Mattermost projects. 

This PR adds helpful links to documentation of said syntaxes and libraries that mattermost-webapp uses.


#### Related PRs:
https://github.com/mattermost/mattermost-webapp/pull/5390



