### PR TITLE
MM-32617 - File Attachment Limit Increase in v5.32

### DIFF
--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -51,6 +51,4 @@ Other document previews (such as Word, Excel, or PPT) are not yet supported.
 Attachment Limits and Sizes
 ---------------------------
 
-The ability to attach a maximum of 10 files per post is available today for Cloud deployments and will be available for self-hosted deployments in Mattermost Server v5.32 and later.
-
-The default maximum file size is 50 MB, but this can be changed by the System Admin.
+A maximum of 10 files can be attached per post. The default maximum file size is 50 MB, but this can be changed by the System Admin.


### PR DESCRIPTION
Documentation ticket: https://mattermost.atlassian.net/browse/MM-32617

Updated:
- User's Guide > Messaging > Sharing Files > Attachment Limits and Sizes
   - Removed the limitation of this feature being available only for Cloud