### PR TITLE
Revert "[MM-25659] document config settings for permanent delete of channel"

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -4351,19 +4351,6 @@ mmctl local mode ignores this setting and behaves as though ``EnableAPITeamDelet
 | This feature's ``config.json`` setting is ``"EnableAPITeamDeletion": false`` with options ``true`` and ``false``.                                                    |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Enable API Channel Deletion
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-**True**: The ``api/v4/channels/{channelid}?permanent=true`` API endpoint can be called by System Admins, or users with appropriate permissions, to permanently delete a channel.
-
-**False**: The API endpoint cannot be called. Note that ``api/v4/channels/{channelid}`` can still be used to soft delete a channel.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableAPIChannelDeletion": false`` with options ``true`` and ``false``.                                                    |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-mmctl local mode ignores this setting and behaves as though ``EnableAPIChannelDeletion`` is set to ``true``.
-
 Enable OpenTracing
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Reverts mattermost/docs#3825; not intended to be merged yet.