### PR TITLE
Add an FAQ for how to install Mattermost with the open source Team Edition licensed under MIT

### DIFF
--- a/source/administration/version-archive.rst
+++ b/source/administration/version-archive.rst
@@ -190,6 +190,8 @@ Mattermost Enterprise Edition v2.1.0 - `View Changelog <https://docs.mattermost.
 Mattermost Team Edition Server Archive
 ---------------------------------------
 
+The open source Mattermost Team Edition is functionally identical to the commercial Mattermost Enterprise Edition in its free “team mode”, but there is no ability to unlock enterprise features. It deploys as single Linux binary with MySQL or PostgreSQL under an MIT license.
+
 Mattermost Team Edition v5.25.2 *Extended Support Release (ESR)* - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-25-esr>`__ - `Download <https://releases.mattermost.com/5.25.2/mattermost-team-5.25.2-linux-amd64.tar.gz?src=arc>`__
   - ``https://releases.mattermost.com/5.25.2/mattermost-team-5.25.2-linux-amd64.tar.gz``
   - SHA-256 Checksum: ``a3e6ccc5e45ca9cc540ea4cc13a68d6e61cf78530ac1d9a629029d4187838625``

--- a/source/overview/faq.rst
+++ b/source/overview/faq.rst
@@ -31,6 +31,13 @@ We have done performance testing of 60,000 concurrent users and 60 million posts
 
 Mattermost provides an open source, well-documented `load test simulator <https://github.com/mattermost/mattermost-load-test>`_ to verify that your Mattermost deployment can achieve the stated scale benchmarks ahead of production deployment.
 
+How do I deploy the open source Mattermost Team Edition under an MIT license?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The open source Mattermost Team Edition is functionally identical to the commercial Mattermost Enterprise Edition in its free “team mode”, but there is no ability to unlock enterprise features. It deploys as single Linux binary with MySQL or PostgreSQL under an MIT license.
+
+To deploy the Team Edition, download the `Mattermost Team Edition binary <https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive>`_, and follow our standard install guides. The same applies to server upgrades.
+
 Community Questions
 -------------------
 

--- a/source/overview/product.rst
+++ b/source/overview/product.rst
@@ -40,7 +40,7 @@ Features include:
 - New features and improvements released every two months
 - Multiple languages including U.S. English, Chinese (Simplified and Traditional), Dutch, French, German, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Romanian, Russian, Turkish, Spanish, and Ukrainian
 
-To get started, `download the open source Mattermost Team Edition server <https://about.mattermost.com/download>`__ under an MIT license.
+To get started, `download the open source Mattermost Team Edition server <https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive>`__ under an MIT license.
 
 Mattermost Enterprise Edition
 ----------------------------


### PR DESCRIPTION
Currently no documentation in place, and the removal of the TE link on the download page makes it harder to discover.

This adds an FAQ entry, with the intent that it's web discoverable and easily referenceable. Also added a brief description of the Team Edition link in the version archive.