### PR TITLE
Remove Team Edition reference from upgrade guide

### DIFF
--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -46,17 +46,9 @@ Location of your local storage directory
 
 #. Download `the latest version of Mattermost Server <https://about.mattermost.com/download/>`__. In the following command, replace ``X.X.X`` with the version that you want to download:
 
-   *Enterprise Edition*
-
    .. code-block:: sh
 
      wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz
-
-   *Team Edition*
-
-   .. code-block:: sh
-
-    wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz
 
 #. Extract the Mattermost Server files.
 

--- a/source/administration/upgrading-to-3.0.rst
+++ b/source/administration/upgrading-to-3.0.rst
@@ -48,10 +48,7 @@ Owner and group of the install directory - *{owner}* and *{group}*
 
 3. Download version 3.0.3.
 
-  Enterprise Edition
-    ``wget https://releases.mattermost.com/3.0.3/mattermost-enterprise-3.0.3-linux-amd64.tar.gz``
-  Team Edition
-    ``wget https://releases.mattermost.com/3.0.3/mattermost-team-3.0.3-linux-amd64.tar.gz``
+  ``wget https://releases.mattermost.com/3.0.3/mattermost-enterprise-3.0.3-linux-amd64.tar.gz``
 
 4. Extract the Mattermost Server files.
 


### PR DESCRIPTION
Remove Team Edition reference from upgrade guide, including the "upgrade to MM v3.0" referenced in the upgrade guide.

Note that Team Edition is not referenced in any install guides, so including it may cause confusion among admins. As a data point, we see a significant number of admins first installing E0, then upgrading to a new version with TE binary for no apparent reason. The hypothesis is that the Enterprise Edition referenced in the upgrade guide is confused with the Enterprise subscription.

For detailed analysis and data, see https://docs.google.com/document/d/1iyNN1ytJ7nKetDjZCRUPG2yqEBgCKVbGjSaB64bvpf0/edit#

Previously approved by @lfbrock at https://community.mattermost.com/private-core/pl/ebtxzz7b3bfzzpszh57ojah85h

EDIT: We will do an analysis on whether this change has a positive impact to the admin user experience.