### PR TITLE
MM-33510 - Remove manual config via config.json

### DIFF
--- a/source/cloud/cloud-administration/sso-google.md
+++ b/source/cloud/cloud-administration/sso-google.md
@@ -57,22 +57,3 @@ Go to the [Google People API](https://console.developers.google.com/apis/api/plu
 6. Select **Save**.
 
 7. Restart your Mattermost server to see the changes take effect.
-
-**Note:**
-- Alternatively, you may enter **Client ID** and **Client Secret** values directly into the `GoogleSettings` section of the Mattermost `config/config.json` file.
-- The following default values are recommended:
-
-```
-"GoogleSettings": {
-        "Enable": false,
-        "Secret": "fake_secret",
-        "Id": "fake_id",
-        "Scope": "profile openid email",
-        "AuthEndpoint": "",
-        "TokenEndpoint": "",
-        "UserApiEndpoint": "",
-        "DiscoveryEndpoint": "https://accounts.google.com/.well-known/openid-configuration",
-        "ButtonText": "",
-        "ButtonColor": ""
-    },
-    ```


### PR DESCRIPTION
Documentation task: https://mattermost.atlassian.net/browse/MM-33510

Updated:
- Cloud Admin Guide > Authentication > Google Single Sign-On
   - Removed manual config.json steps since Cloud System Admins can't modify the config.json file directly