### PR TITLE
fix inline-images

### DIFF
--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -255,9 +255,9 @@ Inline image with hover text
 
   Renders as:
 
-  .. raw:: html
-
-    <img src="../../images/icon-76x76.png" alt="Mattermost" title="Mattermost Icon"></a>
+  .. image:: ../../images/icon-76x76.png
+    :alt: Mattermost
+    :name: Mattermost Icon
 
 Inline image with link
   Note the extra set of square brackets.
@@ -279,9 +279,9 @@ Inline image displayed at 50 pixels wide and 76 pixels high
 
   Renders as:
 
-  .. raw:: html
-
-    <img alt="Mattermost" src="../../images/icon-50x76.png" title="Mattermost Icon">
+  .. image:: ../../images/icon-50x76.png
+    :alt: Mattermost
+    :name: Mattermost Icon 
 
 Inline image displayed at 50 pixels wide and the height adjusted to suit
   .. code-block:: none
@@ -290,9 +290,10 @@ Inline image displayed at 50 pixels wide and the height adjusted to suit
 
   Renders as:
 
-  .. raw:: html
-
-    <img src="../../images/icon-76x76.png" alt="Mattermost" width="50px" title="Mattermost Icon"></a>
+  .. image:: ../../images/icon-76x76.png
+    :alt: Mattermost
+    :width: 50
+    
 
 Lines
 -----


### PR DESCRIPTION
<img width="495" alt="Screenshot 2020-08-05 at 6 28 02 PM" src="https://user-images.githubusercontent.com/39309699/89453696-8fa05f00-d757-11ea-9b7e-b3b080f46475.png">

I used the rst method for rendering the image and not use raw HTML.

The image showing in the screenshot uses the rst method for rendering the image