### PR TITLE
Update italics formatting help to use asterisks

### DIFF
--- a/source/help/messaging/formatting-text.rst
+++ b/source/help/messaging/formatting-text.rst
@@ -22,9 +22,9 @@ Text Style
 
 You can use either ``_`` or ``*`` around a word to make it italic. Use two to make it bold.
 
-* ``_italics_`` renders as `italics`
+* ``*italics*`` (or ``_italics_``) renders as *italics*
 * ``**bold**`` renders as **bold**
-* ``**_bold-italic_**`` renders as |bold_italics|
+* ``***bold-italic***`` renders as |bold_italics|
 * ``~~strikethrough~~`` renders as |strikethrough|
 
 .. |bold_italics| image:: ../../images/bold_italics.PNG


### PR DESCRIPTION
See https://community.mattermost.com/core/pl/jn5a14oraffn7kk76hfy389qph for context.

One user didn't realize `*text*` italicizes it, and asterisks are used in other help docs more consistently, e.g. https://guides.github.com/features/mastering-markdown/.

`_italics_` kept as an alternative for italics.
