### PR TITLE
Allow Preview Environment GitHubAction to run only for Upstream PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           to: 's3://docs.mattermost.com/'
           arguments: '--acl public-read'
           overwrite: true
-          
+
   deploy_staging:
     docker:
       - image: circleci/python:3.6
@@ -48,7 +48,7 @@ jobs:
           to: 's3://docs-stagging.mattermost.com/'
           arguments: '--acl public-read'
           overwrite: true
-          
+
 workflows:
   version: 2
   build_and_deploy:

--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -8,48 +8,33 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if organization member
-        run: |
-          value=false
-          for value in $(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/users/${{ github.event.pull_request.user.login }}/orgs | jq '.[] | contains({"login":"mattermost"})')
-          do
-            if [[ $value ]]; then
-              break
-            fi
-          done
-          echo "IS_MEMBER=$value" >> $GITHUB_ENV
-          if [[ $value ]]; then
-            echo "Is a member of the Mattermost Organization"
-          else
-            echo "Is not a member of the Mattermost Organization"
-          fi
-
       - uses: actions/checkout@v2
-        if: env.IS_MEMBER == 'true'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           submodules: true
           fetch-depth: 0
 
       - name: Setup Python
-        if: env.IS_MEMBER == 'true'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/setup-python@v2
         with:
           python-version: '3.8'
 
       - name: Install pipenv
-        if: env.IS_MEMBER == 'true'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: pip install pipenv
 
       - name: Install dependencies
-        if: env.IS_MEMBER == 'true'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: pipenv install --dev
 
       - name: Build
-        if: env.IS_MEMBER == 'true'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: make html
 
       - uses: shallwefootball/s3-upload-action@master
         name: Upload Preview Env
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -58,7 +43,7 @@ jobs:
           destination_dir: ${{ github.event.number }}
 
       - name: Add comment to PR
-        if: env.IS_MEMBER == 'true'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allow Preview Environment GitHubAction to run only for Upstream PRs 


I will work on a solution to enable the Preview env for forks PRs. this is is just a quick fix to not have the fail check in the PR
