### PR TITLE
Cloud - File Attachment Updates

### DIFF
--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -51,6 +51,6 @@ Other document previews (such as Word, Excel, or PPT) are not yet supported.
 Attachment Limits and Sizes
 ---------------------------
 
-The ability to attach a maximum of 10 files per post is available today for Cloud deployments and will be available for self-hosted deployments in Mattermost Server v5.32 and later.
+A maximum of 10 files can be attached per post.
 
-The default maximum file size is 100 MB, but this can be changed by the System Admin.
+The default maximum file size for Cloud deployments is 100 MB, and this file size increase will be available for self-hosted deployments from Mattermost Server v5.33. 

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -53,4 +53,4 @@ Attachment Limits and Sizes
 
 A maximum of 10 files can be attached per post.
 
-The default maximum file size for Cloud deployments is 100 MB, and this file size increase will be available for self-hosted deployments from Mattermost Server v5.33. 
+The default maximum file size for attachments for Cloud deployments is 100 MB. For self-hosted deployments, this can be changed by the System Admin. 


### PR DESCRIPTION
Docs ticket: https://mattermost.atlassian.net/browse/MM-32617

Updated:
- User's Guide > Messaging > Sharing Files > Attachment Limits and Sizes
   - max of 10 files can be attached per post (available in both Cloud & self-managed as of v5.32)
   - default max file size is now 100MB (from 50MB) for Cloud; will be available for self-managed as of v5.33
