### PR TITLE
MM-11399-Manage Admin Roles Using System Console

### DIFF
--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -126,7 +126,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
 
-2. Under **Privileges > Authentication**, select **Can edit**, and then click **Save**.
+2. Under **Privileges > Authentication**, select **Can edit** then select **Save**.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -4,7 +4,7 @@ Additional System Admin Roles (E20)
 
 From v5.28, System Admins can use the command line to assign roles that permit members to have admin access to specified areas of the System Console. This allows members of your organization to perform certain administrative tasks without providing them with access to all system administrative capabilities.
 
-From v5.30, System Admins can use the System Console to manage admin roles and admin role privileges.
+From v5.30, System Admins can also use the System Console to manage additional System Admin roles and privileges.
 
 - **System Manager:** The System Manager has read/write permissions for management areas of the System Console, such as user management and integrations (excluding permissions). This role has read only access to authentication, reporting, and license interfaces.
 - **User Manager:** The User Manager role is able to read/write to all the user management areas (excluding permissions). The authentication interface is read only.

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -77,7 +77,7 @@ The format of the mmctl command is:
 
 2. Under **Assigned People**, choose **Add People**.
 
-3. Search for and select **Bob Smith** and **Sue Clark** then choose **Add** to grant the User Manager role to those users.
+3. Search for and select **Bob Smith** and **Sue Clark** then select **Add** to grant the User Manager role to those users.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -65,7 +65,7 @@ The format of the mmctl command is:
 
 2. Under **Assigned People**, choose **Add People**.
 
-3. Search for and select ``Bob Smith``, and then click **Add** to grant the System Manager role to that user.
+3. Search for and select ``Bob Smith`` then select **Add** to grant the System Manager role to that user.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -12,7 +12,7 @@ From v5.30, System Admins can use the System Console to manage admin roles and a
 
 There are two ways to assign roles:
 
-1. Using **System Console > User Management > System Roles (Beta)**.
+1. In the System Console under **User Management > System Roles (Beta)**.
 
 2. Using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
 
@@ -53,57 +53,77 @@ Assigning Admin Roles
 
 System Admins can assign roles using the System Console or the mmctl tool. This can be done either locally or remotely.
 
-1. Go to **System Console > User Management > System Roles (Beta) > Assigned People**. 
+  **In the System Console**
 
-The format of the mmctl command is:
+  1. Go to **System Console > User Management > System Roles (Beta) > Assigned People**. 
 
-``mmctl permissions role assign [role_name] [username...]``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions role assign [role_name] [username...]``
 
 **To grant the System Manager role to a single user called Bob Smith:**
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **System Manager** role.
+  **In the System Console**
 
-2. Under **Assigned People**, choose **Add People**.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **System Manager** role.
 
-3. Search for and select ``Bob Smith`` then select **Add** to grant the System Manager role to that user.
+  2. Under **Assigned People**, choose **Add People**.
 
-The format of the mmctl command is:
+  3. Search for and select ``Bob Smith``, then select **Add** to grant the System Manager role to that user.
 
-``mmctl permissions role assign system_manager bob-smith``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions role assign system_manager bob-smith``
 
 **To grant the User Manager role to two users, Bob Smith and Sue Clark:**
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+  **In the System Console**
 
-2. Under **Assigned People**, choose **Add People**.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **User Manager** role.
 
-3. Search for and select **Bob Smith** and **Sue Clark** then select **Add** to grant the User Manager role to those users.
+  2. Under **Assigned People**, choose **Add People**.
 
-The format of the mmctl command is:
+  3. Search for and select **Bob Smith** and **Sue Clark**, then select **Add** to grant the User Manager role to those users.
 
-``mmctl permissions role assign system_user_manager bob-smith sue-clark``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions role assign system_user_manager bob-smith sue-clark``
 
 **To grant the Read Only Admin role to two users, Bob Smith and Sue Clark:**
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **Viewer** role.
+  **In the System Console**
 
