### PR TITLE
Update upgrade.rst: References to TE

### DIFF
--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -5,11 +5,16 @@ In most cases you can upgrade Mattermost Server in a few minutes, but the upgrad
 
 .. important::
   Support for server `Extended Support Release <https://docs.mattermost.com/administration/extended-support-release.html>`_ (ESR) 5.19 is coming to the end of its lifecycle on October 15th, 2020. Upgrading to server v5.25 or later is highly recommended.
+  
+Upgrading Team Edition to Enterprise Edition
+--------------------------------------------
+
+To upgrade from the Team Edition to the Enterprise Edition, follow the normal upgrade instructions below, making sure that you download the Enterprise Edition in Step 3.
 
 Upgrading to the Latest Version
 -------------------------------
 
-If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version earlier than 3.0.0, you must first `upgrade to version 3.0.3 <../administration/upgrading-to-3.0.html>`__.
+If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version prioer to 3.0.0, you must first `upgrade to version 3.0.3 <../administration/upgrading-to-3.0.html>`__.
 
 .. _before-you-begin:
 
@@ -29,12 +34,12 @@ Existing install directory - *{install-path}*
   If you don't know where Mattermost Server is installed, use the ``whereis mattermost`` command. The output should be similar to */opt/mattermost/bin/mattermost*. The install directory is everything before the first occurrence of the string */mattermost*. In this example, the *{install-path}* is ``/opt``.
   If that command does not produce any results because your version is older, try ``whereis platform`` instead.
 Location of your local storage directory
-  The local storage directory contains all the files that users have attached to their messages. If you don't know its location, open the System Console and go to **Files > Storage** in prior versions or **Environment> File Storage** in versions after 5.12 and read the value in **Local Storage Directory**. Relative paths are relative to the ``mattermost`` directory. For example, if the local storage directory is ``./data/`` then the absolute path is ``{install-path}/mattermost/data``.
+  The local storage directory contains all the files that users have attached to their messages. If you don't know its location, open the System Console and go to **Environment> File Storage** (or **Files > Storage** in versions prior to 5.12) and read the value in **Local Storage Directory**. Relative paths are relative to the ``mattermost`` directory. For example, if the local storage directory is ``./data/`` then the absolute path is ``{install-path}/mattermost/data``.
 
 **To upgrade Mattermost Server**:
 
 .. note::
-  If you are upgrading an HA cluster, `review these upgrade notes instead <https://docs.mattermost.com/deployment/cluster.html#upgrade-guide>`__.
+  If you are upgrading a High Availability cluster, `review these upgrade notes instead <https://docs.mattermost.com/deployment/cluster.html#upgrade-guide>`__.
 
 #. Review the :doc:`important-upgrade-notes` to make sure you are aware of any actions you need to take before or after upgrading from your particular version.
 
@@ -58,7 +63,7 @@ Location of your local storage directory
   
    The ``transform`` option adds a suffix to the topmost extracted directory so it does not conflict with the usual install directory.
 
-#. Stop Mattermost Server.
+#. Stop your Mattermost server.
 
    On Ubuntu 14.04 and RHEL 6:
 
@@ -119,7 +124,7 @@ Location of your local storage directory
      cd {install-path}/mattermost
      sudo setcap cap_net_bind_service=+ep ./bin/mattermost
 
-#. Start Mattermost server.
+#. Start your Mattermost server.
 
    On Ubuntu 14.04 and RHEL 6:
 
@@ -135,7 +140,7 @@ Location of your local storage directory
 
 #. Upgrade your ``config.json`` schema:
 
-   #. Open the System Console and change a setting, then revert it. This should enable the Save button for that page.
+   #. Open the System Console and change a setting, then revert it. This will enable the **Save** button for that page.
    #. Click **Save**.
    #. Refresh the page.
 
@@ -143,9 +148,7 @@ Location of your local storage directory
 
 After the server is upgraded, users might need to refresh their browsers to experience any new features.
 
