### PR TITLE
Remove reference to the emoji cheat-sheet

### DIFF
--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -8,7 +8,7 @@ For a Layman's guide to Markdown on Mattermost, `see this blog post <https://mat
 Emojis
 ------
 
-Open the emoji autocomplete by typing ``:`` followed by two characters of the word describing the emoji. A full list of emojis can be found `here <http://www.emoji-cheat-sheet.com/>`__. It is also possible to create your own `Custom Emoji <http://docs.mattermost.com/help/settings/custom-emoji.html>`__ if the emoji you want to use doesn't exist.
+Open the emoji autocomplete by typing ``:`` followed by two characters of the word describing the emoji. It is also possible to create your own `Custom Emoji <http://docs.mattermost.com/help/settings/custom-emoji.html>`__ if the emoji you want to use doesn't exist.
 
 ``:smile: :+1: :sheep:``
 


### PR DESCRIPTION
#### Summary

The emoji-cheat-sheet at http://www.emoji-cheat-sheet.com/ (referenced in the Formatting Text docs) does not contain the full list of emojis supported by Mattermost, as indicated (for example, :printer: exists in Mattermost but is not on emoji-cheat-sheet).

This change removes that reference to avoid confusing users.

It may be worth, in a later change, adding the full list of Mattermost emojis to the docs themselves (instead of referencing a third party site).