### PR TITLE
Add Incident Management automation features

### DIFF
--- a/source/administration/devops-command-center.rst
+++ b/source/administration/devops-command-center.rst
@@ -93,7 +93,10 @@ A playbook must be defined before starting an incident.
   * Optionally configure a broadcast channel to which status updates will be copied. If you are not a member of the configured broadcast channel, `Unknown Channel` will be shown instead of the channel name.
   * Optionally configure the default reminder timer used to prompt for regular updates. The reminder timer may be changed when a status update is written.
   * Optionally configure a template to use for the first status update. Subsequent status updates will start with the text of the most recent update.
-8. On the right-hand side of the screen, configure the permissions:
+8. Select the **Automation** tab.
+9. Within the **Automation** tab, customize automatically triggered tasks:
+  * Optionally enable the **Invite members** toggle and select a set of members, which will be automatically invited to the incident channel when it starts
+10. On the right-hand side of the screen, configure the permissions:
   * Decide whether the automatically created incident channel should be public or private within the team.
   * Share this playbook with other members of the team to allow them to use the playbook to start an incident, as well as edit the playbook.
 

--- a/source/administration/devops-command-center.rst
+++ b/source/administration/devops-command-center.rst
@@ -95,9 +95,9 @@ A playbook must be defined before starting an incident.
   * Optionally configure a template to use for the first status update. Subsequent status updates will start with the text of the most recent update.
 8. Select the **Automation** tab.
 9. Within the **Automation** tab, customize automatically triggered tasks:
-  * Optionally enable the **Invite members** toggle and select a set of members, which will be automatically invited to the incident channel when it starts
+  * Optionally enable the **Invite members** toggle and select a set of members. This set of members are automatically invited to the incident channel when the incident starts.
 10. On the right-hand side of the screen, configure the permissions:
-  * Decide whether the automatically created incident channel should be public or private within the team.
+  * Decide whether the automatically created incident channel should be Public or Private within the team.
   * Share this playbook with other members of the team to allow them to use the playbook to start an incident, as well as edit the playbook.
 
 Configuring a playbook


### PR DESCRIPTION
#### Summary
Start the documentation on the automation features. I'll probably add a bit more structure when we have more features, but given that there is only one at the moment, I simply added it to the playbook creation description.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32345