### PR TITLE
Add (optional) pgpass steps to postgres installation in docs #3483

### DIFF
--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -104,7 +104,7 @@ Assume that the IP address of this server is 10.10.10.1
 13. (Optional) If you don't want to enter your password at each login, you can use a ``.pgpass`` file . It is a special file which has to be assigned ``0600`` in permissions otherwise it will not work. One can also pass the location of the file using the ``PGPASSFILE`` env variable.
 
 This leaves the security to the user running the application. If you run it as a service, then you need *sudo* permissions to start a service file. As a result only *root* user has read-write access. 
-
-For further info on the pgpass file please refer to `the official PostgreSQL documentation<https://www.postgresql.org/docs/9.4/libpq-pgpass.html>`_.
+ 
+For further info on the pgpass file please refer to `the official PostgreSQL documentation   <https://www.postgresql.org/docs/9.4/libpq-pgpass.html>`_
 
 With the database installed and the initial setup complete, you can now install the Mattermost server.

--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -100,5 +100,9 @@ Assume that the IP address of this server is 10.10.10.1
       You might have to install the PostgreSQL client software to use the command.
 
   The PostgreSQL interactive terminal starts. To exit the PostgreSQL interactive terminal, type ``\q`` and press **Enter**.
+  
+13. (Optional) Postgres recommends the standard way to pass passwords is through a ``.pgpass`` file. It is a special file that HAS to be 0600 in permissions otherwise it doesnt work. One can also pass the location of the file using the ``PGPASS`` env variable.
+
+  This leaves the security to the user running the application. If you run it as a service, then you need sudo permissions to   start a service file. Therefore, this file can be only root read-write and disabled for everybody else. After all, if you     are root, there's nothing you can't do
 
 With the database installed and the initial setup complete, you can now install the Mattermost server.

--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -101,7 +101,7 @@ Assume that the IP address of this server is 10.10.10.1
 
   The PostgreSQL interactive terminal starts. To exit the PostgreSQL interactive terminal, type ``\q`` and press **Enter**.
   
-13. (Optional) Postgres recommends the standard way to pass passwords is through a ``.pgpass`` file. It is a special file that HAS to be 0600 in permissions otherwise it doesnt work. One can also pass the location of the file using the ``PGPASS`` env variable.
+13. (Optional) If you don't want to enter your password at each login, you can use a ``.pgpass`` file . It is a special file which has to be assigned ``0600`` in permissions otherwise it will not work. One can also pass the location of the file using the ``PGPASSFILE`` env variable.
 
 This leaves the security to the user running the application. If you run it as a service, then you need *sudo* permissions to start a service file. As a result only *root* user has read-write access. 
 

--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -105,4 +105,6 @@ Assume that the IP address of this server is 10.10.10.1
 
 This leaves the security to the user running the application. If you run it as a service, then you need *sudo* permissions to start a service file. As a result only *root* user has read-write access. 
 
+For further info on the pgpass file please refer to `the official PostgreSQL documentation<https://www.postgresql.org/docs/9.4/libpq-pgpass.html>`_.
+
 With the database installed and the initial setup complete, you can now install the Mattermost server.

--- a/source/install/install-ubuntu-1604-postgresql.rst
+++ b/source/install/install-ubuntu-1604-postgresql.rst
@@ -103,6 +103,6 @@ Assume that the IP address of this server is 10.10.10.1
   
 13. (Optional) Postgres recommends the standard way to pass passwords is through a ``.pgpass`` file. It is a special file that HAS to be 0600 in permissions otherwise it doesnt work. One can also pass the location of the file using the ``PGPASS`` env variable.
 
-  This leaves the security to the user running the application. If you run it as a service, then you need sudo permissions to   start a service file. Therefore, this file can be only root read-write and disabled for everybody else. After all, if you     are root, there's nothing you can't do
+This leaves the security to the user running the application. If you run it as a service, then you need *sudo* permissions to start a service file. As a result only *root* user has read-write access. 
 
 With the database installed and the initial setup complete, you can now install the Mattermost server.


### PR DESCRIPTION

#### Summary

This part of docs was updated to add pgpass steps to Postgres installation in docs

#### Ticket Link

If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/docs/issues/3483

This part of the docs is supposed to be in the same section of the other OS's but I want to confirm that this is added correctly before moving on

