### PR TITLE
Clarified retaining files between Mattermost upgrades.

### DIFF
--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -84,6 +84,8 @@ Location of your local storage directory
    The special directories within mattermost are ``config``, ``logs``, ``plugins``, ``client/plugins``, and ``data`` (unless you have a different value configured for local storage, as per *Before you begin*). The following command clears the contents of mattermost, preserving only those directories and their contents.
    You should first modify the last part to ``xargs echo rm -r`` to verify what will be executed.
 
+   If you store TLSCert/TLSKey files or other information within your `/opt/mattermost` folder you will want to add `-o -path mattermost/yourFolderHere` to the below command or you will have to manually copy the from the backup into the new install.
+
    .. code-block:: sh
 
      sudo find mattermost/ mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/client -o -path mattermost/client/plugins -o -path mattermost/config -o -path mattermost/logs -o -path mattermost/plugins -o -path mattermost/data \) -prune \) | sort | sudo xargs rm -r

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -84,7 +84,7 @@ Location of your local storage directory
    The special directories within mattermost are ``config``, ``logs``, ``plugins``, ``client/plugins``, and ``data`` (unless you have a different value configured for local storage, as per *Before you begin*). The following command clears the contents of mattermost, preserving only those directories and their contents.
    You should first modify the last part to ``xargs echo rm -r`` to verify what will be executed.
 
-   If you store TLSCert/TLSKey files or other information within your ``/opt/mattermost`` folder, you should add ``-o -path mattermost/yourFolderHere`` to the below command or you will have to manually copy the from the backup into the new install.
+   If you store TLSCert/TLSKey files or other information within your ``/opt/mattermost`` folder, you should add ``-o -path mattermost/yourFolderHere`` to the below command or you will have to manually copy the your TLSCert/TLSKey files from the backup into the new install.
 
    .. code-block:: sh
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -84,7 +84,7 @@ Location of your local storage directory
    The special directories within mattermost are ``config``, ``logs``, ``plugins``, ``client/plugins``, and ``data`` (unless you have a different value configured for local storage, as per *Before you begin*). The following command clears the contents of mattermost, preserving only those directories and their contents.
    You should first modify the last part to ``xargs echo rm -r`` to verify what will be executed.
 
-   If you store TLSCert/TLSKey files or other information within your ``/opt/mattermost`` folder, you should add ``-o -path mattermost/yourFolderHere`` to the below command or you will have to manually copy the your TLSCert/TLSKey files from the backup into the new install.
+   If you store TLSCert/TLSKey files or other information within your ``/opt/mattermost`` folder, you should add ``-o -path mattermost/yourFolderHere`` to the below command or you will have to manually copy the TLSCert/TLSKey files from the backup into the new install.
 
    .. code-block:: sh
 

--- a/source/administration/upgrade.rst
+++ b/source/administration/upgrade.rst
@@ -84,7 +84,7 @@ Location of your local storage directory
    The special directories within mattermost are ``config``, ``logs``, ``plugins``, ``client/plugins``, and ``data`` (unless you have a different value configured for local storage, as per *Before you begin*). The following command clears the contents of mattermost, preserving only those directories and their contents.
    You should first modify the last part to ``xargs echo rm -r`` to verify what will be executed.
 
-   If you store TLSCert/TLSKey files or other information within your `/opt/mattermost` folder you will want to add `-o -path mattermost/yourFolderHere` to the below command or you will have to manually copy the from the backup into the new install.
+   If you store TLSCert/TLSKey files or other information within your ``/opt/mattermost`` folder, you should add ``-o -path mattermost/yourFolderHere`` to the below command or you will have to manually copy the from the backup into the new install.
 
    .. code-block:: sh
 


### PR DESCRIPTION
Added an additional line to Step 7 of the upgrade. If you don't persist Key/Cert files that are specified within your config.json file Mattermost will fail to start

