### PR TITLE
Change mscalendar docs link to be gitbooks link

### DIFF
--- a/source/deployment/microsoft-integrations.rst
+++ b/source/deployment/microsoft-integrations.rst
@@ -9,7 +9,7 @@ Office 365 Calendar (E20)
 - Two-way integration between Mattermost and Office 365 Calendar, developed by Mattermost.
 - Receive a daily summary of calendar events, and accept or decline new events.
 - Reflect user status as "Do Not Disturb" when in a meeting scheduled via Outlook Calendar.
-- Source code + docs: https://github.com/mattermost/mattermost-plugin-mscalendar.
+- Docs: https://mattermost.gitbook.io/plugin-mscalendar
 
 Skype for Business
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary

The link at https://docs.mattermost.com/deployment/microsoft-integrations.html that points to the Microsoft Calendar plugin docs is using the private repo, rather than the gitbook docs https://mattermost.gitbook.io/plugin-mscalendar

#### Ticket Link

https://github.com/mattermost/docs/issues/3707
