### PR TITLE
UG References to "sign-in" are inconsistent

### DIFF
--- a/source/help/getting-started/signing-in.rst
+++ b/source/help/getting-started/signing-in.rst
@@ -133,7 +133,7 @@ Android Setup
 
 Your Mattermost teams can be accessed on Android mobile devices by downloading the Mattermost Mobile App.
 
-1. Open the `Google Play Store`_ on your Android device.
+1. Open the Play Store on your Android device.
 2. Search for “Mattermost” and select **INSTALL** to download the app.
 3. Open Mattermost from your homescreen and enter your team and account information to login:
 

--- a/source/help/getting-started/signing-in.rst
+++ b/source/help/getting-started/signing-in.rst
@@ -137,7 +137,7 @@ Your Mattermost teams can be accessed on Android mobile devices by downloading t
 2. Search for "Mattermost" and select **INSTALL** to download the app.
 3. Open Mattermost from your homescreen and enter your team and account information to login:
 
-   a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It is in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 
+   a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It's in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 
    b. **Sign in to Mattermost:** This is your account login information as described by one of the sign in methods above.
 
 .. _Okta: https://developer.okta.com/docs/guides/saml_guidance.html

--- a/source/help/getting-started/signing-in.rst
+++ b/source/help/getting-started/signing-in.rst
@@ -121,7 +121,7 @@ iOS Setup
 
 Your Mattermost teams can be accessed on iOS mobile devices via the Mattermost Mobile App.
 
-1. Open the `App Store` on your Apple device running iOS 9.0 or later.
+1. Open the App Store on your Apple device running iOS 9.0 or later.
 2. Search for “Mattermost” and select **GET** to download the app.
 3. Open Mattermost from your homescreen and enter your team and account information to log in:
 

--- a/source/help/getting-started/signing-in.rst
+++ b/source/help/getting-started/signing-in.rst
@@ -122,7 +122,7 @@ iOS Setup
 Your Mattermost teams can be accessed on iOS mobile devices via the Mattermost Mobile App.
 
 1. Open the App Store on your Apple device running iOS 9.0 or later.
-2. Search for “Mattermost” and select **GET** to download the app.
+2. Search for "Mattermost" and select **GET** to download the app.
 3. Open Mattermost from your homescreen and enter your team and account information to log in:
 
    a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It is in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 

--- a/source/help/getting-started/signing-in.rst
+++ b/source/help/getting-started/signing-in.rst
@@ -9,7 +9,7 @@ An invitation is required to access Mattermost. A member of your Mattermost work
 Sign In 
 --------
 
-To sign in, navigate to the Mattermost sign-in page. You can get the URL of the sign-in page from your System Admin or in an invitation email. We recommend bookmarking the site so you can easily find it again.
+To sign in, navigate to the Mattermost sign-in screen. You can get the URL of the sign-in screen from your System Admin or in an invitation email. We recommend bookmarking the site so you can easily find it again.
 
 After signing in, the team that appears first on your team sidebar will open. If you have not joined a team, the Team Selection page opens where you can view a list of teams that you can join.
 
@@ -121,25 +121,24 @@ iOS Setup
 
 Your Mattermost teams can be accessed on iOS mobile devices via the Mattermost Mobile App.
 
-#. Open the `App Store` on your Apple device running iOS 9.0 or later.
-#. Search for “Mattermost” and select **GET** to download the app.
-#. Open Mattermost from your homescreen and enter your team and account information to log in:
+1. Open the `App Store` on your Apple device running iOS 9.0 or later.
+2. Search for “Mattermost” and select **GET** to download the app.
+3. Open Mattermost from your homescreen and enter your team and account information to log in:
 
-   #. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. You can find the Server URL by asking your
-      System Admin or by looking at the address bar in a desktop browser tab with Mattermost open. It is in the format ``https://domain.com``.
-   #. **Sign in to Mattermost:** This is your account login information as described by one of the sign in methods above.
+   a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It is in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 
+   b. **Sign in to Mattermost:** This is your account login information as described by one of the sign in methods above.
 
 Android Setup
 -------------
 
 Your Mattermost teams can be accessed on Android mobile devices by downloading the Mattermost Mobile App.
 
