### PR TITLE
Remove unnecessary plugin directory rename step

### DIFF
--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -146,16 +146,6 @@ Location of your local storage directory
 
    Your current settings are preserved, and new settings are added with default values.
 
-#. Reinstate the ``plugins`` directories, then restart the mattermost service.
-
-   .. code-block:: sh
-
-     cd {install-path}/mattermost
-     sudo rsync -au plugins~/ plugins
-     sudo rm -rf plugins~
-     sudo rsync -au client/plugins~/ client/plugins
-     sudo rm -rf client/plugins~
-
 After the server is upgraded, users might need to refresh their browsers to experience any new features.
 
 Upgrading Team Edition to Enterprise Edition

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -97,13 +97,6 @@ Location of your local storage directory
 
      sudo find mattermost/ mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/client -o -path mattermost/client/plugins -o -path mattermost/config -o -path mattermost/logs -o -path mattermost/plugins -o -path mattermost/data \) -prune \) | sort | sudo xargs rm -r
     
-#. Rename the ``plugins`` directories so they do not interfere with the upgrade.
-
-   .. code-block:: sh
-
-     sudo mv mattermost/plugins/ mattermost/plugins~
-     sudo mv mattermost/client/plugins/ mattermost/client/plugins~
-    
 #. Change ownership of the new files before copying them.
 
    .. code-block:: sh


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR removes a step from the Mattermost Server upgrade instructions. Step 8 has the administrator rename the plugins directory and the client plugins directory, however this seems to be an unnecessary step since there is a `prepackaged_plugins` directory so that the prepackaged plugins are overwritten when the new version is copied in, but user plugins are left untouched.

I made a note to myself during upgrade of my server from 5.21 to 5.22 to test out the next upgrade while skipping Step 8 and my instance appears to have suffered no ill effects from the omission of this step during my upgrade from 5.22 to 5.23.

If there's any additional testing or verification that I need to do in order to further assuage any concerns about this change, please let me know and I will be happy to do so.

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

