### PR TITLE
MM-31391 - Add max connection idle timeout - Self-Managed

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -388,10 +388,6 @@ Maximum Connection Idle Timeout
 
 Maximum time a database connection can remain idle.
 
-.. note::
-
-  This configuration setting is available in Mattermost Cloud, and will be available in Mattermost Server v5.33 on March 16, 2021. 
-
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"ConnMaxIdleTimeMilliseconds": 5`` with numerical input.                                                                 |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/16792

Updated:
- Self-Managed Admin Guide > Configure Mattermost > Configuration Settings > Database > Maximum Connection Idle Timeout
   - Removed Cloud-first disclaimer note