### PR TITLE
MM-31132 app/server: add pprof endpoint

### DIFF
--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -66,7 +66,7 @@ Replace the ``<hostname1>:<port>`` parameter with your Mattermost host IP addres
 
 .. note::
 
-  A Mattermost Enterprise Edition installation with an E20 license is required to connect to ``/metrics`` using http.
+   A Mattermost Enterprise Edition E20 license is required to connect to ``/metrics`` using HTTP.
 
 5. Finally, run ``vi prometheus.yml`` to finish configuring Prometheus.
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -236,12 +236,16 @@ Use annotations to streamline analysis when a job is long running, such as an LD
 Standard GO Metrics
 ~~~~~~~~~~~~~~~~~~~
 
-The Prometheus integration also provides standard GO metrics for HTTP server runtime profiling data and system monitoring, such as:
+The Prometheus integration provides standard GO metrics for HTTP server runtime profiling data and system monitoring, such as:
 
 - ``go_memstats_alloc_bytes`` for memory usage
 - ``go_goroutines`` for GO routines
 - ``go_gc_duration_seconds`` for garbage collection duration
 - ``go_memstats_heap_objects`` for object tracking on the heap
+
+.. note::
+
+  Profile reports are available without a Mattermost Enterprise Edition license.
 
 To learn how to set up runtime profiling, see the `pprof package GO documentation <https://golang.org/pkg/net/http/pprof/>`__.  You can also visit the ``ip:port/metrics`` page for a complete list of metrics with descriptions.
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -235,7 +235,7 @@ Use annotations to streamline analysis when a job is long running, such as an LD
 
   Jobs where the runtime is less than the Prometheus polling interval are unlikely to be visible because Grafana is performing range queries over the raw Prometheus timeseries data, and rendering an event each time the value changes.
 
-Standard GO Metrics
+Standard Go Metrics
 ~~~~~~~~~~~~~~~~~~~
 
 The performance monitoring feature provides standard Go metrics for HTTP server runtime profiling data and system monitoring, such as:

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -57,7 +57,7 @@ Installing Prometheus
 
 Replace the ``<hostname1>:<port>`` parameter with your Mattermost host IP address and port to scrape the data. It connects to ``/metrics`` using http. 
 
-3. In the Mattermost System Console, go to **Environment > Performance Monitoring** to set **Enable Performance Monitoring** to **true**, then specify the **Listen Address** and select **Save**. See our `configuration settings documentation <https://docs.mattermost.com/administration/config-settings.html#performance-monitoring>`__ for details. After enabling performance monitoring, restart the Mattermost Server.
+3. In the Mattermost System Console, go to **Environment > Performance Monitoring** to set **Enable Performance Monitoring** to **true**, then specify the **Listen Address** and select **Save**. See our `configuration settings documentation <https://docs.mattermost.com/administration/config-settings.html#performance-monitoring>`__ for details.
 
 .. image:: ../images/perf_monitoring_system_console.png
   :scale: 70

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -253,7 +253,7 @@ To learn how to set up runtime profiling, see the `pprof package Go documentatio
 
 .. note::
 
-  A Mattermost Enterprise Edition installation with an E20 license is required to connect to ``/metrics`` using http.
+   A Mattermost Enterprise Edition E20 license is required to connect to ``/metrics`` using HTTP.
 
 If enabled, you can run the profiler by
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -249,7 +249,7 @@ The performance monitoring feature provides standard Go metrics for HTTP server 
 
   Profile reports are available without a Mattermost Enterprise Edition license.
 
-To learn how to set up runtime profiling, see the `pprof package GO documentation <https://golang.org/pkg/net/http/pprof/>`__.  You can also visit the ``ip:port/metrics`` page for a complete list of metrics with descriptions.
+To learn how to set up runtime profiling, see the `pprof package Go documentation <https://golang.org/pkg/net/http/pprof/>`__.  You can also visit the ``ip:port`` page for a complete list of metrics with descriptions.
 
 .. note::
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -18,7 +18,7 @@ Details on integrating your Mattermost server with Prometheus and Grafana.
 Installing Prometheus
 ----------------------
 
-1. `Download a precompiled binary for Prometheus <https://prometheus.io/download/>`__. Binaries are provided for many popular distributions, including Darwin, Linux, and Windows. For install instructions, see `Prometheus install guides <https://prometheus.io/docs/introduction/getting_started/>`__.
+1. `Download a precompiled binary for Prometheus <https://prometheus.io/download/>`__. Binaries are provided for many popular distributions, including Darwin, Linux, and Windows. For installation instructions, see the `Prometheus install guides <https://prometheus.io/docs/introduction/getting_started/>`__.
 
 2. The following settings are recommended in the Prometheus configuration file named ``prometheus.yml``:
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -249,7 +249,7 @@ The performance monitoring feature provides standard Go metrics for HTTP server 
 
   Profile reports are available to Team Edition and Enterprise Edition users.
 
