### PR TITLE
MM-27931, MM-30158 Allow 'multi-selecting' channels in the LHS

### DIFF
--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -154,7 +154,9 @@ When configured by the System Admin, users can enable the features in **Account 
 
 **Collapsible custom categories**: Create custom categories in the sidebar to group channels together for easier navigation (e.g. “Design” or “Marketing”). Collapse categories to display only unread channels and reduce unnecessary scrolling.
 
-**Drag and drop channels and categories**: Drag channels between or within categories, or drag to reorder entire categories to prioritize important conversations.
+**Multi-select channels**: Using the Mattermost Web or Desktop App, select multiple channels at a time. Press and hold SHIFT to select sequential channels. Press and hold CMD (for Mac) or CTRL (for Windows/Linux) to select non-sequential channels.
+
+**Drag and drop channels and categories**: Drag and drop to move selected channels within or between custom categories, or drag to reorder entire categories to prioritize important conversations. Multi-selected channels move together as a group in the order they originally appeared.
 
 **Sort Direct Messages by recent conversations**: Choose to sort Direct Messages alphabetically or by recent conversations first. 
 

--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -154,7 +154,7 @@ When configured by the System Admin, users can enable the features in **Account 
 
 **Collapsible custom categories**: Create custom categories in the sidebar to group channels together for easier navigation (e.g. “Design” or “Marketing”). Collapse categories to display only unread channels and reduce unnecessary scrolling.
 
-**Multi-select channels**: Using the Mattermost Web or Desktop App, select multiple channels at a time. To select sequential channels, press and hold SHIFT. To select non-sequential channels press and hold CMD (for Mac) or CTRL (for Windows/Linux).
+**Multi-select channels**: Using Mattermost Cloud, select multiple channels at a time. To select sequential channels, press and hold SHIFT. To select non-sequential channels press and hold CMD (for Mac) or CTRL (for Windows/Linux). The ability to multi-select channels is coming to the Mattermost Web and Desktop Apps in a future release.
 
 **Drag and drop channels and categories**: Drag and drop to move selected channels within or between custom categories, or drag to reorder entire categories to prioritize important conversations. Multi-selected channels move together as a group in the order they originally appeared.
 

--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -154,7 +154,7 @@ When configured by the System Admin, users can enable the features in **Account 
 
 **Collapsible custom categories**: Create custom categories in the sidebar to group channels together for easier navigation (e.g. “Design” or “Marketing”). Collapse categories to display only unread channels and reduce unnecessary scrolling.
 
-**Multi-select channels**: Using Mattermost Cloud, select multiple channels at a time. To select sequential channels, press and hold SHIFT. To select non-sequential channels press and hold CMD (for Mac) or CTRL (for Windows/Linux). The ability to multi-select channels is coming to the Mattermost Web and Desktop Apps in a future release.
+**Using the Mattermost Web or Desktop App, select multiple channels at a time. To select sequential channels, press and hold SHIFT. To select non-sequential channels press and hold CMD (for Mac) or CTRL (for Windows/Linux).
 
 **Drag and drop channels and categories**: Drag and drop to move selected channels within or between custom categories, or drag to reorder entire categories to prioritize important conversations. Multi-selected channels move together as a group in the order they originally appeared.
 

--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -154,7 +154,7 @@ When configured by the System Admin, users can enable the features in **Account 
 
 **Collapsible custom categories**: Create custom categories in the sidebar to group channels together for easier navigation (e.g. “Design” or “Marketing”). Collapse categories to display only unread channels and reduce unnecessary scrolling.
 
-**Using the Mattermost Web or Desktop App, select multiple channels at a time. To select sequential channels, press and hold SHIFT. To select non-sequential channels press and hold CMD (for Mac) or CTRL (for Windows/Linux).
+**Using the Mattermost Web or Desktop App, select multiple channels at a time. To select sequential channels, press and hold SHIFT. To select non-sequential channels press and hold CMD (for Mac) or CTRL (for Windows/Linux). To clear channel selections, press ESC.
 
 **Drag and drop channels and categories**: Drag and drop to move selected channels within or between custom categories, or drag to reorder entire categories to prioritize important conversations. Multi-selected channels move together as a group in the order they originally appeared.
 

--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -154,7 +154,7 @@ When configured by the System Admin, users can enable the features in **Account 
 
 **Collapsible custom categories**: Create custom categories in the sidebar to group channels together for easier navigation (e.g. “Design” or “Marketing”). Collapse categories to display only unread channels and reduce unnecessary scrolling.
 
-**Multi-select channels**: Using the Mattermost Web or Desktop App, select multiple channels at a time. Press and hold SHIFT to select sequential channels. Press and hold CMD (for Mac) or CTRL (for Windows/Linux) to select non-sequential channels.
+**Multi-select channels**: Using the Mattermost Web or Desktop App, select multiple channels at a time. To select sequential channels, press and hold SHIFT. To select non-sequential channels press and hold CMD (for Mac) or CTRL (for Windows/Linux).
 
 **Drag and drop channels and categories**: Drag and drop to move selected channels within or between custom categories, or drag to reorder entire categories to prioritize important conversations. Multi-selected channels move together as a group in the order they originally appeared.
 


### PR DESCRIPTION
Documentation for: 
- https://mattermost.atlassian.net/browse/MM-27931
- https://mattermost.atlassian.net/browse/MM-30158

Updated:
- User's Guide > Getting Started > Organizing Conversations > Experimental: Channel Organization Features
   - Added new bullet point about being able to multi-select sequential and non-sequential channels
   - Updated existing bullet point about being able to drag and drop selected channels to include details on how multi-selected channels move