### PR TITLE
Fix typo in mattermost license file in K8s install guide

### DIFF
--- a/source/install/install-kubernetes-mattermost.rst
+++ b/source/install/install-kubernetes-mattermost.rst
@@ -23,7 +23,7 @@ Open a text editor and create a text file with the following details.
   kind: Secret
   metadata:
     name: mattermost-license
-  type: Opqaue
+  type: Opaque
   stringData:
     license: %LICENSE_FILE_CONTENTS%
 


### PR DESCRIPTION
Found by @NOP64
