### PR TITLE
Add troubleshooting doc when attempting to run the CLI or bulk loading tool with Bleve enabled

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -2674,3 +2674,16 @@ CLI Documentation:
       -version                          Display the current of the Mattermost platform
 
       -help                             Displays this help page
+
+
+Troubleshooting
+^^^^^^^^^^^^^^^^^
+
+Executing a command hangs and doesn't complete
+------------------------------------------------
+
+If you have Bleve search indexing enabled, temporarily disable it in **System Console > Experimental > Bleve** and run the command again. You can also optionally use a new `mmctl Command Line Tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_ instead.
+
+Bleve does not support multiple processes opening and manipulating the same index. Therefore, if the Mattermost server is running, an attempt to run the CLI will lock when trying to open the indeces.
+
+If you are not using the Bleve search indexing, feel free to post in our `Troubleshooting forum <http://www.mattermost.org/troubleshoot/>`__ to get help.

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -2682,7 +2682,7 @@ Troubleshooting
 Executing a command hangs and doesn't complete
 ------------------------------------------------
 
-If you have Bleve search indexing enabled, temporarily disable it in **System Console > Experimental > Bleve** and run the command again. You can also optionally use a new `mmctl Command Line Tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_ instead.
+If you have Bleve search indexing enabled, temporarily disable it in **System Console > Experimental > Bleve** and run the command again. You can also optionally use the new `mmctl Command Line Tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
 
 Bleve does not support multiple processes opening and manipulating the same index. Therefore, if the Mattermost server is running, an attempt to run the CLI will lock when trying to open the indeces.
 

--- a/source/deployment/bulk-loading-troubleshooting.rst
+++ b/source/deployment/bulk-loading-troubleshooting.rst
@@ -1,0 +1,13 @@
+.. _bulk-loading-troubleshooting:
+
+Troubleshooting
+================
+
+Running bulk loading tool hangs and doesn't complete
+-----------------------------------------------------
+
+If you have Bleve search indexing enabled, temporarily disable it in **System Console > Experimental > Bleve** and run the command again.
+
+Bleve does not support multiple processes opening and manipulating the same index. Therefore, if the Mattermost server is running, an attempt to run the bulk loading tool will lock when trying to open the indeces.
+
+If you are not using the Bleve search indexing, feel free to post in our `Troubleshooting forum <http://www.mattermost.org/troubleshoot/>`__ for help.

--- a/source/deployment/bulk-loading.rst
+++ b/source/deployment/bulk-loading.rst
@@ -35,3 +35,4 @@ Importing additional types of posts is not yet supported.
 .. include:: bulk-loading-about.rst
 .. include:: bulk-loading-data.rst
 .. include:: bulk-loading-data-format.rst
+.. include:: bulk-loading-troubleshooting.rst


### PR DESCRIPTION
See issue report: https://community.mattermost.com/core/pl/ys4xn5tmobnymxof61d1jjg84y