### PR TITLE
Update documentation-guidelines.rst

### DIFF
--- a/source/process/documentation-guidelines.rst
+++ b/source/process/documentation-guidelines.rst
@@ -2,7 +2,7 @@
 Documentation Guidelines
 ========================
 
-The Mattermost Style Guide is in the process of being migrated to the `Mattermost Handbook <https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide>`_. It acts as a reference for writers and editors to ensure that the Mattermost documentation is consistent and clear. 
+The Mattermost Style Guide is in the process of being migrated to the `Mattermost Handbook <https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide>`_. It acts as a reference for writers and editors to ensure that the Mattermost documentation is consistent and clear.
 
 .. Note::
   This guide is not intended to slow down or otherwise impede contributions, which are always welcome. No contribution will be rejected due to non-conforming style, although it might be edited.

--- a/source/process/documentation-guidelines.rst
+++ b/source/process/documentation-guidelines.rst
@@ -2,10 +2,10 @@
 Documentation Guidelines
 ========================
 
-This is the Mattermost style guide for documentation. It acts as a reference for writers and editors to ensure that the Mattermost documentation is consistent and clear.
+The Mattermost Style Guide is in the process of being migrated to the `Mattermost Handbook <https://handbook.mattermost.com/operations/operations/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide>`_. It acts as a reference for writers and editors to ensure that the Mattermost documentation is consistent and clear. 
 
 .. Note::
-  The style guide is not intended to slow down or otherwise impede contributions, which are always welcome. No contribution will be rejected due to non-conforming style, although it might be edited.
+  This guide is not intended to slow down or otherwise impede contributions, which are always welcome. No contribution will be rejected due to non-conforming style, although it might be edited.
 
 .. contents::
   :backlinks: top


### PR DESCRIPTION
This doc is still appearing in Google searches, but it has moved to the handbook. I've added a note with a link to the Handbook and current Style Guide.
