### PR TITLE
Ensure DB encoding is UTF-8

### DIFF
--- a/source/install/install-rhel-7-postgresql.rst
+++ b/source/install/install-rhel-7-postgresql.rst
@@ -44,9 +44,9 @@ Installing PostgreSQL Database
 
   ``psql``
 
-10.  Create the Mattermost database.
+10.  Create the Mattermost database with UTF-8 encoding.
 
-  ``postgres=# CREATE DATABASE mattermost;``
+  ``postgres=# CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;``
 
 11.  Create the Mattermost user 'mmuser'.
 

--- a/source/install/install-rhel-7-postgresql.rst
+++ b/source/install/install-rhel-7-postgresql.rst
@@ -44,7 +44,7 @@ Installing PostgreSQL Database
 
   ``psql``
 
-10.  Create the Mattermost database with UTF-8 encoding.
+10.  Create the Mattermost database.
 
   ``postgres=# CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;``
 

--- a/source/install/install-rhel-8-postgresql.rst
+++ b/source/install/install-rhel-8-postgresql.rst
@@ -30,9 +30,9 @@ Installing PostgreSQL Database
 
   ``psql``
 
-8.  Create the Mattermost database.
+8.  Create the Mattermost database with UTF-8 encoding.
 
-  ``postgres=# CREATE DATABASE mattermost;``
+  ``postgres=# CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;``
 
 9.  Create the Mattermost user *mmuser*.
 

--- a/source/install/install-rhel-8-postgresql.rst
+++ b/source/install/install-rhel-8-postgresql.rst
@@ -30,7 +30,7 @@ Installing PostgreSQL Database
 
   ``psql``
 
-8.  Create the Mattermost database with UTF-8 encoding.
+8.  Create the Mattermost database with.
 
   ``postgres=# CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;``
 

--- a/source/install/install-rhel-8-postgresql.rst
+++ b/source/install/install-rhel-8-postgresql.rst
@@ -30,7 +30,7 @@ Installing PostgreSQL Database
 
   ``psql``
 
-8.  Create the Mattermost database with.
+8.  Create the Mattermost database.
 
   ``postgres=# CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;``
 


### PR DESCRIPTION

#### Summary

The default PostgreSQL DB encoding depends on the shell locale set at initialization time. 
As Mattermost might not work with other encodings, create the DB by setting the UTF-8 encoding explicitly.

#### Ticket Link

More details here:

- https://github.com/mattermost/docs/issues/3943
- https://github.com/NethServer/nethserver-mattermost/pull/56
