### PR TITLE
`config migrate` and EnvVars warnings

### DIFF
--- a/source/administration/config-in-database.rst
+++ b/source/administration/config-in-database.rst
@@ -153,6 +153,9 @@ The command to migrate the config to the database should always be run as the *m
    cd /opt/mattermost
    bin/mattermost config migrate ./config/config.json 'mysql://mmuser:mostest@tcp(127.0.0.1:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s'
 
+.. warning::
+   When migrating config, Mattermost will incorporate configuration from any existing ``MM_*`` environment variables set in the current shell.  See `Environment Variables  <https://docs.mattermost.com/administration/config-settings.html#configuration-settings>`_
+   
 As with the environment file you'll have to escape any single quotes in the database connection string. Also, any existing SAML certificates will be migrated into the database as well so they are available for all servers in the cluster.
 
 With configuration in the database enabled, any changes to the configuration are recorded to the ``Configurations`` and ``ConfigurationFiles`` tables. Furthermore, ``ClusterSettings.ReadOnlyConfig`` is ignored, enabling full use of the System Console.

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -32,7 +32,7 @@ For any setting that is not set in ``config.json`` or in environment variables, 
    If a setting is set through an environment variable and any other changes are made in the System Console, the value stored of the environment variable will be written back to the ``config.json`` as that setting's value.
 
 .. warning::
-   Environment variables for Mattermost settings that are set within the active shell will take effect when migrating configuration `Configuration In Database <https://docs.mattermost.com/administration/config-in-database.html>`_
+   Environment variables for Mattermost settings that are set within the active shell will take effect when migrating configuration. For more information, see `Configuration In Database <https://docs.mattermost.com/administration/config-in-database.html>`_.
    
 .. warning::
    Database connection strings for the database read and search replicas need to be formatted using `URL encoding <https://www.w3schools.com/tags/ref_urlencode.asp>`__. Incorrectly formatted strings may cause some characters to terminate the string early, resulting in issues when the connection string is parsed.

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -32,6 +32,9 @@ For any setting that is not set in ``config.json`` or in environment variables, 
    If a setting is set through an environment variable and any other changes are made in the System Console, the value stored of the environment variable will be written back to the ``config.json`` as that setting's value.
 
 .. warning::
+   Environment variables for Mattermost settings that are set within the active shell will take effect when migrating configuration `Configuration In Database <https://docs.mattermost.com/administration/config-in-database.html>`_
+   
+.. warning::
    Database connection strings for the database read and search replicas need to be formatted using `URL encoding <https://www.w3schools.com/tags/ref_urlencode.asp>`__. Incorrectly formatted strings may cause some characters to terminate the string early, resulting in issues when the connection string is parsed.
 
 .. contents::


### PR DESCRIPTION
We encountered an issue with a customer who leverages a number of different environment variables to help them customize their different environments (DEV/STAGING/PRODUCTION, Primary Site versus Disaster Recovery Site).

**LONG** story short:
1. Customer was trying to update their SAML related certs and keys.
2. They typically ingest the new certs using our [config migrate](https://docs.mattermost.com/administration/config-in-database.html#migrate-configuration-from-config-json) CLI command
3. During the course of _another_ **LONG** story, the environment variables for the certs were changed to match the hard-coded file names we leverage when these certs are uploaded through the System Console (see [this PR](https://github.com/mattermost/mattermost-server/pull/10341))
4.  When we ran the `config migrate` command we were not seeing the new certs in the `ConfigurationFiles` table, and we were not seeing the active config in the `Configurations` table updated with the new file name.  This was a big head scratcher.
5.  As it turns out, we were running the CLI `config migrate` with the full set of environment variables they use when running MM service.
6.  From testing it looks like the `config migrate` was honouring those environment variables (which makes sense in hindsight, but was an issue for us at the time)

I'd like to add some clear callouts on this into our docs below:

https://docs.mattermost.com/administration/config-settings.html

https://docs.mattermost.com/administration/config-in-database.html