-2. Under **Assigned People**, select **Add People**.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **Viewer** role.
 
-3. Search for and select **Bob Smith** and **Sue Clark**, then select **Add** to grant the Viewer role to those users.
+  2. Under **Assigned People**, select **Add People**.
 
-The format of the mmctl command is:
+  3. Search for and select **Bob Smith** and **Sue Clark**, then select **Add** to grant the Viewer role to those users.
 
-``mmctl permissions role assign system_read_only_admin bob-smith sue-clark``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions role assign system_read_only_admin bob-smith sue-clark``
 
 **To remove the System Manager role from a single user called Bob Smith:**
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **Viewer** role.
+  **In the System Console**
 
-2. Under **Assigned People** search for **Bob Smith** then select **Remove**.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **Viewer** role.
 
-The format of the mmctl command is:
+  2. Under **Assigned People** search for **Bob Smith**, then select **Remove**.
 
-``mmctl permissions role unassign system_manager bob-smith``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions role unassign system_manager bob-smith``
 
 Editing Privileges of Admin Roles (Advanced)
 --------------------------------------------
@@ -112,49 +132,65 @@ Each of the admin roles have defined, default privileges as outlined above.
 
 System Admins can grant read and write access to other areas of the System Console, as well as remove read and write access (including default access), for each role. This is completed using the System Console or the mmctl tool, either locally or remotely.
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **System Manager**, **User Manager**, or **Viewer** role.
+  **In the System Console**
 
-2. For each set of privileges, select the access level as **Can edit**, **Read only**, or **No access**.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **System Manager**, **User Manager**, or **Viewer** role.
 
-**Note:** If you set privilege subsections to different access levels, the privilege access level displays as **Mixed Access**.
+  2. For each set of privileges, select the access level as **Can edit**, **Read only**, or **No access**.
 
-The format of the mmctl command is:
+  **Note:** If you set privilege subsections to different access levels then the privilege access level displays as **Mixed Access**.
 
-``mmctl permissions add [role_name] [permission...]``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions add [role_name] [permission...]``
 
 **To grant write access to the Authentication section of the System Console for all users with the User Manager role:**
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+  **In the System Console**
 
-2. Under **Privileges > Authentication**, select **Can edit** then select **Save**.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **User Manager** role.
 
-The format of the mmctl command is:
+  2. Under **Privileges > Authentication** select **Can edit**, then select **Save**.
 
-``mmctl permissions add system_user_manager sysconsole_write_authentication``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions add system_user_manager sysconsole_write_authentication``
 
 **To grant read only access to the Authentication section of the System Console for all users with the User Manager role:**
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+  **In the System Console**
 
-2. Under **Privileges > Authentication**, select **Read only** then select **Save**.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **User Manager** role.
 
-The format of the mmctl command is:
+  2. Under **Privileges > Authentication** select **Read only**, then select **Save**.
 
-``mmctl permissions remove system_user_manager sysconsole_read_authentication``
+  **Using the mmctl tool**
+
+  The format of the mmctl command is:
+
+  ``mmctl permissions remove system_user_manager sysconsole_read_authentication``
 
 **To remove write access to the Authentication section of the System Console for all users with the User Manager role:**
+  
+  **In the System Console**
 
-1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+  1. Go to **System Console > User Management > System Roles (Beta)** then select the **User Manager** role.
 
-2. Under **Privileges > Authentication** select **No access**, then choose **Save**.
+  2. Under **Privileges > Authentication** select **No access**, then choose **Save**.
 
-The format of the mmctl command is:
+  **Using the mmctl tool**
+  
+  The format of the mmctl command is:
 
-``mmctl permissions remove system_user_manager sysconsole_write_authentication``
+  ``mmctl permissions remove system_user_manager sysconsole_write_authentication``
 
 **To reset a role to its default set of permissions:**
 
