### PR TITLE
Update important-upgrade-notes.rst

### DIFF
--- a/source/administration/important-upgrade-notes.rst
+++ b/source/administration/important-upgrade-notes.rst
@@ -2,7 +2,7 @@ Important Upgrade Notes
 =======================
 
 .. important::
-   PostgreSQL ended long-term support for `version 9.4 in February 2020 <https://www.postgresql.org/support/versioning>`_. Mattermost is officially supporting PostgreSQL version 10 with v5.26 release as PostgreSQL 9.4 is no longer supported. New installs will require PostgreSQL 10+. Previous Mattermost versions, including our current ESR, will continue to be compatible with PostgreSQL 9.4. We plan on fully deprecating PostgreSQL 9.4 and all 9.x versions in our v5.30 release (December 16). Please follow the instructions under the Upgrading Section within `the PostgreSQL documentation <https://www.postgresql.org/support/versioning/>`_.
+   PostgreSQL ended long-term support for `version 9.4 in February 2020 <https://www.postgresql.org/support/versioning>`_. Mattermost is officially supporting PostgreSQL version 10 with v5.26 release as PostgreSQL 9.4 is no longer supported. New installs will require PostgreSQL 10+. Previous Mattermost versions, including our current ESR, will continue to be compatible with PostgreSQL 9.4. PostgreSQL 9.4 and all 9.x versions are now fully deprecated in our v5.30 release (December 16). Please follow the instructions under the Upgrading Section within `the PostgreSQL documentation <https://www.postgresql.org/support/versioning/>`_.
    
 .. important::
    Support for Mattermost Server v5.19 `Extended Support Release <https://docs.mattermost.com/administration/extended-support-release.html>`_ has come to the end of its lifecycle. Upgrading to v5.25 or later is required.


### PR DESCRIPTION
For Postgres v9.4 deprecation, will also add to the changelog.