-Upgrading Team Edition to Enterprise Edition
---------------------------------------------
+Uploading a License Key
+--------------------------
 
-To upgrade from the Team Edition to the Enterprise Edition, follow the normal upgrade instructions above, but make sure that you download the Enterprise Edition in Step 3.
-
-After the Enterprise Edition is running, open the *System Console* and go to **OTHER > Edition and License > License Key** in prior versions or **System Console > About > Editions and License** in versions after 5.12 and upload your license key file.
+When Enterprise Edition is running, open **System Console > About > Editions and License** and upload your license key.

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -9,7 +9,8 @@ In most cases you can upgrade Mattermost Server in a few minutes, but the upgrad
 Upgrading to the Latest Version
 -------------------------------
 
-If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version prioer to 3.0.0, you must first `upgrade to version 3.0.3 <../administration/upgrading-to-3.0.html>`__.
+If you are upgrading from version 3.0 or later, these instructions apply to you. If you are upgrading from a version prior to 3.0.0, you must first `upgrade to version 3.0.3 <../administration/upgrading-to-3.0.html>`__.
+
 
 .. _before-you-begin:
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -30,7 +30,8 @@ Existing install directory - *{install-path}*
   If you don't know where Mattermost Server is installed, use the ``whereis mattermost`` command. The output should be similar to */opt/mattermost/bin/mattermost*. The install directory is everything before the first occurrence of the string */mattermost*. In this example, the *{install-path}* is ``/opt``.
   If that command does not produce any results because your version is older, try ``whereis platform`` instead.
 Location of your local storage directory
-  The local storage directory contains all the files that users have attached to their messages. If you don't know its location, open the System Console and go to **Environment> File Storage** (or **Files > Storage** in versions prior to 5.12) and read the value in **Local Storage Directory**. Relative paths are relative to the ``mattermost`` directory. For example, if the local storage directory is ``./data/`` then the absolute path is ``{install-path}/mattermost/data``.
+  The local storage directory contains all the files that users have attached to their messages. If you don't know its location, open the System Console and go to **Environment > File Storage** (or **Files > Storage** in versions prior to 5.12) and read the value in **Local Storage Directory**. Relative paths are relative to the ``mattermost`` directory. For example, if the local storage directory is ``./data/`` then the absolute path is ``{install-path}/mattermost/data``.
+
 
 **To upgrade Mattermost Server**:
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -5,11 +5,6 @@ In most cases you can upgrade Mattermost Server in a few minutes, but the upgrad
 
 .. important::
   Support for server `Extended Support Release <https://docs.mattermost.com/administration/extended-support-release.html>`_ (ESR) 5.19 is coming to the end of its lifecycle on October 15th, 2020. Upgrading to server v5.25 or later is highly recommended.
-  
-Upgrading Team Edition to Enterprise Edition
---------------------------------------------
-
-To upgrade from the Team Edition to the Enterprise Edition, follow the normal upgrade instructions below, making sure that you download the Enterprise Edition in Step 3.
 
 Upgrading to the Latest Version
 -------------------------------
@@ -147,6 +142,11 @@ Location of your local storage directory
    Your current settings are preserved, and new settings are added with default values.
 
 After the server is upgraded, users might need to refresh their browsers to experience any new features.
+
+Upgrading Team Edition to Enterprise Edition
+--------------------------------------------
+
+To upgrade from the Team Edition to the Enterprise Edition, follow the normal upgrade instructions provided above, making sure that you download the Enterprise Edition in Step 3.
 
 Uploading a License Key
 --------------------------


### PR DESCRIPTION
Updated wording around upgrading from TE to EE, in light of https://github.com/mattermost/docs/pull/3782 where the TE option was removed from step 3. Moved the section to higher in the doc for visibility (0/5 on that), and added "Uploading a License Key" as a separate section.