### PR TITLE
Fix broken links

### DIFF
--- a/source/cloud/cloud-integrations.rst
+++ b/source/cloud/cloud-integrations.rst
@@ -2,7 +2,7 @@ Incoming Webhooks
 =================
 
 .. note::
-  This is the admin documentation for incoming webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/>`__.
+  This is the admin documentation for incoming webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports webhooks to easily integrate external applications into the server.
 

--- a/source/cloud/cloud-integrations/cloud-incoming-webhooks.rst
+++ b/source/cloud/cloud-integrations/cloud-incoming-webhooks.rst
@@ -2,7 +2,7 @@ Incoming Webhooks
 =================
 
 .. note::
-  This is the admin documentation for incoming webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/>`__.
+  This is the admin documentation for incoming webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports webhooks to easily integrate external applications into the server.
 

--- a/source/cloud/cloud-integrations/cloud-outgoing-webhooks.rst
+++ b/source/cloud/cloud-integrations/cloud-outgoing-webhooks.rst
@@ -3,7 +3,7 @@ Outgoing Webhooks
 =================
 
 .. note::
-  This is the admin documentation for outgoing webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/>`__.
+  This is the admin documentation for outgoing webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports webhooks to easily integrate external applications into Mattermost.
 

--- a/source/cloud/cloud-integrations/cloud-slash-commands.rst
+++ b/source/cloud/cloud-integrations/cloud-slash-commands.rst
@@ -4,7 +4,7 @@ Slash Commands
 
 .. note::
 
-  This is the admin documentation for slash commands. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/>`__.
+  This is the admin documentation for slash commands. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports slash commands to easily integrate external applications into the server. They function similarly to `outgoing webhooks <https://docs.mattermost.com/cloud/cloud-integrations/cloud-outgoing-webhooks.html>`_, except they can be used in any channel - including Private channels and Direct Messages.
 

--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -5,7 +5,7 @@ Slash Commands
 
 .. note::
 
-  This is the admin documentation for slash commands. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/>`__.
+  This is the admin documentation for slash commands. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports slash commands to easily integrate external applications into the server. They function similarly to :doc:`outgoing webhooks <../developer/webhooks-outgoing/>`, except they can be used in any channel - including Private channels and Direct Messages.
 

--- a/source/developer/webhooks-incoming.rst
+++ b/source/developer/webhooks-incoming.rst
@@ -4,7 +4,7 @@ Incoming Webhooks
 =================
 
 .. note::
-  This is the admin documentation for incoming webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/>`__.
+  This is the admin documentation for incoming webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports webhooks to easily integrate external applications into the server.
 

--- a/source/developer/webhooks-outgoing.rst
+++ b/source/developer/webhooks-outgoing.rst
@@ -4,7 +4,7 @@ Outgoing Webhooks
 =================
 
 .. note::
-  This is the admin documentation for outgoing webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/>`__.
+  This is the admin documentation for outgoing webhooks. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports webhooks to easily integrate external applications into the server.
 


### PR DESCRIPTION
Unsure if this is the correct fix, but https://developers.mattermost.com/integrate/ seems to be a broken page