### PR TITLE
[WIP] Broken images in inline section #3615

### DIFF
--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -257,7 +257,7 @@ Inline image with hover text
 
   .. raw:: html
 
-    <img src="../../_images/icon-76x76.png" alt="Mattermost" title="Mattermost Icon"></a>
+    <img src="../../images/icon-76x76.png" alt="Mattermost" title="Mattermost Icon"></a>
 
 Inline image with link
   Note the extra set of square brackets.
@@ -282,7 +282,7 @@ Inline image displayed at 50 pixels wide and 76 pixels high
 
   .. raw:: html
 
-    <img alt="Mattermost" src="../../_images/icon-50x76.png" title="Mattermost Icon">
+    <img alt="Mattermost" src="../../images/icon-50x76.png" title="Mattermost Icon">
 
 Inline image displayed at 50 pixels wide and the height adjusted to suit
   .. code-block:: none
@@ -293,7 +293,7 @@ Inline image displayed at 50 pixels wide and the height adjusted to suit
 
   .. raw:: html
 
-    <img src="../../_images/icon-76x76.png" alt="Mattermost" width="50px" title="Mattermost Icon"></a>
+    <img src="../../images/icon-76x76.png" alt="Mattermost" width="50px" title="Mattermost Icon"></a>
 
 Lines
 -----

--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -269,9 +269,8 @@ Inline image with link
   Renders as:
 
   .. image:: ../../images/icon-76x76.png
-     :alt: MatterMost Icon 76X76
-    :alt: Mattermost
     :target: https://github.com/mattermost/mattermost-server
+   
 
 Inline image displayed at 50 pixels wide and 76 pixels high
   .. code-block:: none


### PR DESCRIPTION
#### Summary
This PR is to fix broken images in the inline section. it's stated as WIP because it's not a complete fix.

- The images are showing beside a  link
- one of the images in the inline section is not showing, need help in understanding how it was written
- The image beside the link removing it removes the link 

<img width="218" alt="Screenshot 2020-05-14 at 2 59 25 PM" src="https://user-images.githubusercontent.com/39309699/81943680-981f4880-95f3-11ea-8f9b-a9c6a3872fd8.png">


#### Ticket Link

  Fixes https://github.com/mattermost/docs/issues/3615



