### PR TITLE
MM-27312 Allow uploading 10 files per post

### DIFF
--- a/source/help/getting-started/messaging-basics.rst
+++ b/source/help/getting-started/messaging-basics.rst
@@ -44,5 +44,5 @@ Learn more about:
 * `Composing Messages and Replies <https://docs.mattermost.com/help/messaging/sending-messages.html>`__
 * `Mentioning Teammates <https://docs.mattermost.com/help/messaging/mentioning-teammates.html>`__
 * `Formatting Messages using Markdown <https://docs.mattermost.com/help/messaging/formatting-text.html>`__
-* `Attaching Files <https://docs.mattermost.com/help/messaging/attaching-files.html>`__
+* `Sharing Files <https://docs.mattermost.com/help/messaging/attaching-files.html>`__
 * `Executing Commands <https://docs.mattermost.com/help/messaging/executing-commands.html>`__

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -9,7 +9,7 @@ Attach Files to Messages
 You can attach files to messages in the following ways:
 
 -  Use the attachment icon - select the paperclip icon inside the message input box
--  Drag and Drop
+-  Drag and drop
 -  Paste from the clipboard
 
 Preview File Attachments

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -1,12 +1,11 @@
 Sharing Files
 ===============
 
-With file attachments, you can share additional information that will help your 
-team to visually understand your ideas. Sharing videos, voice recordings,
-screenshots, and photos will make your messages more effective and clear.
+With file attachments, you can share additional information that will help your team to visually understand your ideas. Sharing videos, voice recordings, screenshots, and photos will make your messages more effective and clear.
 
 Attach Files to Messages
 ------------------------
+
 You can attach files to messages in the following ways:
 
 -  Use the attachment icon - select the paperclip icon inside the message input box
@@ -15,6 +14,7 @@ You can attach files to messages in the following ways:
 
 Preview File Attachments
 ------------------------
+
 Mattermost has a built-in file previewer that you can use to:
 
 -  Download files
@@ -25,23 +25,20 @@ Select the thumbnail of an attached file to open it in the file previewer.
 
 Downloading Files
 ~~~~~~~~~~~~~~~~~
-You can download an attached file by selecting the download icon next to the file 
-thumbnail.
+
+You can download an attached file by selecting the download icon next to the file thumbnail.
 
 Sharing Public Links
 ~~~~~~~~~~~~~~~~~~~~
-Public URLs allow you to share attachments with anyone outside the Mattermost 
-system. To share an attachment, select the thumbnail of an attachment, then select
-**Get Public Link**.
 
-.. Tip::
-  If **Get Public Link** is not visible in the file previewer,
-  and you prefer that the feature is enabled, you can request your System
-  Admin to enable the feature from the System Console under
-  **Site Configuration > Public Links**.
+Public URLs allow you to share attachments with anyone outside the Mattermost system. To share an attachment, select the thumbnail of an attachment, then select **Get Public Link**.
+
+.. tip::
+  If **Get Public Link** is not visible in the file previewer, and you prefer that the feature is enabled, you can request your System Admin to enable the feature from the System Console under **Site Configuration > Public Links**.
 
 Viewing Media:
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
+
 The following media formats are supported on most browsers:
 
 -  Images: BMP, GIF, JPG, JPEG, PNG, SVG
@@ -53,10 +50,7 @@ Other document previews (such as Word, Excel, or PPT) are not yet supported.
 
 Attachment Limits and Sizes
 ---------------------------
-Mattermost Team Edition and Enterprise Edition supports a maximum of five (5) attached 
-files per post.
 
-Mattermost Cloud supports a maximum of ten (10) attached files per post.
+Mattermost Team Edition and Enterprise Edition supports a maximum of five (5) attached files per post. Mattermost Cloud supports a maximum of ten (10) attached files per post.
 
-The default maximum file size is 50 MB, but this can be changed by the 
-System Admin.
+The default maximum file size is 50 MB, but this can be changed by the System Admin.

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -51,6 +51,6 @@ Other document previews (such as Word, Excel, or PPT) are not yet supported.
 Attachment Limits and Sizes
 ---------------------------
 
-Mattermost Cloud supports a maximum of 10 attached files per post. Mattermost Team Edition and Enterprise Edition support a maximum of five attached files per post, and this maximum will be increased to 10 files per post in a future release.
+The ability to attach a maximum of 10 files per post is available today for Cloud deployments and will be available for self-hosted deployments in Mattermost Server v5.32 and later.
 
 The default maximum file size is 50 MB, but this can be changed by the System Admin.

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -51,6 +51,6 @@ Other document previews (such as Word, Excel, or PPT) are not yet supported.
 Attachment Limits and Sizes
 ---------------------------
 
