### PR TITLE
MM-28882 Add config to Ignore Guests on AD/LDAP Sync

### DIFF
--- a/source/deployment/sso-saml-ldapsync.rst
+++ b/source/deployment/sso-saml-ldapsync.rst
@@ -9,8 +9,9 @@ In addition to configuring SAML sign-in, you can optionally configure synchroniz
 To configure SAML synchronization with AD/LDAP:
 
 1. Go to **System Console > Authentication > SAML 2.0** (or **System Console > SAML** in versions prior to 5.12) and set **Enable Synchronizing SAML Accounts With AD/LDAP** to ``true``.
-2. Go to  **System Console > Authentication > SAML 2.0** and set **Ignore Guest Users when Synchronizing with AD/LDAP** to ``true`` or ``false``. 
-3. Set the rest of the AD/LDAP settings based on `configuration settings documentation <http://docs.mattermost.com/administration/config-settings.html#ad-ldap>`__ to connect Mattermost with your AD/LDAP server.
+2. Go to  **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and set **Enable Synchronization with AD/LDAP** to ``true``.
+3. To ignore guest users when sychronizing, go to **System Console > Authentication > SAML 2.0** and set **Ignore Guest Users when Synchronizing with AD/LDAP** to ``true``. 
+4. Set the rest of the AD/LDAP settings based on `configuration settings documentation <http://docs.mattermost.com/administration/config-settings.html#ad-ldap>`__ to connect Mattermost with your AD/LDAP server.
 
  - If you don't want to enable AD/LDAP sign-in, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and keep **Enable sign-in with AD/LDAP** as ``false``.
 

--- a/source/deployment/sso-saml-ldapsync.rst
+++ b/source/deployment/sso-saml-ldapsync.rst
@@ -15,7 +15,7 @@ To configure SAML synchronization with AD/LDAP:
  - If you don't want to enable AD/LDAP sign-in, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and keep **Enable sign-in with AD/LDAP** as ``false``.
 
 4. To specify how often Mattermost synchronizes SAML user accounts with AD/LDAP, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and set **Synchronization Interval**. The default setting is 60 minutes. If you want to synchronize immediately after disabling an account, click **AD/LDAP Synchronize Now**.
-5. To test Mattermost can successfully connect to your AD/LDAP server, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and click the **AD/LDAP Test** button.
+5. To confirm that Mattermost can successfully connect to your AD/LDAP server, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and select **AD/LDAP Test**.
 
 Once the synchronization with AD/LDAP is enabled, user attributes are synchronized with AD/LDAP based on their email address. If a user with a given email address doesn't have an AD/LDAP account, they will be deactivated in Mattermost on the next AD/LDAP sync. To re-activate the account:
 

--- a/source/deployment/sso-saml-ldapsync.rst
+++ b/source/deployment/sso-saml-ldapsync.rst
@@ -9,13 +9,13 @@ In addition to configuring SAML sign-in, you can optionally configure synchroniz
 To configure SAML synchronization with AD/LDAP:
 
 1. Go to **System Console > Authentication > SAML 2.0** (or **System Console > SAML** in versions prior to 5.12) and set **Enable Synchronizing SAML Accounts With AD/LDAP** to ``true``.
-2. Go to  **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and set **Enable Synchronization with AD/LDAP** to ``true``.
+2. Go to  **System Console > Authentication > SAML 2.0** and set **Ignore Guest Users when Synchronizing with AD/LDAP** to ``true`` or ``false``. 
 3. Set the rest of the AD/LDAP settings based on `configuration settings documentation <http://docs.mattermost.com/administration/config-settings.html#ad-ldap>`__ to connect Mattermost with your AD/LDAP server.
 
- - If you don't want to enable AD/LDAP sign-in, keep **Enable sign-in with AD/LDAP** as ``false``.
+ - If you don't want to enable AD/LDAP sign-in, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and keep **Enable sign-in with AD/LDAP** as ``false``.
 
-4. Set **Syncronization Interval** to specify how often Mattermost synchronizes SAML user accounts with AD/LDAP. The default setting is 60 minutes. If you want to synchronize immediately after disabling an account, use the "AD/LDAP Synchronize Now" button in **System Console > AD/LDAP** in prior versions or **System Console** > **Authentication** > **AD/LDAP** in versions after 5.12.
-5. To test Mattermost can successfully connect to your AD/LDAP server, click the **AD/LDAP Test** button.
+4. To specify how often Mattermost synchronizes SAML user accounts with AD/LDAP, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and set **Synchronization Interval**. The default setting is 60 minutes. If you want to synchronize immediately after disabling an account, click the **AD/LDAP Synchronize Now** button.
+5. To test Mattermost can successfully connect to your AD/LDAP server, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and click the **AD/LDAP Test** button.
 
 Once the synchronization with AD/LDAP is enabled, user attributes are synchronized with AD/LDAP based on their email address. If a user with a given email address doesn't have an AD/LDAP account, they will be deactivated in Mattermost on the next AD/LDAP sync. To re-activate the account:
 

--- a/source/deployment/sso-saml-ldapsync.rst
+++ b/source/deployment/sso-saml-ldapsync.rst
@@ -14,7 +14,7 @@ To configure SAML synchronization with AD/LDAP:
 
  - If you don't want to enable AD/LDAP sign-in, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and keep **Enable sign-in with AD/LDAP** as ``false``.
 
-4. To specify how often Mattermost synchronizes SAML user accounts with AD/LDAP, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and set **Synchronization Interval**. The default setting is 60 minutes. If you want to synchronize immediately after disabling an account, click the **AD/LDAP Synchronize Now** button.
+4. To specify how often Mattermost synchronizes SAML user accounts with AD/LDAP, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and set **Synchronization Interval**. The default setting is 60 minutes. If you want to synchronize immediately after disabling an account, click **AD/LDAP Synchronize Now**.
 5. To test Mattermost can successfully connect to your AD/LDAP server, go to **System Console > Authentication > AD/LDAP** (or **System Console > AD/LDAP** in versions prior to 5.12) and click the **AD/LDAP Test** button.
 
 Once the synchronization with AD/LDAP is enabled, user attributes are synchronized with AD/LDAP based on their email address. If a user with a given email address doesn't have an AD/LDAP account, they will be deactivated in Mattermost on the next AD/LDAP sync. To re-activate the account:


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-28882

Updated:
https://docs.mattermost.com/deployment/sso-saml-ldapsync.html

- Under SAML Configure SAML synchronization with AD/LDAP:
replaced redundant step 2 with new step 2 for Ignore Guest configuration setting
added UI context switch details when remaining steps move from SAML 2.0 to AD/LDAP page)
