### PR TITLE
[MM-28630] Fixes mattermost version note and adds mmctl system version and status docs

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -54,10 +54,10 @@ To run the CLI commands, you must be in the Mattermost root directory. On a defa
 
 .. note::
   Ensure you run the Mattermost binary as the ``mattermost`` user. Running it as ``root`` user (for example) may cause complications with permissions as the binary initiates plugins and accesses various files when running CLI commands. Running the server as ``root`` may result in ownership of the plugins and files to be overwritten as well as other potential permissions errors.
-  
+
 .. note::
-When running CLI commands on a Mattermost installation that has the configuration stored in the database, you might need to pass the database connection string as follows: 
-``bin/mattermost --config="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable\u0026connect_timeout=10"`` 
+When running CLI commands on a Mattermost installation that has the configuration stored in the database, you might need to pass the database connection string as follows:
+``bin/mattermost --config="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable\u0026connect_timeout=10"``
 
 
 Using the CLI on GitLab Omnibus
@@ -653,7 +653,7 @@ mattermost config migrate
     .. code-block:: none
 
        bin/mattermost config migrate  path/to/config.json "postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
-       
+
 mattermost config reset
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -669,7 +669,7 @@ mattermost config reset
     .. code-block:: none
 
        bin/mattermost config reset SqlSettings.DriverName LogSettings
-       
+
    Options
     .. code-block:: none
 
@@ -2278,7 +2278,7 @@ mattermost version
 
 .. note::
 
-   This command will be replaced in a future release with the mmctl command `mmctl version <https://docs.mattermost.com/administration/mmctl-cli-tool.html#mmctl-version>`__.
+   This command will be replaced in a future release with the mmctl command `mmctl system version <https://docs.mattermost.com/administration/mmctl-cli-tool.html#mmctl-system-version>`__.
 
 
 Description

--- a/source/administration/mmctl-cli-tool.rst
+++ b/source/administration/mmctl-cli-tool.rst
@@ -122,7 +122,7 @@ Once the development server is set up, cd into the ``mattermost-server directory
 Change your directory to ``mmctl`` and run the end to end test suite with:
 
 .. code-block:: sh
-  
+
   make test-e2e
 
 Authenticating and logging in
@@ -494,13 +494,13 @@ Management of bots.
     -  `mmctl bot enable`_ - Enable a bot
     -  `mmctl bot list`_ - List all bots
     -  `mmctl bot update`_ - Update bot configuration
-    
+
 **Options**
 
 .. code-block:: sh
 
    -h, --help   help for bot
-   
+
 mmctl bot assign
 ^^^^^^^^^^^^^^^^^
 
@@ -570,7 +570,7 @@ mmctl bot create
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
-   
+
 mmctl bot disable
 ^^^^^^^^^^^^^^^^^
 
@@ -604,8 +604,8 @@ mmctl bot disable
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
-   
-   
+
+
 mmctl bot enable
 ^^^^^^^^^^^^^^^^^
 
@@ -639,7 +639,7 @@ mmctl bot enable
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
-   
+
 mmctl bot list
 ^^^^^^^^^^^^^^^^^
 
@@ -675,7 +675,7 @@ mmctl bot list
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
-   
+
 mmctl bot update
 ^^^^^^^^^^^^^^^^^
 
@@ -976,7 +976,7 @@ mmctl channel move
 
    -h, --help    help for move
    --force       Remove users that are not members of target team before moving the channel.
-   
+
 **Options inherited from parent commands**
 
 .. code-block:: sh
@@ -1141,13 +1141,13 @@ Management of slash commands.
     -  `mmctl command modify`_ - Modify a slash command
     -  `mmctl command move`_ - Move a slash command to a different team
     -  `mmctl command show`_ - Show a custom slash command
-    
+
 **Options**
 
 .. code-block:: sh
 
     -h, --help      help for command
-    
+
 mmctl command archive
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -1416,7 +1416,7 @@ Generates autocompletion scripts for bash and zsh.
   Child Commands
     -  `mmctl completion bash`_ - Edit the configuration settings
     -  `mmctl completion zsh`_ - Get the value of a configuration setting
-    
+
 **Options**
 
 .. code-block:: sh
@@ -1429,7 +1429,7 @@ mmctl completion bash
 **Description**
 
   Generates the bash autocompletion scripts.
-  
+
   To load completion, run
 
 .. code-block:: sh
@@ -1465,7 +1465,7 @@ mmctl completion zsh
 **Description**
 
   Generates the zsh autocompletion scripts.
-  
+
   To load completion, run
 
 .. code-block:: sh
@@ -2633,7 +2633,10 @@ Child Commands
   -  `mmctl system clearbusy`_ - Clears the busy state
   -  `mmctl system getbusy`_ - Get the current busy state
   -  `mmctl system setbusy`_ - Set the busy state to ``true``
-  
+  -  `mmctl system status`_ - Prints the status of the server
+  -  `mmctl system version`_ - Prints the remote server version
+
+
 **Options**
 
 .. code-block:: sh
@@ -2716,7 +2719,7 @@ mmctl system getbusy
     --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
     --local                        allows communicating with the server through a unix socket
     --strict                       will only run commands if the mmctl version matches the server one
-    
+
 mmctl system setbusy
 ^^^^^^^^^^^^^^^^^^
 
@@ -2742,6 +2745,74 @@ mmctl system setbusy
 
     -h, --help           help for setbusy
     -s, --seconds uint   Number of seconds until server is automatically marked as not busy (default 3600)
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+    --format string                the format of the command output [plain, json] (default "plain")
+    --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+    --local                        allows communicating with the server through a unix socket
+    --strict                       will only run commands if the mmctl version matches the server one
+
+mmctl system status
+^^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+ Prints the server status calculated using several basic server healthchecks.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl system status [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   system status
+
+**Options**
+
+.. code-block:: sh
+
+    -h, --help   help for status
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+    --format string                the format of the command output [plain, json] (default "plain")
+    --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+    --local                        allows communicating with the server through a unix socket
+    --strict                       will only run commands if the mmctl version matches the server one
+
+mmctl system version
+^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+ Prints the server version of the currently connected Mattermost instance.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl system version [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   system version
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for version
 
 **Options inherited from parent commands**
 
@@ -3180,7 +3251,7 @@ mmctl token generate
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
-   
+
 mmctl token list
 ^^^^^^^^^^^^^^^^^^
 
@@ -3209,7 +3280,7 @@ mmctl token list
    -h, --help       help for list
    --inactive       List only inactive tokens
    --page int       Page number to fetch for the list of users
-   --per-page int   Number of users to be fetched (default 200) 
+   --per-page int   Number of users to be fetched (default 200)
 
 **Options inherited from parent commands**
 
@@ -3219,7 +3290,7 @@ mmctl token list
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
-   
+
 mmctl token revoke
 ^^^^^^^^^^^^^^^^^^
 
@@ -3458,7 +3529,7 @@ mmctl user invite
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
-   
+
 mmctl user list
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
#### Summary
This PR adds the `mmctl system version` and `mmctl system status` docs and fixes the `mattermost version` note to point to `mmctl system version` instead of `mmctl version`. These two new commands will be added to `mmctl` on `v5.30`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28630

