### PR TITLE
Add a link to join the user community to key docs pages

### DIFF
--- a/source/administration/plugins.rst
+++ b/source/administration/plugins.rst
@@ -299,6 +299,8 @@ Join our community server discussion in the `Toolkit channel <https://community.
 Troubleshooting
 -----------------
 
+Please see common questions below. For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
+
 Plugin uploads fail even though uploads are enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -197,4 +197,4 @@ Known Slack compatibility issues
 Troubleshooting
 ---------------
 
-See `developer documentation <https://developers.mattermost.com/integrate/slash-commands>`__ for troubleshooting help.
+See `developer documentation <https://developers.mattermost.com/integrate/slash-commands>`__ for troubleshooting, or `join the Mattermost user community for help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -161,6 +161,8 @@ Some common error messages include:
 
 If your integration prints the JSON payload data instead of rendering the generated message, make sure your integration is returning the ``application/json`` content-type.
 
+For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
+
 Frequently Asked Questions
 ----------------------------
 

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -169,6 +169,8 @@ To debug outgoing webhooks in **System Console > Logs**, set **System Console > 
 
 When ``TRUE``, as of v5.14 all outgoing webhooks are logged and include a ``request_id`` value in the log file. 
 
+For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
+
 My integration prints the JSON data in a Mattermost channel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/help/settings/custom-emoji.rst
+++ b/source/help/settings/custom-emoji.rst
@@ -6,7 +6,10 @@ You can create Custom Emojis which are available to everyone on your Mattermost 
 
 To create and find Custom Emojis, open the **Main Menu** at the top right of the channels sidebar and select **Custom Emoji**.
 
-**Note:** If you cannot see the **Custom Emoji** option in the menu, then your Mattermost System Admin may have restricted access to certain users. Contact your Mattermost System Admin for help.
+  .. note::
+    If you cannot see the **Custom Emoji** option in the menu, then your Mattermost System Admin may have restricted access to certain users. Contact your Mattermost System Admin for help.
+    
+    For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
 
 Creating Custom Emojis
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/source/install/desktop.rst
+++ b/source/install/desktop.rst
@@ -184,7 +184,7 @@ Desktop app not responsive within Citrix Virtual Apps or Desktop Environment
 
 Append ``Mattermost.exe;`` to the Registry Key ``HKLM\SYSTEM\CurrentControlSet\Services\CtxUvi\UviProcessExcludes`` and reboot the system.
 
-For additional troubleshooting tips, see the `troubleshooting guide <https://www.mattermost.org/troubleshoot/>`__.
+For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
 
 Reporting Issues
 --------------------------------------------------

--- a/source/install/install-common-intro.rst
+++ b/source/install/install-common-intro.rst
@@ -3,5 +3,8 @@ A complete Mattermost installation consists of three major components: a proxy s
 For the database, you can install either MySQL or PostgreSQL. The proxy is NGINX.
 
 .. note::
-  If you have any problems installing Mattermost, see
-  the `troubleshooting guide <https://docs.mattermost.com/install/troubleshooting.html>`__. For help with inviting users to your system, see `inviting team members <https://docs.mattermost.com/help/getting-started/managing-members.html#inviting-team-members>`__ and other `getting started information <https://docs.mattermost.com/guides/user.html#getting-started>`__. To submit an improvement or correction, click  **Edit** at the top of this page.
+  If you have any problems installing Mattermost, see the `troubleshooting guide <https://docs.mattermost.com/install/troubleshooting.html>`__, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
+  
+  For help with inviting users to your system, see `inviting team members <https://docs.mattermost.com/help/getting-started/managing-members.html#inviting-team-members>`__ and other `getting started information <https://docs.mattermost.com/guides/user.html#getting-started>`__.
+  
+  To submit an improvement or correction to this page, click  **Edit** at the top of this page.

--- a/source/install/install-common-intro.rst
+++ b/source/install/install-common-intro.rst
@@ -7,4 +7,4 @@ For the database, you can install either MySQL or PostgreSQL. The proxy is NGINX
   
   For help with inviting users to your system, see `inviting team members <https://docs.mattermost.com/help/getting-started/managing-members.html#inviting-team-members>`__ and other `getting started information <https://docs.mattermost.com/guides/user.html#getting-started>`__.
   
-  To submit an improvement or correction to this page, click  **Edit** at the top of this page.
+  To submit an improvement or correction to this page, click **Edit** in the top-right corner of the page.

--- a/source/install/smtp-email-setup.rst
+++ b/source/install/smtp-email-setup.rst
@@ -186,4 +186,4 @@ Checking your SMTP server is reachable
   As we're not installing telnet by default on the official docker images you either need to use ``ping`` on those or install telnet yourself either directly or by modifying the Dockerfile.
 
 .. note::
-  For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_. To submit an improvement or correction to this page, click  **Edit** at the top of this page.
+  For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_. To submit an improvement or correction to this page, click **Edit** in the top-right corner of the page.

--- a/source/install/smtp-email-setup.rst
+++ b/source/install/smtp-email-setup.rst
@@ -186,5 +186,4 @@ Checking your SMTP server is reachable
   As we're not installing telnet by default on the official docker images you either need to use ``ping`` on those or install telnet yourself either directly or by modifying the Dockerfile.
 
 .. note::
-  For additional troubleshooting tips, see
-  the `troubleshooting guide <https://www.mattermost.org/troubleshoot/>`__. To submit an improvement or correction, click  **Edit** at the top of this page.
+  For further assistance, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_. To submit an improvement or correction to this page, click  **Edit** at the top of this page.

--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -2,7 +2,7 @@
 
 This document summarizes common troubleshooting issues and techniques.
 
-Depending on the type of error or problem you're experiencing, refer to the sections below for troubleshooting guidance. If you're a new user, it might help to go over the installation steps again to confirm the process. Alternatively, the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ might be helpful as someone may have experienced the same error in the past.
+Depending on the type of error or problem you're experiencing, refer to the sections below for troubleshooting guidance. If you're a new user, it might help to go over the installation steps again to confirm the process. Alternatively, review the `Troubleshooting forum <https://forum.mattermost.org/c/trouble-shoot>`__ for previously reported errors, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
 
 If you're an Enterprise Edition subscriber, you may open a support ticket in the `Enterprise Edition Support portal <https://mattermost.zendesk.com/hc/en-us/requests/new>`_.
 


### PR DESCRIPTION
Adding a link to join the user community to key docs pages
- admin troubleshooting guide
- integration guides for slash commands, incoming and outgoing webhooks, plugins
- install guides
- SMTP setup guide
- desktop app install guide
- custom emoji page (given it's the highest rated page)

For additional context, we are adding a new entry point into the product for people to join the user community (community.mattermost.com). Adding this same link to key documentation page for administrators to get help with install and setup.
![image](https://user-images.githubusercontent.com/13119842/87952679-1b3b9f80-ca78-11ea-8e9b-c0c768d09f5c.png)
