### PR TITLE
clarification of profile picture sync

### DIFF
--- a/source/deployment/sso-ldap.md
+++ b/source/deployment/sso-ldap.md
@@ -53,7 +53,7 @@ To configure AD/LDAP synchronization with AD/LDAP sign-in:
 
 1. Go to **System Console > Authentication > AD/LDAP** and set **Enable Synchronization with AD/LDAP** to `true`.
 
-2. Scroll down to **Syncronization Interval (minutes)** to specify how often Mattermost accounts synchronize attributes with AD/LDAP. The default setting is 60 minutes. *Note: profile picture attribute is synchronized upon user login only*
+2. Scroll down to **Synchronization Interval (minutes)** to specify how often Mattermost accounts synchronize attributes with AD/LDAP. The default setting is 60 minutes. The profile picture attribute is only synchronized when the user logs in.
 
 If you want to synchronize immediately after disabling an account, use the **AD/LDAP Synchronize Now** button in **System Console > AD/LDAP**.
 

--- a/source/deployment/sso-ldap.md
+++ b/source/deployment/sso-ldap.md
@@ -53,7 +53,7 @@ To configure AD/LDAP synchronization with AD/LDAP sign-in:
 
 1. Go to **System Console > Authentication > AD/LDAP** and set **Enable Synchronization with AD/LDAP** to `true`.
 
-2. Scroll down to **Syncronization Interval (minutes)** to specify how often Mattermost accounts synchronize attributes with AD/LDAP. The default setting is 60 minutes.
+2. Scroll down to **Syncronization Interval (minutes)** to specify how often Mattermost accounts synchronize attributes with AD/LDAP. The default setting is 60 minutes. *note profile picture attribute is synchronized upon user login only)*
 
 If you want to synchronize immediately after disabling an account, use the **AD/LDAP Synchronize Now** button in **System Console > AD/LDAP**.
 

--- a/source/deployment/sso-ldap.md
+++ b/source/deployment/sso-ldap.md
@@ -53,7 +53,7 @@ To configure AD/LDAP synchronization with AD/LDAP sign-in:
 
 1. Go to **System Console > Authentication > AD/LDAP** and set **Enable Synchronization with AD/LDAP** to `true`.
 
-2. Scroll down to **Syncronization Interval (minutes)** to specify how often Mattermost accounts synchronize attributes with AD/LDAP. The default setting is 60 minutes. *note profile picture attribute is synchronized upon user login only)*
+2. Scroll down to **Syncronization Interval (minutes)** to specify how often Mattermost accounts synchronize attributes with AD/LDAP. The default setting is 60 minutes. *Note: profile picture attribute is synchronized upon user login only*
 
 If you want to synchronize immediately after disabling an account, use the **AD/LDAP Synchronize Now** button in **System Console > AD/LDAP**.
 


### PR DESCRIPTION
profile picture attribute is only synced upon login and does not adhere to the sync interval for the rest of the AD/LDAP attributes.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

