### PR TITLE
Update GitLab Omnibus "mattermost" command

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -70,7 +70,7 @@ On GitLab Omnibus, you must be in the following directory when you run CLI comma
   .. code-block:: bash
 
     cd /opt/gitlab/embedded/service/mattermost
-    sudo -u mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json version
+    sudo /opt/gitlab/embedded/bin/chpst -e /opt/gitlab/etc/mattermost/env -P -U mattermost:mattermost -u mattermost:mattermost /opt/gitlab/embedded/bin/mattermost --config=/var/opt/gitlab/mattermost/config.json version
 
 .. note::
   The example commands in the documentation are for a default installation of Mattermost. You must modify the commands so that they work on GitLab Omnibus.


### PR DESCRIPTION
GitLab's way of calling mattermost has changed and the previous one mentioned here will not work. See https://docs.gitlab.com/omnibus/gitlab-mattermost/#mattermost-command-line-tools-cli

#### Summary

Brings the GitLab Omnibus-specific way of calling the mattermost CLI in line with GitLab's own documentation.
