### PR TITLE
Adds print media to resolve truncated printed pages

### DIFF
--- a/source/theme.css
+++ b/source/theme.css
@@ -571,3 +571,31 @@ header .header__searchbar {
       overflow: visible !important;
    }
 }
+
+@media print {
+	body,
+	div.wy-grid-for-nav,
+	section.wy-nav-content-wrap {
+		height: auto;
+	}
+
+	body {
+		overflow: visible;
+	}
+
+	section.wy-nav-content-wrap {
+		margin-left: 0px;
+	}
+
+	header {
+		position: absolute;
+	}
+
+	.header__container > :not(.header__logo) {
+		display: none;
+	}
+
+	div.c-thermometer__trigger {
+		display: none;
+	}
+}


### PR DESCRIPTION
#### Summary

This pull request resolves the issue referenced in #2733 

This issue affects most pages, if not all, since there seems to be a design change since then. 

The css template just needed a print media in order to fix the printed page look. In order to make things look better though, I kept only the Mattermost logo, and the page's content.

Before:

![image](https://user-images.githubusercontent.com/5631091/97580168-0621c580-1a04-11eb-9611-9afb2dfcb0b1.png)

After:

![image](https://user-images.githubusercontent.com/5631091/97580187-0a4de300-1a04-11eb-8612-e1eda4ac0678.png)

> ###### [Printed PDF page in case you just want to preview the result](https://github.com/mattermost/docs/files/5458653/Product.Overview.Mattermost.5.28.documentation.pdf)



#### Ticket Link

Fixes https://github.com/mattermost/docs/issues/2733
