### PR TITLE
Clarify local mode prior 5.26

### DIFF
--- a/source/administration/mmctl-cli-tool.rst
+++ b/source/administration/mmctl-cli-tool.rst
@@ -105,7 +105,7 @@ To use local mode, the Mattermost server first needs to `have local mode enabled
 Using local mode
 ----------------
 
-You need to append --local to the command you want to use or you can set the enviroment variable ``MMCTL_LOCAL=true``.
+You need to append ``--local`` to the command you want to use or set the environment variable as ``MMCTL_LOCAL=true``.
 
 In versions prior to 5.26, only the commands ``config``, ``plugin`` and ``license`` are available.
 

--- a/source/administration/mmctl-cli-tool.rst
+++ b/source/administration/mmctl-cli-tool.rst
@@ -99,6 +99,8 @@ The API that the socket exposes follows the same specification that can be found
 
 To use local mode, the Mattermost server first needs to `have local mode enabled <https://docs.mattermost.com/administration/config-settings.html#enable-local-mode>`_. When local mode is enabled, a socket is created at ``/var/tmp/mattermost_local.socket`` by default.
 
+On version prior 5.26 only ``config``, ``plugin`` and ``license`` are available.
+
 Running the tests
 ------------------
 

--- a/source/administration/mmctl-cli-tool.rst
+++ b/source/administration/mmctl-cli-tool.rst
@@ -97,9 +97,17 @@ Local mode allows platform administrators with access to the Mattermost server t
 
 The API that the socket exposes follows the same specification that can be found `in the API documentation <https://api.mattermost.com>`_, so mmctl is able to interact with it without needing any modifications. When a request comes in through the socket, it is flagged as local by the server, and this flag is taken into account when checking for session permissions to correctly authorize the sessions.
 
+Activate local mode
+-------------------
+
 To use local mode, the Mattermost server first needs to `have local mode enabled <https://docs.mattermost.com/administration/config-settings.html#enable-local-mode>`_. When local mode is enabled, a socket is created at ``/var/tmp/mattermost_local.socket`` by default.
 
-On version prior 5.26 only ``config``, ``plugin`` and ``license`` are available.
+Using local mode
+----------------
+
+You need to append --local to the command you want to use or you can set the enviroment variable ``MMCTL_LOCAL=true``.
+
+In versions prior to 5.26, only the commands ``config``, ``plugin`` and ``license`` are available.
 
 Running the tests
 ------------------

--- a/source/administration/mmctl-cli-tool.rst
+++ b/source/administration/mmctl-cli-tool.rst
@@ -107,7 +107,7 @@ Using local mode
 
 You need to append ``--local`` to the command you want to use or set the environment variable as ``MMCTL_LOCAL=true``.
 
-In versions prior to 5.26, only the commands ``config``, ``plugin`` and ``license`` are available.
+In versions prior to 5.26, only the commands ``config``, ``plugin``, and ``license`` are available.
 
 Running the tests
 ------------------


### PR DESCRIPTION
see
https://community-daily.mattermost.com/core/pl/pkxofembijg3jkeondgekfdgwa

The mmctl before 5.26 doesn't support every command in local mode