### PR TITLE
MM-30436 Initialize server configuration with custom defaults

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -39,7 +39,7 @@ For any setting that is not set in ``config.json`` or in environment variables, 
 Starting from Mattermost v5.30, you can load a set of custom configuration defaults using an environment variable. This custom configuration applies only if the values are not already present in the current server configuration.
 
 1. Create a JSON file that contains the custom configuration defaults. For example, ``custom.json``.
-2. Edit the ``config.json`` file to include the new environment variable ``MM_CUSTOM_DEFAULTS_PATH=custom.json``.
+2. When starting the server, point the custom defaults environment variable to the defaults file: ``MM_CUSTOM_DEFAULTS_PATH=custom.json``.
 
 
 .. contents::

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -38,7 +38,7 @@ For any setting that is not set in ``config.json`` or in environment variables, 
 
 Starting from Mattermost v5.30, you can load a set of custom configuration defaults using an environment variable. This custom configuration applies only if the values are not already present in the current server configuration.
 
-1. Create a ``custom.json`` file that contains the custom configuration defaults.
+1. Create a JSON file that contains the custom configuration defaults. For example, ``custom.json``.
 2. Edit the ``config.json`` file to include the new environment variable ``MM_CUSTOM_DEFAULTS_PATH=custom.json``.
 
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -36,7 +36,7 @@ For any setting that is not set in ``config.json`` or in environment variables, 
    
 **Load Custom Configuration Defaults**
 
-Starting from Mattermost v5.30, you can load a set of custom configuration defaults using an environment variable.
+Starting from Mattermost v5.30, you can load a set of custom configuration defaults using an environment variable. This custom configuration applies only if the values are not already present in the current server configuration.
 
 1. Create a ``custom.json`` file that contains the custom configuration defaults.
 2. Edit the ``config.json`` file to include the new environment variable ``MM_CUSTOM_DEFAULTS_PATH=custom.json``.

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -36,7 +36,7 @@ For any setting that is not set in ``config.json`` or in environment variables, 
    
 **Load Custom Configuration Defaults**
 
-Starting from Mattermost version 5.30, you can load a set of custom configuration defaults using an environment variable.
+Starting from Mattermost v5.30, you can load a set of custom configuration defaults using an environment variable.
 
 1. Create a ``custom.json`` file that contains the custom configuration defaults.
 2. Edit the ``config.json`` file to include the new environment variable ``MM_CUSTOM_DEFAULTS_PATH=custom.json``.

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -26,13 +26,21 @@ The name of the environment variable for any setting can be derived from the nam
 
 Finally, if a setting is configured through an environment variable, modifying it in the System Console is disabled.
 
-For any setting that is not set in ``config.json`` or in environment variables, the Mattermost server uses the default value as documented here.
+For any setting that is not set in ``config.json`` or in environment variables, the Mattermost server uses the default value as documented in the sections below.
 
 .. note::
    If a setting is set through an environment variable and any other changes are made in the System Console, the value stored of the environment variable will be written back to the ``config.json`` as that setting's value.
 
 .. warning::
    Database connection strings for the database read and search replicas need to be formatted using `URL encoding <https://www.w3schools.com/tags/ref_urlencode.asp>`__. Incorrectly formatted strings may cause some characters to terminate the string early, resulting in issues when the connection string is parsed.
+   
+**Load Custom Configuration Defaults**
+
+Starting from Mattermost version 5.30, you can load a set of custom configuration defaults using an environment variable.
+
+1. Create a ``custom.json`` file that contains the custom configuration defaults.
+2. Edit the ``config.json`` file to include the new environment variable ``MM_CUSTOM_DEFAULTS_PATH=custom.json``.
+
 
 .. contents::
   :depth: 2


### PR DESCRIPTION
Documentation for: https://mattermost.atlassian.net/browse/MM-30436

Updated:
- Admin Guide > Configure Mattermost > Configure Settings > added new subsection: Load Custom Configuration Defaults immediately following the Environment Variables section