-**Note:** This is completed using the mmctl tool only, either locally or remotely.
+This is completed using the mmctl tool only, either locally or remotely.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -146,7 +146,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
 
-2. Under **Privileges > Authentication**, select **No access**, and then click **Save**.
+2. Under **Privileges > Authentication** select **No access**, then choose **Save**.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -136,7 +136,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
 
-2. Under **Privileges > Authentication**, select **Read only**, and then click **Save**.
+2. Under **Privileges > Authentication**, select **Read only** then select **Save**.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -16,7 +16,7 @@ There are two ways to assign roles:
 
 2. Using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
 
-When a user is assigned a role, they have access the System Console. Each role has a set of default permissions. The items that they can view depend on the role they've been assigned.
+When a user is assigned a role, they have access the System Console. As each role has a different set of default permissions the items that they can view depend on the role they've been assigned.
 
 **System Manager**
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -75,7 +75,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
 
-2. Under **Assigned People**, click **Add People**.
+2. Under **Assigned People**, choose **Add People**.
 
 3. Search for and select ``Bob Smith`` and ``Sue Clark``, and then click **Add** to grant the User Manager role to those users.
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -87,7 +87,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **Viewer** role.
 
-2. Under **Assigned People**, click **Add People**.
+2. Under **Assigned People**, select **Add People**.
 
 3. Search for and select ``Bob Smith`` and ``Sue Clark``, and then click **Add** to grant the Viewer role to those users.
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -2,7 +2,7 @@
 Additional System Admin Roles (E20)
 ====================================
 
-From v5.28, System Admins can use the command line to assign roles to members that permit admin access to designated areas of the System Console. This allows other members of your organization to perform certain administrative tasks without providing access to all system administrative capabilities.
+From v5.28, System Admins can use the command line to assign roles that permit members to have admin access to specified areas of the System Console. This allows members of your organization to perform certain administrative tasks without providing them with access to all system administrative capabilities.
 
 From v5.30, System Admins can use the System Console to manage admin roles and admin role privileges.
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -77,7 +77,7 @@ The format of the mmctl command is:
 
 2. Under **Assigned People**, choose **Add People**.
 
-3. Search for and select ``Bob Smith`` and ``Sue Clark``, and then click **Add** to grant the User Manager role to those users.
+3. Search for and select **Bob Smith** and **Sue Clark** then choose **Add** to grant the User Manager role to those users.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -55,7 +55,7 @@ System Admins can assign roles using the System Console or the mmctl tool. This 
 
   **In the System Console**
 
-  1. Go to **System Console > User Management > System Roles (Beta) > Assigned People**. 
+- Go to **System Console > User Management > System Roles (Beta) > Assigned People**. 
 
   **Using the mmctl tool**
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -12,7 +12,7 @@ From v5.30, System Admins can use the System Console to manage admin roles and a
 
 There are two ways to assign roles:
 
-1. Using the System Console. Go to **System Console > User Management > System Roles (Beta)**.
+1. Using **System Console > User Management > System Roles (Beta)**.
 
 2. Using the command line, using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -89,7 +89,7 @@ The format of the mmctl command is:
 
 2. Under **Assigned People**, select **Add People**.
 
-3. Search for and select ``Bob Smith`` and ``Sue Clark``, and then click **Add** to grant the Viewer role to those users.
+3. Search for and select **Bob Smith** and **Sue Clark**, then select **Add** to grant the Viewer role to those users.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -14,7 +14,7 @@ There are two ways to assign roles:
 
 1. Using **System Console > User Management > System Roles (Beta)**.
 
-2. Using the command line, using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
+2. Using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
 
 When a user is assigned a role, they have access the System Console. Each role has a set of default permissions. The items that they can view depend on the role they've been assigned.
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -63,7 +63,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **System Manager** role.
 
