### PR TITLE
Removed server restart step

### DIFF
--- a/source/deployment/sso-google.md
+++ b/source/deployment/sso-google.md
@@ -40,8 +40,6 @@ Under **Restrictions > Authorized redirect URIs**, enter `your-mattermost-url/si
 
 7. In **System Console > OAuth 2.0 > Select OAuth 2.0 service provider**, choose **Google Apps** as the service provider and enter **Client ID** and **Client Secret** from step 6 in their respective fields.
 
-8. Restart your Mattermost server to see the changes take effect.
-
 **Note:**
 - You may also enter **Client ID** and **Client Secret** fields from step 6 directly in `GoogleSettings` section of `config/config.json`.
 - The following default values in `GoogleSettings` section of `config/config.json` are recommended:


### PR DESCRIPTION
Informed by: https://github.com/mattermost/docs/pull/4228

Updated:
- Self-Managed Admin Guide > Onboard Users > Google Single Sign-On
   - Removed the very last procedural step instructing the admin to restart the Mattermost server for changes to take effect. No longer necessary.
