### PR TITLE
Correct pronoun usage in Omnibus install instructions

### DIFF
--- a/source/install/mattermost-omnibus.rst
+++ b/source/install/mattermost-omnibus.rst
@@ -31,7 +31,7 @@ If you're installing Omnibus, and have a domain and SSL use:
 
 ``sudo apt install mattermost-omnibus -y``
 
-In order to issue that certificate, the installer requests a domain name and an email address from us. These are used to generate the certificate and deliver any related communications respectively.
+In order to issue that certificate, the installer requests a domain name and an email address from you. These are used to generate the certificate and deliver any related communications respectively.
 
 After all the packages are installed, Omnibus runs the ansible scripts that configure all the platform components and starts the server. To access Mattermost, open a browser, navigate to your domain, and create the System Admin user to start using the platform.
 


### PR DESCRIPTION
#### Summary
FQDN and email are requested from the end-user installing Omnibus, not from Mattermost.

When read by the end-user, "us" refers to Mattermost, the owner of the help document. The installer does not request the FQDN "from Mattermost", it requests it from the end-user.

#### Ticket Link
N/A