-2. Under **Assigned People**, click **Add People**.
+2. Under **Assigned People**, choose **Add People**.
 
 3. Search for and select ``Bob Smith``, and then click **Add** to grant the System Manager role to that user.
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -2,15 +2,21 @@
 Additional System Admin Roles (E20)
 ====================================
 
-From v5.28, System Admins can assign roles to members, allowing them access only to designated areas of the System Console. This allows other members of your organization to perform certain administrative tasks without providing access to all system administrative capabilities.
+From v5.28, System Admins can use the command line to assign roles to members that permit admin access to designated areas of the System Console. This allows other members of your organization to perform certain administrative tasks without providing access to all system administrative capabilities.
+
+From v5.30, System Admins can use the System Console to manage admin roles and admin role privileges.
 
 - **System Manager:** The System Manager has read/write permissions for management areas of the System Console, such as user management and integrations (excluding permissions). This role has read only access to authentication, reporting, and license interfaces.
 - **User Manager:** The User Manager role is able to read/write to all the user management areas (excluding permissions). The authentication interface is read only.
-- **Read Only Admin:** This role is able to access all pages of the System Console but has no write access to any.
+- **Read Only Admin:** This role is able to access all pages of the System Console but has no write access to any pages.
 
-Roles are assigned via the command line, using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
+There are two ways to assign roles:
 
-Each role has a set of default permissions, and when a user is assigned a role, they are able to access the System Console. The items that they can view depend on the role they've been assigned.
+1. Using the System Console. Go to **System Console > User Management > System Roles (Beta)**.
+
+2. Using the command line, using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
+
+Each role has a set of default permissions. When a user is assigned a role, they are able to access the System Console. The items that they can view depend on the role they've been assigned.
 
 **System Manager**
 
@@ -45,7 +51,9 @@ Each role has a set of default permissions, and when a user is assigned a role, 
 Assigning Admin Roles
 ---------------------
 
-System Admins can assign roles and modify privileges using the mmctl tool. This can be done either locally or remotely.
+System Admins can assign roles using the System Console or the mmctl tool. This can be done either locally or remotely.
+
+1. Go to **System Console > User Management > System Roles (Beta) > Assigned People**. 
 
 The format of the mmctl command is:
 
@@ -53,17 +61,47 @@ The format of the mmctl command is:
 
 **To grant the System Manager role to a single user called Bob Smith:**
 
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **System Manager** role.
+
+2. Under **Assigned People**, click **Add People**.
+
+3. Search for and select ``Bob Smith``, and then click **Add** to grant the System Manager role to that user.
+
+The format of the mmctl command is:
+
 ``mmctl permissions role assign system_manager bob-smith``
 
 **To grant the User Manager role to two users, Bob Smith and Sue Clark:**
+
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+
+2. Under **Assigned People**, click **Add People**.
+
+3. Search for and select ``Bob Smith`` and ``Sue Clark``, and then click **Add** to grant the User Manager role to those users.
+
+The format of the mmctl command is:
 
 ``mmctl permissions role assign system_user_manager bob-smith sue-clark``
 
 **To grant the Read Only Admin role to two users, Bob Smith and Sue Clark:**
 
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **Viewer** role.
+
+2. Under **Assigned People**, click **Add People**.
+
+3. Search for and select ``Bob Smith`` and ``Sue Clark``, and then click **Add** to grant the Viewer role to those users.
+
+The format of the mmctl command is:
+
 ``mmctl permissions role assign system_read_only_admin bob-smith sue-clark``
 
 **To remove the System Manager role from a single user called Bob Smith:**
+
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **Viewer** role.
+
+2. Under **Assigned People**, search for ``Bob Smith``, and then select **Remove**.
+
+The format of the mmctl command is:
 
 ``mmctl permissions role unassign system_manager bob-smith``
 
@@ -72,7 +110,13 @@ Editing Privileges of Admin Roles (Advanced)
 
 Each of the admin roles have defined, default privileges as outlined above. 
 
