### PR TITLE
MM-30090 Add documentation for ManagedResourcePaths setting

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -296,6 +296,17 @@ Enable Insecure Outgoing Connections
 | This feature's ``config.json`` setting is ``"EnableInsecureOutgoingConnections": false`` with options ``true`` and ``false``.                                        |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+Managed Resource Paths
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A comma-separated list of paths within the Mattermost domain that are managed by a third party service instead of Mattermost itself. Links to these paths will be opened in a new tab/window by Mattermost apps. For example, if Mattermost is running on ``"https://mymattermost.com"``, setting this setting to ``"conference"`` will cause links such as ``"https://mymattermost.com/conference"`` to be opened in a new window.
+
+When using the Mattermost Desktop App, additional configuration is required to open the link within the Desktop App instead of in a browser. See `here <https://docs.mattermost.com/install/desktop-managed-resources.html>` for more information.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ManagedResourcePaths": ""`` with string input.                                        |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
 Reload Configuration from Disk
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -301,7 +301,7 @@ Managed Resource Paths
 
 A comma-separated list of paths within the Mattermost domain that are managed by a third party service instead of Mattermost itself. Links to these paths will be opened in a new tab/window by Mattermost apps. For example, if Mattermost is running on ``"https://mymattermost.com"``, setting this setting to ``"conference"`` will cause links such as ``"https://mymattermost.com/conference"`` to be opened in a new window.
 
-When using the Mattermost Desktop App, additional configuration is required to open the link within the Desktop App instead of in a browser. See `here <https://docs.mattermost.com/install/desktop-managed-resources.html>` for more information.
+When using the Mattermost Desktop App, additional configuration is required to open the link within the Desktop App instead of in a browser. See `here <https://docs.mattermost.com/install/desktop-managed-resources.html>`_ for more information.
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"ManagedResourcePaths": ""`` with string input.                                        |

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -304,7 +304,7 @@ A comma-separated list of paths within the Mattermost domain that are managed by
 When using the Mattermost Desktop App, additional configuration is required to open the link within the Desktop App instead of in a browser. See `here <https://docs.mattermost.com/install/desktop-managed-resources.html>`_ for more information.
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ManagedResourcePaths": ""`` with string input.                                        |
+| This feature's ``config.json`` setting is ``"ManagedResourcePaths": ""`` with string input.                                                                          |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Reload Configuration from Disk

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -299,7 +299,7 @@ Enable Insecure Outgoing Connections
 Managed Resource Paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A comma-separated list of paths within the Mattermost domain that are managed by a third party service instead of Mattermost itself. Links to these paths will be opened in a new tab/window by Mattermost apps. For example, if Mattermost is running on ``"https://mymattermost.com"``, setting this setting to ``"conference"`` will cause links such as ``"https://mymattermost.com/conference"`` to be opened in a new window.
+A comma-separated list of paths within the Mattermost domain that are managed by a third party service instead of Mattermost itself. Links to these paths will be opened in a new tab/window by Mattermost apps. For example, if Mattermost is running on ``https://mymattermost.com``, setting this to ``conference`` will cause links such as ``https://mymattermost.com/conference`` to be opened in a new window.
 
 When using the Mattermost Desktop App, additional configuration is required to open the link within the Desktop App instead of in a browser. See `here <https://docs.mattermost.com/install/desktop-managed-resources.html>`_ for more information.
 

--- a/source/install/desktop-managed-resources.rst
+++ b/source/install/desktop-managed-resources.rst
@@ -9,6 +9,8 @@ The Mattermost Desktop App supports managed resources. A managed resource can be
 
 Add the path of a managed resource to your configuration file. When selected, it opens as a pop-up window in the Mattermost Desktop app.
 
+In addition to customizing the Mattermost Desktop App, the `Managed Resource Paths <https://docs.mattermost.com/administration/config-settings.html#managed-resource-paths>` setting on the Mattermost server must be configured.
+
 In the below example we add the managed resource ``/video``.
 
 .. code-block:: json

--- a/source/install/desktop-managed-resources.rst
+++ b/source/install/desktop-managed-resources.rst
@@ -9,7 +9,7 @@ The Mattermost Desktop App supports managed resources. A managed resource can be
 
 Add the path of a managed resource to your configuration file. When selected, it opens as a pop-up window in the Mattermost Desktop app.
 
-In addition to customizing the Mattermost Desktop App, the `Managed Resource Paths <https://docs.mattermost.com/administration/config-settings.html#managed-resource-paths>` setting on the Mattermost server must be configured.
+In addition to customizing the Mattermost Desktop App, the `Managed Resource Paths <https://docs.mattermost.com/administration/config-settings.html#managed-resource-paths>`_ setting on the Mattermost server must be configured.
 
 In the below example we add the managed resource ``/video``.
 


### PR DESCRIPTION
Due to some changes in 5.28 around the internal/external link handling in the web app, we broke the newly added [Desktop Managed Resources](https://docs.mattermost.com/install/desktop-managed-resources.html) feature which basically lets non-MM services host stuff at certain routes under the MM server.

Since most paths in the server could be a team URL, the new link handling is correct for anyone not using that feature, so instead of reverting the link handling changes, we're adding a way to the server to manually specify these paths that should not be handled by the web app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30090

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/16213
https://github.com/mattermost/mattermost-redux/pull/1282
https://github.com/mattermost/mattermost-webapp/pull/7024
