### PR TITLE
Update postgres instructions to add trust for local ipv4 connections

### DIFF
--- a/source/install/install-debian-postgresql.rst
+++ b/source/install/install-debian-postgresql.rst
@@ -64,7 +64,7 @@ Assume that the IP address of this server is 10.10.10.1
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` as root in a text editor.
+    a. Open ``/etc/postgresql/9.4/main/pg_hba.conf`` as root in a text editor.
 
     b. Find the following lines:
 

--- a/source/install/install-debian-postgresql.rst
+++ b/source/install/install-debian-postgresql.rst
@@ -64,15 +64,19 @@ Assume that the IP address of this server is 10.10.10.1
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/etc/postgresql/9.4/main/pg_hba.conf`` as root in a text editor.
+    a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` as root in a text editor.
 
-    b. Find the following line:
+    b. Find the following lines:
 
       ``local   all             all                        peer``
+      
+      ``host    all             all         ::1/128        ident``
 
-    c. Change ``peer`` to ``trust``:
+    c. Change ``peer`` and ``ident`` to ``trust``:
 
       ``local   all             all                        trust``
+      
+      ``host    all             all         ::1/128        trust``
 
   **If the Mattermost server and the database are on different machines**:
 

--- a/source/install/install-rhel-7-postgresql.rst
+++ b/source/install/install-rhel-7-postgresql.rst
@@ -89,13 +89,17 @@ Installing PostgreSQL Database
 
     a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` as root in a text editor.
 
-    b. Find the following line:
+    b. Find the following lines:
 
       ``local   all             all                        peer``
+      
+      ``host    all             all         ::1/128        ident``
 
-    c. Change ``peer`` to ``trust``:
+    c. Change ``peer`` and ``ident`` to ``trust``:
 
       ``local   all             all                        trust``
+      
+      ``host    all             all         ::1/128        trust``
 
   **If the Mattermost server and the database are on different machines**:
 

--- a/source/install/install-rhel-8-postgresql.rst
+++ b/source/install/install-rhel-8-postgresql.rst
@@ -73,7 +73,7 @@ Installing PostgreSQL Database
 
   **If the Mattermost server and the database are on the same machine:**
 
-    a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` as root in a text editor.
+    a. Open ``/var/lib/pgsql/data/pg_hba.conf`` as root in a text editor.
 
     b. Find the following lines:
 

--- a/source/install/install-rhel-8-postgresql.rst
+++ b/source/install/install-rhel-8-postgresql.rst
@@ -73,15 +73,19 @@ Installing PostgreSQL Database
 
   **If the Mattermost server and the database are on the same machine:**
 
-    a. Open ``/var/lib/pgsql/data/pg_hba.conf`` as *root* in a text editor.
+    a. Open ``/var/lib/pgsql/9.4/data/pg_hba.conf`` as root in a text editor.
 
-    b. Find the following line:
+    b. Find the following lines:
 
       ``local   all             all                        peer``
+      
+      ``host    all             all         ::1/128        ident``
 
-    c. Change ``peer`` to ``trust``:
+    c. Change ``peer`` and ``ident`` to ``trust``:
 
       ``local   all             all                        trust``
+      
+      ``host    all             all         ::1/128        trust``
 
   **If the Mattermost server and the database are on different machines:**
 

--- a/source/install/install-ubuntu-1804-postgresql.rst
+++ b/source/install/install-ubuntu-1804-postgresql.rst
@@ -64,15 +64,19 @@ Assume that the IP address of this server is 10.10.10.1.
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/etc/postgresql/10/main/pg_hba.conf`` as root in a text editor.
+    a. Open ``/var/lib/pgsql/10/data/pg_hba.conf`` as root in a text editor.
 
-    b. Find the following line:
+    b. Find the following lines:
 
       ``local   all             all                        peer``
+      
+      ``host    all             all         ::1/128        ident``
 
-    c. Change ``peer`` to ``trust``:
+    c. Change ``peer`` and ``ident`` to ``trust``:
 
       ``local   all             all                        trust``
+      
+      ``host    all             all         ::1/128        trust``
 
   **If the Mattermost server and the database are on different machines**:
 

--- a/source/install/install-ubuntu-1804-postgresql.rst
+++ b/source/install/install-ubuntu-1804-postgresql.rst
@@ -64,7 +64,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/var/lib/pgsql/10/main/pg_hba.conf`` as root in a text editor.
+    a. Open ``/etc/postgresql/10/main/pg_hba.conf`` as root in a text editor.
 
     b. Find the following lines:
 

--- a/source/install/install-ubuntu-1804-postgresql.rst
+++ b/source/install/install-ubuntu-1804-postgresql.rst
@@ -64,7 +64,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/var/lib/pgsql/10/data/pg_hba.conf`` as root in a text editor.
+    a. Open ``/var/lib/pgsql/10/main/pg_hba.conf`` as root in a text editor.
 
     b. Find the following lines:
 

--- a/source/install/install-ubuntu-2004-postgresql.rst
+++ b/source/install/install-ubuntu-2004-postgresql.rst
@@ -65,7 +65,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/var/lib/pgsql/10/main/pg_hba.conf`` as root in a text editor.
+    a. Open ``/etc/postgresql/10/main/pg_hba.conf`` as root in a text editor.
 
     b. Find the following lines:
 

--- a/source/install/install-ubuntu-2004-postgresql.rst
+++ b/source/install/install-ubuntu-2004-postgresql.rst
@@ -65,7 +65,7 @@ Assume that the IP address of this server is 10.10.10.1.
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/etc/postgresql/10/main/pg_hba.conf`` as root in a text editor.
+    a. Open ``/etc/postgresql/10/main/pg_hba.conf`` as *root* in a text editor.
 
     b. Find the following lines:
 

--- a/source/install/install-ubuntu-2004-postgresql.rst
+++ b/source/install/install-ubuntu-2004-postgresql.rst
@@ -65,15 +65,19 @@ Assume that the IP address of this server is 10.10.10.1.
 
   **If the Mattermost server and the database are on the same machine**:
 
-    a. Open ``/etc/postgresql/10/main/pg_hba.conf`` in a text editor as *root* user.
+    a. Open ``/var/lib/pgsql/10/main/pg_hba.conf`` as root in a text editor.
 
-    b. Find the following line:
+    b. Find the following lines:
 
       ``local   all             all                        peer``
+      
+      ``host    all             all         ::1/128        ident``
 
-    c. Change ``peer`` to ``trust``:
+    c. Change ``peer`` and ``ident`` to ``trust``:
 
       ``local   all             all                        trust``
+      
+      ``host    all             all         ::1/128        trust``
 
   **If the Mattermost server and the database are on different machines:**
 


### PR DESCRIPTION
Previously we only had the postgres trust connection change made for local socket connections. 
However on almost all of the systems postgres may also very well connect through ipv4 when  for example using localhost as the domain. This adds an additional line of change to the `pg_hba.conf` to make that connection possible. 
From a security standpoint not much should change since it's still only for local connections.