-To learn how to set up runtime profiling, see the `pprof package Go documentation <https://golang.org/pkg/net/http/pprof/>`__.  You can also visit the ``ip:port`` page for a complete list of metrics with descriptions.
+To learn how to set up runtime profiling, see the `pprof package Go documentation <https://golang.org/pkg/net/http/pprof/>`__. You can also visit the ``ip:port`` page for a complete list of metrics with descriptions.
 
 .. note::
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -241,7 +241,7 @@ Standard Go Metrics
 The performance monitoring feature provides standard Go metrics for HTTP server runtime profiling data and system monitoring, such as:
 
 - ``go_memstats_alloc_bytes`` for memory usage
-- ``go_goroutines`` for GO routines
+- ``go_goroutines`` for number of goroutines
 - ``go_gc_duration_seconds`` for garbage collection duration
 - ``go_memstats_heap_objects`` for object tracking on the heap
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -18,7 +18,7 @@ Details on integrating your Mattermost server with Prometheus and Grafana.
 Installing Prometheus
 ----------------------
 
-1. `Download a precompiled binary for Prometheus <https://prometheus.io/download/>`__. Binaries are provided for many popular distributions, including Darwin, Linux and Windows. For install instructions, see `Prometheus install guides <https://prometheus.io/docs/introduction/getting_started/>`__.
+1. `Download a precompiled binary for Prometheus <https://prometheus.io/download/>`__. Binaries are provided for many popular distributions, including Darwin, Linux, and Windows. For install instructions, see `Prometheus install guides <https://prometheus.io/docs/introduction/getting_started/>`__.
 
 2. The following settings are recommended in the Prometheus configuration file named ``prometheus.yml``:
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -18,9 +18,7 @@ Details on integrating your Mattermost server with Prometheus and Grafana.
 Installing Prometheus
 ----------------------
 
-1. `Download a precompiled binary for Prometheus <https://prometheus.io/download/>`__. Binaries are provided for many popular distributions, including Darwin, Linux and Windows.
-
-For install instructions, see `Prometheus install guides <https://prometheus.io/docs/introduction/getting_started/>`__.
+1. `Download a precompiled binary for Prometheus <https://prometheus.io/download/>`__. Binaries are provided for many popular distributions, including Darwin, Linux and Windows. For install instructions, see `Prometheus install guides <https://prometheus.io/docs/introduction/getting_started/>`__.
 
 2. The following settings are recommended in the Prometheus configuration file named ``prometheus.yml``:
 
@@ -57,14 +55,18 @@ For install instructions, see `Prometheus install guides <https://prometheus.io/
         static_configs:
           - targets: ["<hostname1>:<port>", "<hostname2>:<port>"]
 
-The ``<hostname1>:<port>`` parameter has to be replaced with your Mattermost host ip address and port to scrape the data. It connects to ``/metrics`` using http. 
+Replace the ``<hostname1>:<port>`` parameter with your Mattermost host IP address and port to scrape the data. It connects to ``/metrics`` using http. 
 
-3. Enable performance monitoring in the Mattermost System Console and specify the listen address. See more detail in our `configuration settings documentation <https://docs.mattermost.com/administration/config-settings.html#performance-monitoring-beta>`__. After enabling performance monitoring, make sure to reboot Mattermost.
+3. In the Mattermost System Console, go to **Environment > Performance Monitoring** to set **Enable Performance Monitoring** to **true**, then specify the **Listen Address** and select **Save**. See our `configuration settings documentation <https://docs.mattermost.com/administration/config-settings.html#performance-monitoring>`__ for details. After enabling performance monitoring, restart the Mattermost Server.
 
 .. image:: ../images/perf_monitoring_system_console.png
   :scale: 70
 
 4. To test the server is running, go to ``<ip>:<port>/metrics``.
+
+.. note::
+
+  A Mattermost Enterprise Edition installation with an E20 license is required to connect to ``/metrics`` using http.
 
 5. Finally, run ``vi prometheus.yml`` to finish configuring Prometheus.
 
@@ -248,6 +250,10 @@ The Prometheus integration provides standard GO metrics for HTTP server runtime 
   Profile reports are available without a Mattermost Enterprise Edition license.
 
 To learn how to set up runtime profiling, see the `pprof package GO documentation <https://golang.org/pkg/net/http/pprof/>`__.  You can also visit the ``ip:port/metrics`` page for a complete list of metrics with descriptions.
