### PR TITLE
MM-31085 Create db init CLI command

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -743,7 +743,7 @@ mattermost db init
 ------------------
 
   Description
-    Initializes the database for a given DSN (data name source), executes migrations, and loads custom defaults when specified.
+    Initializes the database for a given data source name (DSN), executes migrations, and loads custom defaults when specified.
 
   Format
     .. code-block:: none

--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -738,6 +738,37 @@ mattermost config validate
       .. code-block:: none
 
         bin/mattermost config validate
+	
+mattermost db init
+------------------
+
+  Description
+    Initializes the database for a given DSN (data name source), executes migrations, and loads custom defaults when specified.
+
+  Format
+    .. code-block:: none
+
+      mattermost db init
+
+  Examples
+  
+    Use the ``config`` flag to pass the DSN:
+    
+    .. code-block:: none
+
+       mattermost db init --config postgres://localhost/mattermost
+       
+    Run this command to use the ``MM_CONFIG`` environment variable:
+    
+    .. code-block:: none
+      
+       MM_CONFIG=postgres://localhost/mattermost mattermost db init
+    
+    Run this command to set a custom defaults file to be loaded into the database: 
+    
+    .. code-block:: none
+    
+       MM_CUSTOM_DEFAULTS_PATH=custom.json MM_CONFIG=postgres://localhost/mattermost mattermost db init
 
 mattermost export
 -----------------


### PR DESCRIPTION
Documentation for: https://mattermost.atlassian.net/browse/MM-31085

Updated:
- Self-Managed Admin Guide > Administration > Command Line Tools > Mattermost 3.6 and later
   - Added new mattermost db init command documentation