### PR TITLE
Fix incorrect 'install Mattermost server' section in Ubuntu 20.04LTS guide

### DIFF
--- a/source/install/install-ubuntu-2004.rst
+++ b/source/install/install-ubuntu-2004.rst
@@ -15,7 +15,7 @@ Install a production-ready Mattermost system on up to three machines.
 .. include:: install-ubuntu-2004-server.rst
 .. include:: install-ubuntu-2004-mysql.rst
 .. include:: install-ubuntu-2004-postgresql.rst
-.. include:: install-ubuntu-1804-mattermost.rst
+.. include:: install-ubuntu-1604-mattermost.rst
 .. include:: config-mattermost-server.rst
 .. include:: config-tls-mattermost.rst
 .. include:: install-nginx.rst


### PR DESCRIPTION
Thanks to @esadur for noticing!

@justinegeffen @svelle @amyblais I'm going to merge this after one review because someone going through the install guide won't successfully complete the installation. However, Amy/Sven/Justine I would ask each of you to verify that the doc I added is the correct one.

The doc section I added is the same one used for Ubuntu 16.04LTS and 18.04LTS guides: https://github.com/mattermost/docs/blob/master/source/install/install-ubuntu-1604-mattermost.rst