### PR TITLE
MM-28551  mmctl local mode API migration (phase 4)

### DIFF
--- a/source/administration/mmctl-cli-tool.rst
+++ b/source/administration/mmctl-cli-tool.rst
@@ -35,6 +35,7 @@ This feature was developed to a large extent by community contributions and we'd
    - `mmctl token`_ - Token Management
    - `mmctl user`_ - User Management
    - `mmctl version`_ - Version Management
+   - `mmctl webhook`_ - Webhook Management
    - `mmctl websocket`_ - Websocket Management
 
 **Options**
@@ -4123,6 +4124,321 @@ mmctl version
    --insecure-sha1-intermediate  allows the use of insecure TLS protocols, such as SHA-1
    --local                       allows communicating with the server through a unix socket
    --strict                      will only run commands if the mmctl version matches the server one
+
+mmctl webhook
+-------------
+
+**Description**
+
+Management of webhooks.
+
+Child Commands
+   -  `mmctl webhook create-incoming`_ - Create an incoming webhook
+   -  `mmctl webhook create-outgoing`_ - Create an outgoing webhook
+   -  `mmctl webhook delete`_ - Delete webhooks
+   -  `mmctl webhook list`_ - List webhooks
+   -  `mmctl webhook modify-incoming`_ - Modify an incoming webhook
+   -  `mmctl webhook modify-outgoing`_ - Modify an outgoing webhook
+   -  `mmctl webhook show`_ - Show a webhook
+
+**Format**
+
+.. code-block:: sh
+
+    mmctl websocket [flags]
+
+**Options**
+
+.. code-block:: sh
+
+    -h, --help       help for webhook
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+mmctl webhook create-incoming
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+Create an incoming webhook to allow external posting of messages to a specific channel.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl webhook create-incoming [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+    webhook create-incoming --channel [channelID] --user [userID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL]
+
+**Options**
+
+.. code-block:: sh
+
+   --channel string        Channel ID (required)
+   --description string    Incoming webhook description
+   --display-name string   Incoming webhook display name
+   -h, --help              help for create-incoming
+   --icon string           Icon URL
+   --lock-to-channel       Lock to channel
+   --user string           User ID (required)
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+   --format string                the format of the command output [plain, json] (default "plain")
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --local                        allows communicating with the server through a unix socket
+   --strict                       will only run commands if the mmctl version matches the server one
+
+
+mmctl webhook create-outgoing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+Create an outgoing webhook to allow external posting of messages from a specific channel.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl webhook create-outgoing [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   webhook create-outgoing --team myteam --user myusername --display-name mywebhook --trigger-word "build" --trigger-word "test" --url http://localhost:8000/my-webhook-handler
+  	webhook create-outgoing --team myteam --channel mychannel --user myusername --display-name mywebhook --description "My cool webhook" --trigger-when start --trigger-word build --trigger-word test --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json"
+
+**Options**
+
+.. code-block:: sh
+
+   --channel string             Channel name or ID
+   --content-type string        Content-type
+   --description string         Outgoing webhook description
+   --display-name string        Outgoing webhook display name (required)
+   -h, --help                   help for create-outgoing
+   --icon string                Icon URL
+   --team string                Team name or ID (required)
+   --trigger-when string        When to trigger webhook (exact: for first word matches a trigger word exactly, start: for first word starts with a trigger word) (default "exact")
+   --trigger-word stringArray   Word to trigger webhook (required)
+   --url stringArray            Callback URL (required)
+   --user string                User username, email, or ID (required)
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+   --format string                the format of the command output [plain, json] (default "plain")
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --local                        allows communicating with the server through a unix socket
+   --strict                       will only run commands if the mmctl version matches the server one
+
+mmctl webhook delete
+^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+Delete a webhook with a given ID.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl webhook delete [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   webhook delete [webhookID]
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for delete
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+   --format string                the format of the command output [plain, json] (default "plain")
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --local                        allows communicating with the server through a unix socket
+   --strict                       will only run commands if the mmctl version matches the server one
+
+mmctl webhook list
+^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+Print a list of all webhooks.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl webhook list [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   webhook list myteam
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for list
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+   --format string                the format of the command output [plain, json] (default "plain")
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --local                        allows communicating with the server through a unix socket
+   --strict                       will only run commands if the mmctl version matches the server one
+
+mmctl webhook modify-incoming
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+Modify an existing incoming webhook by changing its title, description, channel, or icon URL.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl webhook modify-incoming [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   webhook modify-incoming [webhookID] --channel [channelID] --display-name [displayName] --description [webhookDescription] --lock-to-channel --icon [iconURL]
+
+**Options**
+
+.. code-block:: sh
+
+   --channel string        Channel ID
+   --description string    Incoming webhook description
+   --display-name string   Incoming webhook display name
+   -h, --help              help for modify-incoming
+   --icon string           Icon URL
+   --lock-to-channel       Lock to channel
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+   --format string                the format of the command output [plain, json] (default "plain")
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --local                        allows communicating with the server through a unix socket
+   --strict                       will only run commands if the mmctl version matches the server one
+
+
+mmctl webhook modify-outgoing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+Modify an existing outgoing webhook by changing its title, description, channel, icon, url, content-type, or triggers.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl webhook modify-outgoing [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   webhook modify-outgoing [webhookId] --channel [channelId] --display-name [displayName] --description "New webhook description" --icon http://localhost:8000/my-slash-handler-bot-icon.png --url http://localhost:8000/my-webhook-handler --content-type "application/json" --trigger-word test --trigger-when start
+
+**Options**
+
+.. code-block:: sh
+
+   --channel string             Channel name or ID
+   --content-type string        Content-type
+   --description string         Outgoing webhook description
+   --display-name string        Outgoing webhook display name
+   -h, --help                   help for modify-outgoing
+   --icon string                Icon URL
+   --trigger-when string        When to trigger webhook (exact: for first word matches a trigger word exactly, start: for first word starts with a trigger word)
+   --trigger-word stringArray   Word to trigger webhook
+   --url stringArray            Callback URL
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+   --format string                the format of the command output [plain, json] (default "plain")
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --local                        allows communicating with the server through a unix socket
+   --strict                       will only run commands if the mmctl version matches the server one
+
+mmctl webhook show
+^^^^^^^^^^^^^^^^^^
+
+**Description**
+
+Show the webhook specified by `[webhookId]`.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl webhook show [webhookId] [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   webhook show w16zb5tu3n1zkqo18goqry1je
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for show
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+   --format string                the format of the command output [plain, json] (default "plain")
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --local                        allows communicating with the server through a unix socket
+   --strict                       will only run commands if the mmctl version matches the server one
 
 mmctl websocket
 ---------------


### PR DESCRIPTION
Documentation for: 
- https://mattermost.atlassian.net/browse/MM-28551, which includes a number of related tasks (MM-30017 through MM-30025 inclusive)

Updated:
- Under Admin Guide > Administration > mmctl Command Line Tool (Beta)
  - Added new `mmctl webhook` section (including top-of-page TOC link)
  - Added new webhook subcommands