-System Admins can grant read and write access to other areas of the System Console, as well as remove read write access (including default access), for each role. This is completed using the mmctl tool, either locally or remotely.
+System Admins can grant read and write access to other areas of the System Console, as well as remove read and write access (including default access), for each role. This is completed using the System Console or the mmctl tool, either locally or remotely.
+
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **System Manager**, **User Manager**, or **Viewer** role.
+
+2. For each set of privileges, select the access level as **Can edit**, **Read only**, or **No access**.
+
+**Note:** If you set privilege subsections to different access levels, the privilege access level displays as **Mixed Access**.
 
 The format of the mmctl command is:
 
@@ -80,15 +124,45 @@ The format of the mmctl command is:
 
 **To grant write access to the Authentication section of the System Console for all users with the User Manager role:**
 
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+
+2. Under **Privileges > Authentication**, select **Can edit**, and then click **Save**.
+
+The format of the mmctl command is:
+
 ``mmctl permissions add system_user_manager sysconsole_write_authentication``
 
 **To grant read only access to the Authentication section of the System Console for all users with the User Manager role:**
+
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+
+2. Under **Privileges > Authentication**, select **Read only**, and then click **Save**.
+
+The format of the mmctl command is:
 
 ``mmctl permissions remove system_user_manager sysconsole_read_authentication``
 
 **To remove write access to the Authentication section of the System Console for all users with the User Manager role:**
 
+1. Go to **System Console > User Management > System Roles (Beta)** and select the **User Manager** role.
+
+2. Under **Privileges > Authentication**, select **No access**, and then click **Save**.
+
+The format of the mmctl command is:
+
 ``mmctl permissions remove system_user_manager sysconsole_write_authentication``
+
+**To reset a role to its default set of permissions:**
+
+**Note:** This is completed using the mmctl tool only, either locally or remotely.
+
+The format of the mmctl command is:
+
+``mmctl permissions reset [role_name]``
+
+For example, to reset the permissions of the ``system_read_only_admin`` role:
+
+``mmctl permissions reset system_read_only_admin``
 
 Admin Roles and Privileges
 ---------------------------

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -99,7 +99,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **Viewer** role.
 
-2. Under **Assigned People**, search for ``Bob Smith``, and then select **Remove**.
+2. Under **Assigned People**, search for **Bob Smith**, and then select **Remove**.
 
 The format of the mmctl command is:
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -16,7 +16,7 @@ There are two ways to assign roles:
 
 2. Using the command line, using the `mmctl tool <https://docs.mattermost.com/administration/mmctl-cli-tool.html>`_.
 
-Each role has a set of default permissions. When a user is assigned a role, they are able to access the System Console. The items that they can view depend on the role they've been assigned.
+When a user is assigned a role, they have access the System Console. Each role has a set of default permissions. The items that they can view depend on the role they've been assigned.
 
 **System Manager**
 

--- a/source/deployment/admin-roles.rst
+++ b/source/deployment/admin-roles.rst
@@ -99,7 +99,7 @@ The format of the mmctl command is:
 
 1. Go to **System Console > User Management > System Roles (Beta)** and select the **Viewer** role.
 
-2. Under **Assigned People**, search for **Bob Smith**, and then select **Remove**.
+2. Under **Assigned People** search for **Bob Smith** then select **Remove**.
 
 The format of the mmctl command is:
 


### PR DESCRIPTION
Documentation updates for:
- https://mattermost.atlassian.net/browse/MM-28227: New System Roles (Special Admins) - managing via System Console
- https://mattermost.atlassian.net/browse/MM-11399: Add mmctl role reset command

Updated:
- Admin Guide > Onboard Users > Additional System Admin Roles (E20): Added System Console steps for assigning roles and editing privileges
- Admin Guide > Onboard Users > Additional System Admin Roles (E20): Added mmctl for resetting role privileges