### PR TITLE
Broken link fix from PR 4420

### DIFF
--- a/source/cloud/cloud-integrations/cloud-slash-commands.rst
+++ b/source/cloud/cloud-integrations/cloud-slash-commands.rst
@@ -4,11 +4,11 @@ Slash Commands
 
 .. note::
 
-  This is the admin documentation for slash commands. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate>`__.
+  This is the admin documentation for slash commands. If you're a developer looking to build an integration, see `our developer documentation <https://developers.mattermost.com/integrate/getting-started/>`__.
 
 Mattermost supports slash commands to easily integrate external applications into the workspace. They function similarly to `outgoing webhooks <https://docs.mattermost.com/cloud/cloud-integrations/cloud-outgoing-webhooks.html>`_, except they can be used in any channel - including Private channels and direct messages.
 
-Messages that begin with ``/`` are interpreted as slash commands. The commands will send an HTTP POST request to a web service, and process a response back to Mattermost. Mattermost supports both `built-in <https://docs.mattermost.com/cloud/cloud-integrations/cloud-slash-commands.html#built-in-commands>`__ and `custom slash commands <https://docs.mattermost.com/cloud/cloud-integrations/cloud-slash-commands.html>`__.
+Messages that begin with ``/`` are interpreted as slash commands. The commands will send an HTTP POST request to a web service, and process a response back to Mattermost. Mattermost supports both `built-in <https://docs.mattermost.com/cloud/cloud-integrations/cloud-slash-commands.html#built-in-commands>`__ and `custom slash commands <https://docs.mattermost.com/cloud/cloud-integrations/cloud-slash-commands.html#custom-slash-command>`__.
 
 .. note::
   


### PR DESCRIPTION
Fixed broken link identified via https://github.com/mattermost/docs/pull/4420
Fixed 1 additional link that wasn't going to the correct destination.