### PR TITLE
fixed the link for Connect to Another Server

### DIFF
--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -621,9 +621,9 @@ To help us narrow down whether it’s a server configuration issue, device speci
 
 **Connect to another server**
 
-1. Create an account at https://demo.mattermost.com.
+1. Create an account at https://community.mattermost.com.
 2. Erase your mobile application and reinstall it.
-3. In your mobile app, enter the server URL https://demo.mattermost.com and then your login credentials to test whether the connection is working.
+3. In your mobile app, enter the server URL https://community.mattermost.com and then your login credentials to test whether the connection is working.
 
 **Connect with another device**
 


### PR DESCRIPTION

#### Summary
Fixed a quick link that pointed to demo.mattermost.com to be community.mattermost.com so the connection could be tested.
