### PR TITLE
Fix GitLab documentation link

### DIFF
--- a/source/deployment/deployment.md
+++ b/source/deployment/deployment.md
@@ -7,7 +7,7 @@ The Mattermost network diagram below illustrates a private cloud deployment of M
 
 **Note**
 
-  - GitLab Mattermost deployment is [documented separately](https://doc.gitlab.com/omnibus/gitlab-mattermost/) and not included below.
+  - GitLab Mattermost deployment is [documented separately](https://docs.gitlab.com/omnibus/gitlab-mattermost/) and not included below.
 
 ## Requirements and Installation Guides
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Fix the GitLab link in the documentation. It currently points to an invalid URL.  This commit points it to the correct URL

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

