### PR TITLE
docs : Added note about DB performance to LDAP

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -2600,6 +2600,9 @@ When accounts are disabled in AD/LDAP users are made inactive in Mattermost, and
 | This feature's ``config.json`` setting is ``"SyncIntervalMinutes": 60`` with numerical input.                                                                        |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. note::
+  Because LDAP syncs cause a large number of database read queries you should monitor database load during a sync to determine how often these syncs should happen in your environment.
+
 Maximum Page Size
 ^^^^^^^^^^^^^^^^^^
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -2601,7 +2601,7 @@ When accounts are disabled in AD/LDAP users are made inactive in Mattermost, and
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. note::
-  Because LDAP syncs cause a large number of database read queries you should monitor database load during a sync to determine how often these syncs should happen in your environment.
+  LDAP syncs cause a large number of database read queries. Ensure that you monitor database load during a sync to determine how often these syncs should happen in your environment in order to minimize performance degradation.
 
 Maximum Page Size
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
* This PR adds a note section to the [LDAP Sync Interval configuration docs](https://docs.mattermost.com/administration/config-settings.html#synchronization-interval-minutes) so that customers can know regarding the database performance while LDAP Synchronization happens.
* Changes have been made under `source/administration/config-settings.rst`
* Please find the updated file [here](https://github.com/yash2189/docs/blob/MM-3630/source/administration/config-settings.rst)
#### Ticket Link #3630 
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

