### PR TITLE
Backport notes to changelog

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -258,7 +258,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 - **v5.31.2, release day TBD**
   - Improving typing performance on busy servers with the new sidebar enabled. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
-  - Fixing some replication lag issues.
+  - Fixing bugs related to replication lag for Enterprise Edition instances configured to use read replicas. [MM-31094](https://mattermost.atlassian.net/browse/MM-31094)
 - **v5.31.1, released 2021-02-05**
   - Fixed an issue where the ``config.json`` was sporadically getting reset upon CLI command execution. [MM-32234](https://mattermost.atlassian.net/browse/MM-32234)
   - Fixed an issue where ``FeatureFlags`` section was getting erroneously written to ``config.json``. [MM-32389](https://mattermost.atlassian.net/browse/MM-32389)

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -7,6 +7,7 @@ Also see [changelog in progress](https://bit.ly/2nK3cVf) for the next release.
 ## Release v5.33 - [Feature Release](https://docs.mattermost.com/administration/release-definitions.html#feature-release)
 
 - **v5.33.2, release day TBD**
+  - Investigating an issue with WebSocket handling where client-side pings fail WebSocket connections [MM-34158](https://mattermost.atlassian.net/browse/MM-34158)
   - Improving typing performance on busy servers with the new sidebar enabled. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
 - **v5.33.1, released 2021-03-22**
   - Fixed an issue where WebSockets failed with TLS connections. [MM-34000](https://mattermost.atlassian.net/browse/MM-34000)

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -7,7 +7,7 @@ Also see [changelog in progress](https://bit.ly/2nK3cVf) for the next release.
 ## Release v5.33 - [Feature Release](https://docs.mattermost.com/administration/release-definitions.html#feature-release)
 
 - **v5.33.2, release day TBD**
-  - Fixing performance issues with the new sidebar that affects typing performance on busy servers. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
+  - Improving typing performance on busy servers with the new sidebar enabled. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
 - **v5.33.1, released 2021-03-22**
   - Fixed an issue where WebSockets failed with TLS connections. [MM-34000](https://mattermost.atlassian.net/browse/MM-34000)
   - Fixed a race condition which would crash the app server due to improper handling of WebSockets closing. [MM-33233](https://mattermost.atlassian.net/browse/MM-33233)
@@ -257,7 +257,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 ## Release v5.31 - [ESR](https://docs.mattermost.com/administration/extended-support-release.html)
 
 - **v5.31.2, release day TBD**
-  - Fixing performance issues with the new sidebar that affects typing performance on busy servers. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
+  - Improving typing performance on busy servers with the new sidebar enabled. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
   - Fixing some replication lag issues.
 - **v5.31.1, released 2021-02-05**
   - Fixed an issue where the ``config.json`` was sporadically getting reset upon CLI command execution. [MM-32234](https://mattermost.atlassian.net/browse/MM-32234)

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -6,6 +6,8 @@ Also see [changelog in progress](https://bit.ly/2nK3cVf) for the next release.
 
 ## Release v5.33 - [Feature Release](https://docs.mattermost.com/administration/release-definitions.html#feature-release)
 
+- **v5.33.2, release day TBD**
+  - Fixing performance issues with the new sidebar that affects typing performance on busy servers. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
 - **v5.33.1, released 2021-03-22**
   - Fixed an issue where WebSockets failed with TLS connections. [MM-34000](https://mattermost.atlassian.net/browse/MM-34000)
   - Fixed a race condition which would crash the app server due to improper handling of WebSockets closing. [MM-33233](https://mattermost.atlassian.net/browse/MM-33233)
@@ -254,6 +256,9 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ## Release v5.31 - [ESR](https://docs.mattermost.com/administration/extended-support-release.html)
 
+- **v5.31.2, release day TBD**
+  - Fixing performance issues with the new sidebar that affects typing performance on busy servers. [MM-30407](https://mattermost.atlassian.net/browse/MM-30407)
+  - Fixing some replication lag issues.
 - **v5.31.1, released 2021-02-05**
   - Fixed an issue where the ``config.json`` was sporadically getting reset upon CLI command execution. [MM-32234](https://mattermost.atlassian.net/browse/MM-32234)
   - Fixed an issue where ``FeatureFlags`` section was getting erroneously written to ``config.json``. [MM-32389](https://mattermost.atlassian.net/browse/MM-32389)


### PR DESCRIPTION
For https://github.com/mattermost/mattermost-webapp/pull/7685, https://github.com/mattermost/mattermost-server/pull/17187, and https://mattermost.atlassian.net/browse/MM-34158