### PR TITLE
Cloud - MaxFileSize changed from 50Mb to 100Mb

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -589,7 +589,7 @@ Maximum File Size
 Maximum file size for message attachments entered in megabytes in the System Console UI. Converted to bytes in ``config.json`` at 1048576 bytes per megabyte.
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"MaxFileSize": 52428800`` with numerical input.                                                                          |
+| This feature's ``config.json`` setting is ``"MaxFileSize": 104857600`` with numerical input.                                                                          |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. warning:: Verify server memory can support your setting choice. Large file sizes increase the risk of server crashes and failed uploads due to network disruptions.

--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -589,7 +589,7 @@ Maximum File Size
 Maximum file size for message attachments entered in megabytes in the System Console UI. Converted to bytes in ``config.json`` at 1048576 bytes per megabyte.
 
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"MaxFileSize": 104857600`` with numerical input.                                                                          |
+| This feature's ``config.json`` setting is ``"MaxFileSize": 104857600`` with numerical input.                                                                         |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. warning:: Verify server memory can support your setting choice. Large file sizes increase the risk of server crashes and failed uploads due to network disruptions.

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -53,4 +53,4 @@ Attachment Limits and Sizes
 
 The ability to attach a maximum of 10 files per post is available today for Cloud deployments and will be available for self-hosted deployments in Mattermost Server v5.32 and later.
 
-The default maximum file size is 50 MB, but this can be changed by the System Admin.
+The default maximum file size is 100 MB, but this can be changed by the System Admin.


### PR DESCRIPTION
Documentation ticket: https://mattermost.atlassian.net/browse/MM-32597

Updated:
- User's Guide > Messaging > Sharing Files > Attachment Limits and Sizes -- changed default maximum file size from 50 MB to 100 MB