### PR TITLE
[MM-26891] Document change in EnableAPITeamDeletion behaviour for mmctl local mode

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -3955,7 +3955,7 @@ Enable API Team Deletion
 
 **False**: The API endpoint cannot be called. Note that ``api/v4/teams/{teamid}`` can still be used to soft delete a team.
 
-mmctl local mode ignores this setting and behaves as though ``EnableAPITeamDeletion`` set to true.
+mmctl local mode ignores this setting and behaves as though ``EnableAPITeamDeletion`` is set to ``true``.
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableAPITeamDeletion": false`` with options ``true`` and ``false``.                                                    |

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -3955,6 +3955,8 @@ Enable API Team Deletion
 
 **False**: The API endpoint cannot be called. Note that ``api/v4/teams/{teamid}`` can still be used to soft delete a team.
 
+mmctl local mode ignores this setting and behaves as though ``EnableAPITeamDeletion`` set to true.
+
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableAPITeamDeletion": false`` with options ``true`` and ``false``.                                                    |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Document change in EnableAPITeamDeletion behaviour for mmctl local mode

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- Part of https://mattermost.atlassian.net/browse/MM-26891
