### PR TITLE
Broken Link Fixes

### DIFF
--- a/source/cloud/cloud-administration/sso-gitlab.rst
+++ b/source/cloud/cloud-administration/sso-gitlab.rst
@@ -5,7 +5,9 @@ GitLab Single Sign-On
 Migrating from OAuth 2.0 to OpenID Connect
 -------------------------------------------
 
-OAuth 2.0 is being deprecated and replaced by OpenID Connect. Refer to product documentation to `convert your existing OAuth configuration <https://docs.mattermost.com/cloud/cloud-administration/converting-oauth-2.0-to-openid-connect>`__ for GitLab to the OpenID Connect standard. 
+OAuth 2.0 is being deprecated and replaced by OpenID Connect. Refer to product documentation to `convert your existing OAuth configuration <https://docs.mattermost.com/cloud/cloud-administration/converting-oauth-2.0-to-openid-connect.html>`__ for GitLab to the OpenID Connect standard. 
+
+converting-oauth-2.0-to-openid-connect.rst
 
 Configuring GitLab as a Single Sign-On (SSO) service
 ----------------------------------------------------

--- a/source/cloud/cloud-administration/sso-google.md
+++ b/source/cloud/cloud-administration/sso-google.md
@@ -2,7 +2,7 @@
 
 ## Migrating from OAuth 2.0 to OpenID Connect
 
-OAuth 2.0 is being deprecated and replaced by OpenID Connect. Refer to the product documentation to [convert your existing OAuth configuration](https://docs.mattermost.com/cloud/cloud-administration/converting-oauth-2.0-to-openid-connect) for Google Apps to the OpenID Connect standard.
+OAuth 2.0 is being deprecated and replaced by OpenID Connect. Refer to the product documentation to [convert your existing OAuth configuration](https://docs.mattermost.com/cloud/cloud-administration/converting-oauth-2.0-to-openid-connect.html) for Google Apps to the OpenID Connect standard.
 
 ## Configuring Google Apps as a Single Sign-On (SSO) service
 

--- a/source/cloud/cloud-administration/sso-office.md
+++ b/source/cloud/cloud-administration/sso-office.md
@@ -2,7 +2,7 @@
 
 ## Migrating from OAuth to OpenID Connect
 
-OAuth 2.0 is being deprecated and replaced by OpenID Connect. Refer to the product documentation to [convert your existing OAuth configuration](https://docs.mattermost.com/cloud/cloud-administration/converting-oauth-2.0-to-openid-connect) for Office 365 to the OpenID Connect standard.
+OAuth 2.0 is being deprecated and replaced by OpenID Connect. Refer to the product documentation to [convert your existing OAuth configuration](https://docs.mattermost.com/cloud/cloud-administration/converting-oauth-2.0-to-openid-connect.html) for Office 365 to the OpenID Connect standard.
 
 ## Configuring Office 365 as a Single Sign-On (SSO) service
 


### PR DESCRIPTION
Updated:
- Cloud Admin Guide > Authentication > GitLab Single Sign-On > Migrating from OAuth to OpenID Connect
   - Fixed broken link to conversion page.