-Mattermost Team Edition and Enterprise Edition support a maximum of five attached files per post. Mattermost Cloud supports a maximum of 10 attached files per post.
+Mattermost Cloud supports a maximum of 10 attached files per post. Mattermost Team Edition and Enterprise Edition support a maximum of five attached files per post, and this maximum will be increased to 10 files per post in a future release.
 
 The default maximum file size is 50 MB, but this can be changed by the System Admin.

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -1,44 +1,44 @@
 Sharing Files
 ===============
 
-With attachments, you can share additional information that will help your 
+With file attachments, you can share additional information that will help your 
 team to visually understand your ideas. Sharing videos, voice recordings,
 screenshots, and photos will make your messages more effective and clear.
 
-How to Attach Files
--------------------
-You can attach files in the following ways:
+Attach Files to Messages
+------------------------
+You can attach files to messages in the following ways:
 
--  Use the attachment icon - click the paperclip icon inside the message input box
+-  Use the attachment icon - select the paperclip icon inside the message input box
 -  Drag and Drop
 -  Paste from the clipboard
 
-File Previewer
---------------
+Preview File Attachments
+------------------------
 Mattermost has a built-in file previewer that you can use to:
 
 -  Download files
 -  Share public links
 -  View media
 
-Click the thumbnail of an attached file to open it in the file previewer.
+Select the thumbnail of an attached file to open it in the file previewer.
 
 Downloading Files
 ~~~~~~~~~~~~~~~~~
-You can download an attached file by clicking the download icon next to the file 
+You can download an attached file by selecting the download icon next to the file 
 thumbnail.
 
 Sharing Public Links
 ~~~~~~~~~~~~~~~~~~~~
 Public URLs allow you to share attachments with anyone outside the Mattermost 
-system. To share an attachment, click the thumbnail of an attachment, then click
+system. To share an attachment, select the thumbnail of an attachment, then select
 **Get Public Link**.
 
 .. Tip::
-  If **Get Public Link** is not visible in the file previewer
+  If **Get Public Link** is not visible in the file previewer,
   and you prefer that the feature is enabled, you can request your System
   Admin to enable the feature from the System Console under
-  **Security > Public Links**.
+  **Site Configuration > Public Links**.
 
 Viewing Media:
 ~~~~~~~~~~~~~~~~~~~~~
@@ -49,12 +49,14 @@ The following media formats are supported on most browsers:
 -  Audio: MP3, M4A
 -  Files: PDF, TXT
 
-Other document previews (Word, Excel, PPT) are not yet supported.
+Other document previews (such as Word, Excel, or PPT) are not yet supported.
 
 Attachment Limits and Sizes
 ---------------------------
-Please note that Mattermost supports a maximum of five (5) attached 
+Mattermost Team Edition and Enterprise Edition supports a maximum of five (5) attached 
 files per post.
+
+Mattermost Cloud supports a maximum of ten (10) attached files per post.
 
 The default maximum file size is 50 MB, but this can be changed by the 
 System Admin.

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -36,7 +36,7 @@ Public URLs allow you to share attachments with anyone outside the Mattermost sy
 .. tip::
   If **Get Public Link** is not visible in the file previewer, and you prefer that the feature is enabled, you can request your System Admin to enable the feature from the System Console under **Site Configuration > Public Links**.
 
-Viewing Media:
+Viewing Media
 ~~~~~~~~~~~~~~
 
 The following media formats are supported on most browsers:

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -51,6 +51,6 @@ Other document previews (such as Word, Excel, or PPT) are not yet supported.
 Attachment Limits and Sizes
 ---------------------------
 
-Mattermost Team Edition and Enterprise Edition supports a maximum of five (5) attached files per post. Mattermost Cloud supports a maximum of ten (10) attached files per post.
+Mattermost Team Edition and Enterprise Edition support a maximum of five attached files per post. Mattermost Cloud supports a maximum of 10 attached files per post.
 
 The default maximum file size is 50 MB, but this can be changed by the System Admin.


### PR DESCRIPTION
Documentation for: https://mattermost.atlassian.net/browse/MM-27312

Updated:
- User's Guide > Messaging > Sharing Files
   - Clarified references to "attachments" to indicate file attachments (rather than Slack attachments)
   - Updated "File Previewer" section title to "Preview File Attachments" 
   - Updated instances of "click" to "select"
   - Updated Tip to provide correct System Console route to Public Links setting
   - Under Attachment Limits and Sizes, added Cloud support for up to 10 file attachments, and clarified that a max of 5 file attachments remains as-is for TE and EE