### PR TITLE
MM-31339: Send one direct message reply a day

### DIFF
--- a/source/help/settings/account-settings.rst
+++ b/source/help/settings/account-settings.rst
@@ -150,7 +150,7 @@ In addition to **Words that Trigger Mentions**, this setting allows you to recei
 Automatic Direct Message Replies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Set a custom message that will be automatically sent once per day in response to Direct Messages. Mentions in Public and Private Channels won't trigger the automated reply. Enabling Automatic Replies sets your availability to **Out of Office** and disables desktop, email, and push notifications. This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html?highlight=config%20settings#enable-automatic-replies-experimental>`__. 
+Set an automated custom message that will be sent once per day in response to Direct Messages. Mentions in Public and Private Channels won't trigger the automated reply. Enabling Automatic Replies sets your availability to **Out of Office** and disables desktop, email, and push notifications. This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html?highlight=config%20settings#enable-automatic-replies-experimental>`__.
 
 Display
 -------

--- a/source/help/settings/account-settings.rst
+++ b/source/help/settings/account-settings.rst
@@ -149,7 +149,8 @@ In addition to **Words that Trigger Mentions**, this setting allows you to recei
 
 Automatic Direct Message Replies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Set a custom message that will be automatically sent in response to Direct Messages. Mentions in Public and Private Channels will not trigger the automated reply. Enabling Automatic Replies sets your availability to **Out of Office** and disables desktop, email, and push notifications. This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html?highlight=config%20settings#enable-automatic-replies-experimental>`__.
+
+Set a custom message that will be automatically sent once per day in response to Direct Messages. Mentions in Public and Private Channels won't trigger the automated reply. Enabling Automatic Replies sets your availability to **Out of Office** and disables desktop, email, and push notifications. This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html?highlight=config%20settings#enable-automatic-replies-experimental>`__. 
 
 Display
 -------


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/17181

Updated:
- User's Guide > Settings > Notifications > Automatic Direct Message Replies
   - Updated the feature description to mention that only a single auto reply is sent per day