### PR TITLE
MM-30159 Allow moving multi-selected channels with channel context menu

### DIFF
--- a/source/help/getting-started/organizing-conversations.rst
+++ b/source/help/getting-started/organizing-conversations.rst
@@ -154,6 +154,8 @@ When configured by the System Admin, users can enable the features in **Account 
 
 **Collapsible custom categories**: Create custom categories in the sidebar to group channels together for easier navigation (e.g. “Design” or “Marketing”). Collapse categories to display only unread channels and reduce unnecessary scrolling.
 
+**Move channels and categories**: Prioritize important conversations by dragging and dropping channels between or within categories, or drag channels to reorder entire categories. You can also select the **More options** icon, then select **Move to**, followed by a category destination. 
+
 **Drag and drop channels and categories**: Drag channels between or within categories, or drag to reorder entire categories to prioritize important conversations.
 
 **Sort Direct Messages by recent conversations**: Choose to sort Direct Messages alphabetically or by recent conversations first. 


### PR DESCRIPTION
Documentation for: https://mattermost.atlassian.net/browse/MM-30159

Updated:
- User Guide > Getting Started > Organizing Conversations > Experimental: Channel Organization Features
   - Expanded the bullet point about drag and drop to include additional options (available through any channel's 3-dot icon)