### PR TITLE
Compliance Export CSV version correction

### DIFF
--- a/source/administration/compliance-export.rst
+++ b/source/administration/compliance-export.rst
@@ -100,7 +100,7 @@ When run manually via the System Console, ``.csv`` and Actiance XML files are wr
 Is there a maximum row limit for CSV files?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-No. From Mattermost Server v5.35, there's no limit to the number of rows within Compliance Monitoring CSV files.
+No. From Mattermost Server v5.36, there's no limit to the number of rows within Compliance Monitoring CSV files.
 
 Why is the Compliance Exports feature in Beta?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Corrected the version of Mattermost where CSV files will not be limited to a specific number of rows from v5.35 to v5.36.
