### PR TITLE
Replace embedded scripts with google tag manager

### DIFF
--- a/source/404.html
+++ b/source/404.html
@@ -19,8 +19,19 @@
     }
 
   </style>
+  <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K874RWM');</script>
+  <!-- End Google Tag Manager -->
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K874RWM"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <header>
     <a href="https://docs.mattermost.com/" class="header__logo">
       <img width="176" src="https://about.mattermost.com/wp-content/uploads/2017/03/headerlogo.svg" alt="Mattermost Logo">

--- a/source/templates/layout-notoc.html
+++ b/source/templates/layout-notoc.html
@@ -68,67 +68,15 @@
     {%- endif %}
   {%- endblock %}
   {%- block extrahead %}
-    <!-- Bizible Script -->
-    <script src="//cdn.bizible.com/scripts/bizible.js" async=""></script>
 
-    {% if googleanalytics_enabled %}
-      <!-- Google Analytics -->
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K874RWM');</script>
+    <!-- End Google Tag Manager -->
 
-        ga('create', '{{ googleanalytics_id }}', 'auto');
-        ga('send', 'pageview');
-      </script>
-      <!-- End Google Analytics -->
-    {% endif %}
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-67846571-1"></script>
-    <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'UA-67846571-1');
-    </script>
-  
-  	<!-- Global site tag (gtag.js) - Google Analytics -->
-  	<!-- Second Google Analytics tag to assist mapping with mattermost.com visits --> 
-  	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-120238482-1"></script>
-  	<script>
-  	  window.dataLayer = window.dataLayer || [];
-  	  function gtag(){dataLayer.push(arguments);}
-  	  gtag('js', new Date());
-
-  	  gtag('config', 'UA-120238482-1');
-  	</script>
-
-    <!-- Munchkin code -->
-    <script type="text/javascript">
-      (function() {
-        var didInit = false;
-        function initMunchkin() {
-          if(didInit === false) {
-            didInit = true;
-            Munchkin.init('161-FBE-733');
-          }
-        }
-        var s = document.createElement('script');
-        s.type = 'text/javascript';
-        s.async = true;
-        s.src = '//munchkin.marketo.net/munchkin.js';
-        s.onreadystatechange = function() {
-          if (this.readyState == 'complete' || this.readyState == 'loaded') {
-            initMunchkin();
-          }
-        };
-        s.onload = initMunchkin;
-        document.getElementsByTagName('head')[0].appendChild(s);
-      })();
-    </script>
   {% endblock %}
 
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
@@ -153,6 +101,11 @@
 </head>
 
 <body class="wy-body-for-nav" role="document">
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K874RWM"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
   {% block menu %} {% endblock %}
   {% block extrabody %} {% endblock %}

--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -19,75 +19,11 @@
 {% endblock %}
 
 {% block extrahead %}
-	<!-- Bizible Script -->
-	<script src="//cdn.bizible.com/scripts/bizible.js" async=""></script>
-
-	{% if googleanalytics_enabled %}
-		<!-- Google Analytics -->
-		<script>
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-			ga('create', '{{ googleanalytics_id }}', 'auto');
-			ga('send', 'pageview');
-		</script>
-		<!-- End Google Analytics -->
-	{% endif %}
-
-	<!-- Global site tag (gtag.js) - Google Analytics -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-67846571-1"></script>
-	<script>
-	window.dataLayer = window.dataLayer || [];
-	function gtag(){dataLayer.push(arguments);}
-	gtag('js', new Date());
-
-	gtag('config', 'UA-67846571-1');
-	</script>
-
-	<!-- Global site tag (gtag.js) - Google Analytics -->
-	<!-- Second Google Analytics tag to assist mapping with mattermost.com visits --> 
-	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-120238482-1"></script>
-	<script>
-	  window.dataLayer = window.dataLayer || [];
-	  function gtag(){dataLayer.push(arguments);}
-	  gtag('js', new Date());
-
-	  gtag('config', 'UA-120238482-1');
-	</script>
-
-	<!-- LeadLander -->
-	<script type="text/javascript" language="javascript">
-		var sf14gv = 31865;
-		(function() {
-			var sf14g = document.createElement('script');
-			sf14g.src = 'https://tracking.leadlander.com/lt.min.js';
-			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sf14g, s);
-		})();
-	</script>
-
-	<!-- Munchkin code -->
-	<script type="text/javascript">
-		(function() {
-			var didInit = false;
-			function initMunchkin() {
-			if(didInit === false) {
-				didInit = true;
-				Munchkin.init('161-FBE-733');
-			}
-			}
-			var s = document.createElement('script');
-			s.type = 'text/javascript';
-			s.async = true;
-			s.src = '//munchkin.marketo.net/munchkin.js';
-			s.onreadystatechange = function() {
-			if (this.readyState == 'complete' || this.readyState == 'loaded') {
-				initMunchkin();
-			}
-			};
-			s.onload = initMunchkin;
-			document.getElementsByTagName('head')[0].appendChild(s);
-		})();
-	</script>
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','dataLayer','GTM-K874RWM');</script>
+	<!-- End Google Tag Manager -->
 {% endblock %}


### PR DESCRIPTION
#### Summary
As requested by SEO team, all 3rd-party javascript snippets that were previously embedded within the application have been transferred to a GTM container. The scripts were replaced with the GTM snippet and tested locally to ensure they were firing as intended.

Note: The `conf.py` setting `html_context.googleanalytics_enabled` was being used as a condition for only one of the three Analytics tracking snippets. A sitewide search yielded no results for this setting being modified within the app itself. It's possible that this setting can be removed, or it could be that the setting is adjusted during a deployment process. Recommending that a reviewer spot-check this. We may need to add conditional triggers in GTM to move this properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MAR-93