-#. Open the `Google Play Store`_ on your Android device.
-#. Search for “Mattermost” and select **INSTALL** to download the app.
-#. Open Mattermost from your homescreen and enter your team and account information to login:
+1. Open the `Google Play Store`_ on your Android device.
+2. Search for “Mattermost” and select **INSTALL** to download the app.
+3. Open Mattermost from your homescreen and enter your team and account information to login:
 
-   #. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. You can find the Server URL by asking your System Admin or by looking at the address bar in a desktop browser tab with Mattermost open. It is in the format ``https://domain.com``.
-   #. **Sign in to Mattermost:** This is your account login information as described by one of the sign in methods above.
+   a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It is in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 
+   b. **Sign in to Mattermost:** This is your account login information as described by one of the sign in methods above.
 
 .. _Okta: https://developer.okta.com/docs/guides/saml_guidance.html
 .. _Microsoft ADFS: https://msdn.microsoft.com/en-us/library/bb897402.aspx

--- a/source/help/getting-started/signing-in.rst
+++ b/source/help/getting-started/signing-in.rst
@@ -134,7 +134,7 @@ Android Setup
 Your Mattermost teams can be accessed on Android mobile devices by downloading the Mattermost Mobile App.
 
 1. Open the Play Store on your Android device.
-2. Search for “Mattermost” and select **INSTALL** to download the app.
+2. Search for "Mattermost" and select **INSTALL** to download the app.
 3. Open Mattermost from your homescreen and enter your team and account information to login:
 
    a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It is in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 

--- a/source/help/getting-started/signing-in.rst
+++ b/source/help/getting-started/signing-in.rst
@@ -125,7 +125,7 @@ Your Mattermost teams can be accessed on iOS mobile devices via the Mattermost M
 2. Search for "Mattermost" and select **GET** to download the app.
 3. Open Mattermost from your homescreen and enter your team and account information to log in:
 
-   a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It is in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 
+   a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It's in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 
    b. **Sign in to Mattermost:** This is your account login information as described by one of the sign in methods above.
 
 Android Setup

--- a/source/help/settings/account-settings.rst
+++ b/source/help/settings/account-settings.rst
@@ -33,7 +33,7 @@ Position can be used to describe your role or job title. It appears in the profi
 Email
 ~~~~~
 
-Email is used for sign-in, notifications, and password reset. Email requires verification if changed. If you are signing in using a single sign-on service, the email field is not editable and you will receive email notifications to the email you used to sign up to your SSO service.
+Email is used for signing in, notifications, and password reset. Email requires verification if changed. If you are signing in using a single sign-on service, the email field is not editable and you will receive email notifications to the email you used to sign up to your SSO service.
 
 Profile Picture
 ~~~~~~~~~~~~~~~
@@ -53,7 +53,7 @@ You may change your password if you’ve logged in by email. If you are signing 
 Multi-factor Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When this option is available you can require a phone-based passcode in addition to your password for sign-in.
+When this option is available, you can require a phone-based passcode in addition to your password when signing in.
 
 To enable, download Google Authenticator from `iTunes <https://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8>`__ or `Google Play <https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en>`__ for your phone, then:
 

--- a/source/help/settings/team-settings.rst
+++ b/source/help/settings/team-settings.rst
@@ -13,7 +13,7 @@ General settings provide options around how teams are displayed to users.
 Team Name
 ~~~~~~~~~
 
-Your **Team Name** is displayed on the sign-in page, and in the top of the left-hand sidebar for your team. 
+Your **Team Name** is displayed on the sign-in screen, and in the top of the left-hand sidebar for your team. 
 
 You can enter a name up to 15 characters in length. Please note that `some unicode characters <https://www.w3.org/TR/unicode-xml/#Charlist>`_ are not supported. The length of team names is limited to ensure readability.
 


### PR DESCRIPTION
Documentation ticket: https://mattermost.atlassian.net/browse/MM-33322

Updated:
- User's Guide > Getting Started > Signing In > Sign In
   - Updated "sign-in page" references to "sign-in screen"
