### PR TITLE
Updating Image max sizes

### DIFF
--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -55,4 +55,4 @@ Up to five files can be attached per post.
 
 The default maximum file size is 100 MB, but this can be changed by the System Admin.
 
-Images have a max size of 6048px x 4032px OR 24 megapixels, roughly 36MB as a raw image
+Image files can be a maximum size of 6048 pixels x 4032 pixels, or 24 MP (mega pixels), or a raw image file size of approximately 36 MB.

--- a/source/help/messaging/attaching-files.rst
+++ b/source/help/messaging/attaching-files.rst
@@ -54,3 +54,5 @@ Attachment Limits and Sizes
 Up to five files can be attached per post.
 
 The default maximum file size is 100 MB, but this can be changed by the System Admin.
+
+Images have a max size of 6048px x 4032px OR 24 megapixels, roughly 36MB as a raw image


### PR DESCRIPTION
Image max size information found here - https://github.com/mattermost/mattermost-server/blob/7b8cff1962b22103e117a10c60ce8238004a7740/app/file.go#L64

It's not clear that I could find in the docs what the max size for images was.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

