### PR TITLE
Update Download Link 4.4.1 --> 4.4.2

### DIFF
--- a/source/help/apps/desktop-changelog.rst
+++ b/source/help/apps/desktop-changelog.rst
@@ -4,7 +4,7 @@ Desktop Application Changelog
 Release v4.4
 ----------------------------
 
-**Download Binaries:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop/releases/tag/v4.4.1>`_
+**Download Binaries:** `Mattermost Desktop on GitHub <https://github.com/mattermost/desktop/releases/tag/v4.4.2>`_
 
 - **v4.4.2, released 2020-05-11**
  - Fixed an issue on Windows where a channel was marked as read if the app was closed on a channel where the message was posted. `MM-23215 <https://mattermost.atlassian.net/browse/MM-23215>`_


### PR DESCRIPTION
Just a small update that the users are going to the 4.4.2 release page.