+
+.. note::
+
+  A Mattermost Enterprise Edition installation with an E20 license is required to connect to ``/metrics`` using http.
 
 If enabled, you can run the profiler by
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -238,7 +238,7 @@ Use annotations to streamline analysis when a job is long running, such as an LD
 Standard GO Metrics
 ~~~~~~~~~~~~~~~~~~~
 
-The Prometheus integration provides standard GO metrics for HTTP server runtime profiling data and system monitoring, such as:
+The performance monitoring feature provides standard Go metrics for HTTP server runtime profiling data and system monitoring, such as:
 
 - ``go_memstats_alloc_bytes`` for memory usage
 - ``go_goroutines`` for GO routines

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -55,7 +55,7 @@ Installing Prometheus
         static_configs:
           - targets: ["<hostname1>:<port>", "<hostname2>:<port>"]
 
-Replace the ``<hostname1>:<port>`` parameter with your Mattermost host IP address and port to scrape the data. It connects to ``/metrics`` using http. 
+Replace the ``<hostname1>:<port>`` parameter with your Mattermost host IP address and port to scrape the data. It connects to ``/metrics`` using HTTP. 
 
 3. In the Mattermost System Console, go to **Environment > Performance Monitoring** to set **Enable Performance Monitoring** to **true**, then specify the **Listen Address** and select **Save**. See our `configuration settings documentation <https://docs.mattermost.com/administration/config-settings.html#performance-monitoring>`__ for details.
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -62,7 +62,7 @@ Replace the ``<hostname1>:<port>`` parameter with your Mattermost host IP addres
 .. image:: ../images/perf_monitoring_system_console.png
   :scale: 70
 
-4. To test the server is running, go to ``<ip>:<port>/metrics``.
+4. To test that the server is running, go to ``<ip>:<port>/metrics``.
 
 .. note::
 

--- a/source/deployment/metrics.rst
+++ b/source/deployment/metrics.rst
@@ -247,7 +247,7 @@ The performance monitoring feature provides standard Go metrics for HTTP server 
 
 .. note::
 
-  Profile reports are available without a Mattermost Enterprise Edition license.
+  Profile reports are available to Team Edition and Enterprise Edition users.
 
 To learn how to set up runtime profiling, see the `pprof package Go documentation <https://golang.org/pkg/net/http/pprof/>`__.  You can also visit the ``ip:port`` page for a complete list of metrics with descriptions.
 

--- a/source/overview/product.rst
+++ b/source/overview/product.rst
@@ -36,9 +36,10 @@ Features include:
 - Tools for custom branding
 - Continuous archiving
 - Multi-factor authentication
-- Highly customizable `third party bots, integrations <https://about.mattermost.com/community-applications/#publicApps>`__, and `command line tools <https://docs.mattermost.com/administration/command-line-tools.html>`__
+- Highly customizable `third-party bots, integrations <https://about.mattermost.com/community-applications/#publicApps>`__, and `command line tools <https://docs.mattermost.com/administration/command-line-tools.html>`__
 - Extensive integration support via `webhooks, APIs, drivers <https://docs.mattermost.com/guides/integration.html>`__, and `third-party extensions <https://about.mattermost.com/default-app-directory/>`__
 - Easily scalable to dozens of users per team
+- `Runtime profiling data and system monitoring reports <https://docs.mattermost.com/deployment/metrics.html#standard-go-metrics>`__
 - New features and improvements released every month
 - Multiple languages including U.S. English, Bulgarian, Chinese (Simplified and Traditional), Dutch, French, German, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Romanian, Russian, Turkish, Spanish, Swedish, and Ukrainian
 

--- a/source/overview/product.rst
+++ b/source/overview/product.rst
@@ -40,7 +40,7 @@ Features include:
 - Extensive integration support via `webhooks, APIs, drivers <https://docs.mattermost.com/guides/integration.html>`__, and `third-party extensions <https://about.mattermost.com/default-app-directory/>`__
 - Easily scalable to dozens of users per team
 - `Runtime profiling data and system monitoring reports <https://docs.mattermost.com/deployment/metrics.html#standard-go-metrics>`__
-- New features and improvements released every month
+- New features and improvements released regularly
 - Multiple languages including U.S. English, Bulgarian, Chinese (Simplified and Traditional), Dutch, French, German, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Romanian, Russian, Turkish, Spanish, Swedish, and Ukrainian
 
 To get started, `download the open source Mattermost Team Edition server <https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive>`__ under an MIT license.


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/17001

Updated:
- Self-Managed Admin Guide > Scaling Mattermost > Performance Monitoring (E20) > Statistics > Standard GO Metrics
   - Added note indicating that profile reports are available without a MM licence