### PR TITLE
MM-29011 Feature flag for Shared Channels

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -5375,6 +5375,19 @@ In previous Mattermost Server versions, and this documentation, the instructions
 | This feature's ``config.json`` setting is ``"RunScheduler": true`` with options ``true`` and ``false``.                                 |
 +-----------------------------------------------------------------------------------------------------------------------------------------+
 
+Shared Channels (Experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Available in Enterprise Edition E20*
+
+**True**: Enables users from multiple Mattermost instances to collaborate with one another using shared channels.
+
+**False**: Disables channel sharing.
+
++---------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"EnableSharedChannels": false`` with options ``true`` and ``false``.                |                                         |
++---------------------------------------------------------------------------------------------------------------------------------+ 
+
 Deprecated Configuration Settings
 -----------------------------------
 

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -5385,7 +5385,7 @@ Shared Channels (Experimental)
 **False**: Disables channel sharing.
 
 +---------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableSharedChannels": false`` with options ``true`` and ``false``.                |                                         |
+| This feature's ``config.json`` setting is ``"EnableSharedChannels": false`` with options ``true`` and ``false``.                |
 +---------------------------------------------------------------------------------------------------------------------------------+ 
 
 Deprecated Configuration Settings


### PR DESCRIPTION
Documentation for: https://mattermost.atlassian.net/browse/MM-29011

Updated:
- Self-Managed Admin Guide > Configure Mattermost > Configuration Settings > Experimental Settings only in config.json
   - Added new experimental E20/Cloud config setting "Shared Channels (Experimental)"
