### PR TITLE
Update team-channel-management.rst

### DIFF
--- a/source/administration/telemetry.rst
+++ b/source/administration/telemetry.rst
@@ -78,7 +78,7 @@ Commercial License Information (Enterprise Edition Only)
 Channel Moderation Configuration Information (Enterprise Edition Only)
   Information related to channel moderation, including number of channel schemes, number of channels with posting messages disabled for users or guests, number of channels with emoji reactions disabled for users or guests, number of channels with managing members disabled, number of channels with channel mentions disabled for users or guests.
   
-Team and Channel Member Management Information (Enterprise Edition Only)
+Channel Member Management Information (Enterprise Edition Only)
   Information related to bulk user management and team and channel filtering, including number of users added, number of users removed, number of users promoted, number of users demoted, number of times archive and unarchive is used from any channel configuration page, and number of times channel search or team search filters are used.
 
 Groups Configuration Information (Enterprise Edition Only)

--- a/source/deployment/team-channel-management.rst
+++ b/source/deployment/team-channel-management.rst
@@ -1,7 +1,7 @@
 Managing Team and Channel Members (E20)
 =======================================
 
-System Admins can manage team and channel configuration in the System Console.
+System Admins can manage channel configuration in the System Console.
 
 - **Management:** Manage sync, moderation, and membership settings.
 - **Promoting/demoting Team and Channel Admins:** Team and Channel Admins can be demoted via the System Console.


### PR DESCRIPTION
@thefactremains You mentioned that team management didn't make it to v5.26? Then it has to be removed from the docs. Please review which sections need to be removed.