### PR TITLE
Changelog - dot releases

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -6,12 +6,12 @@ Also see [changelog in progress](https://bit.ly/2nK3cVf) for the next release.
 
 ## Release v5.35 - [Feature Release](https://docs.mattermost.com/administration/release-definitions.html#feature-release)
 
-- **v5.35.2, release day TBD**
-  - Fixing an issue where subsequent migrations fail to run after running a dot release on new installations. [MM-35931](https://mattermost.atlassian.net/browse/MM-35931)
-  - Fixing an issue where the server may crash if content extractor dependencies for PDFs are not present. [MM-35990](https://mattermost.atlassian.net/browse/MM-35990)
-  - Fixing an issue where the setting to allow disabling link previews from certain domains is grayed out in the System Console. [MM-35796](https://mattermost.atlassian.net/browse/MM-35796)
-  - Fixing an issue where SMTP test connection shows a permission error when upgrading from version < 5.35 to 5.35 or greater. [MM-35861](https://mattermost.atlassian.net/browse/MM-35861)
-  - Fixing an issue with extracting OpenDocument Text files as part of content extraction. [MM-36103](https://mattermost.atlassian.net/browse/MM-36103)
+- **v5.35.2, released 2021-06-03**
+  - Fixed an issue where subsequent migrations failed to run after running a dot release on new installations. [MM-35931](https://mattermost.atlassian.net/browse/MM-35931)
+  - Fixed an issue where the server would crash if content extractor dependencies for PDFs were not present. [MM-35990](https://mattermost.atlassian.net/browse/MM-35990)
+  - Fixed an issue where the setting to allow disabling link previews from certain domains was grayed out in the System Console. [MM-35796](https://mattermost.atlassian.net/browse/MM-35796)
+  - Fixed an issue where SMTP test connection showed a permission error when upgrading from version < 5.35 to 5.35 or greater. [MM-35861](https://mattermost.atlassian.net/browse/MM-35861)
+  - Fixed an issue with extracting OpenDocument Text files as part of content extraction. [MM-36103](https://mattermost.atlassian.net/browse/MM-36103)
 - **v5.35.1, released 2021-05-18**
   - Fixed an issue where 5.35.0 migration failed on MySQL installations with an "invalid connection" error due to an issue with the ``readTimeout`` parameter in ``SqlSettings.DataSource`` (default is 30 seconds). The ``readTimeout`` datasource query parameter is now being ignored and the application provided ``SqlSettings.QueryTimeout`` should be used instead. [MM-35767](https://mattermost.atlassian.net/browse/MM-35767)
 - **v5.35.0, released 2021-05-16**
@@ -120,7 +120,6 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
  - Added ``country-list``, ``form-data``, ``gfycat-sdk``, ``redux-thunk``, ``rudder-sdk-js``, ``serialize-error`` and ``shallow-equals``, and removed ``mattermost-redux`` from https://github.com/mattermost/mattermost-webapp.
 
 ### Known Issues
- - The setting to allow disabling link previews from certain domains may appear as grayed out in the System Console. [MM-35796](https://mattermost.atlassian.net/browse/MM-35796)
  - A persistent unread badge on sidebar hamburger menu may show if **Enable Marketplace** or **Enable Plugins** is disabled in the System Console [MM-36160](https://mattermost.atlassian.net/browse/MM-36160).
  - ``config.json`` can reset when running the command ``systemctl restart mattermost``, and when running any commands that write to the config (e.g. ``config`` or ``plugin``) [MM-33752](https://mattermost.atlassian.net/browse/MM-33752), [MM-32390](https://mattermost.atlassian.net/browse/MM-32390).
  - Adding an at-mention at the start of a post draft and pressing the leftwards or rightwards arrow can clear the post draft and the undo history [MM-33823](https://mattermost.atlassian.net/browse/MM-33823).
@@ -139,8 +138,8 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ## Release v5.34 - [Feature Release](https://docs.mattermost.com/administration/release-definitions.html#feature-release)
 
-- **v5.34.3, release day TBD**
-  - Fixing an issue where subsequent migrations fail to run after running a dot release on new installations. [MM-35931](https://mattermost.atlassian.net/browse/MM-35931)
+- **v5.34.3, released 2021-06-03**
+  - Fixed an issue where subsequent migrations failed to run after running a dot release on new installations. [MM-35931](https://mattermost.atlassian.net/browse/MM-35931)
 - **v5.34.2, released 2021-04-17**
   - Fixed an issue where installs with some special characters in the MySQL password would break and fail to start.
 - **v5.34.1, released 2021-04-15**
@@ -235,8 +234,9 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ## Release v5.33 - [Feature Release](https://docs.mattermost.com/administration/release-definitions.html#feature-release)
 
-- **v5.33.4, release day TBD**
-  - Fixing an issue where subsequent migrations fail to run after running a dot release on new installations. [MM-35931](https://mattermost.atlassian.net/browse/MM-35931)
+- **v5.33.4, released 2021-06-03**
+  - Fixed an issue where subsequent migrations failed to run after running a dot release on new installations. [MM-35931](https://mattermost.atlassian.net/browse/MM-35931)
+  - Added a performance improvement to the emoji picker overlay to improve typing performance.
 - **v5.33.3, released 2021-03-31**
   - Fixed an issue where, after migrating to OpenID, Office 365 returned different ID attributes based on user type, causing an error for users with expired sessions when they tried to sign in to Mattermost. [MM-34356](https://mattermost.atlassian.net/browse/MM-34356)
 - **v5.33.2, released 2021-03-25**

--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -375,6 +375,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 - **v5.32.2, release day TBD**
   - Fixing an issue where subsequent migrations fail to run after running a dot release on new installations. [MM-35931](https://mattermost.atlassian.net/browse/MM-35931)
+  - Fixing an issue where plugin icons are showing as a column instead of as a row in the left-hand side. [MM-36199](https://mattermost.atlassian.net/browse/MM-36199)
 - **v5.32.1, released 2021-02-17**
   - Fixed an issue where any search containing an underscore failed on PostgreSQL databases. This was fixed by reverting a v5.32.0 feature that added support for searching for terms on PostgreSQL that contain underscores.
 - **v5.32.0, released 2021-02-16**

--- a/source/administration/version-archive.rst
+++ b/source/administration/version-archive.rst
@@ -9,18 +9,18 @@ If you want to check that the version of Mattermost you are installing is the of
 Mattermost Enterprise Edition
 ------------------------------
 
-Mattermost Enterprise Edition v5.35.1 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-35-feature-release>`__ - `Download <https://releases.mattermost.com/5.35.1/mattermost-5.35.1-linux-amd64.tar.gz?src=arc>`__
-  - ``https://releases.mattermost.com/5.35.1/mattermost-5.35.1-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``dbadcafba3f9b6c5af030b6701d8edbb048df39bc94567fbf900865eed6d53b7``
-  - GPG Signature: https://releases.mattermost.com/5.35.1/mattermost-5.35.1-linux-amd64.tar.gz.sig
-Mattermost Enterprise Edition v5.34.2 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-34-feature-release>`__ - `Download <https://releases.mattermost.com/5.34.2/mattermost-5.34.2-linux-amd64.tar.gz?src=arc>`__
-  - ``https://releases.mattermost.com/5.34.2/mattermost-5.34.2-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``15111484bd543cc895d91bc74fa500bb23e1bc614526c38acd2c2aaaf5435da5``
-  - GPG Signature: https://releases.mattermost.com/5.34.2/mattermost-5.34.2-linux-amd64.tar.gz.sig
-Mattermost Enterprise Edition v5.33.3 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-33-feature-release>`__ - `Download <https://releases.mattermost.com/5.33.3/mattermost-5.33.3-linux-amd64.tar.gz?src=arc>`__
-  - ``https://releases.mattermost.com/5.33.3/mattermost-5.33.3-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``cedeab60e4ecb6f5fb592964aa281f0cca1e29203cba403f94b11c1a930fccd2``
-  - GPG Signature: https://releases.mattermost.com/5.33.3/mattermost-5.33.3-linux-amd64.tar.gz.sig
+Mattermost Enterprise Edition v5.35.2 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-35-feature-release>`__ - `Download <https://releases.mattermost.com/5.35.2/mattermost-5.35.2-linux-amd64.tar.gz?src=arc>`__
+  - ``https://releases.mattermost.com/5.35.2/mattermost-5.35.2-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``8102fe4c059f39eb6f3d0b533a2f5b58d3111b5fa317b18a481850a7f90889cf``
+  - GPG Signature: https://releases.mattermost.com/5.35.2/mattermost-5.35.2-linux-amd64.tar.gz.sig
+Mattermost Enterprise Edition v5.34.3 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-34-feature-release>`__ - `Download <https://releases.mattermost.com/5.34.3/mattermost-5.34.3-linux-amd64.tar.gz?src=arc>`__
+  - ``https://releases.mattermost.com/5.34.3/mattermost-5.34.3-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``7bfbbd8a386654ef1bbd4d6076f9a7631448c741937eee11fe3a1460cd542771``
+  - GPG Signature: https://releases.mattermost.com/5.34.3/mattermost-5.34.3-linux-amd64.tar.gz.sig
+Mattermost Enterprise Edition v5.33.4 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-33-feature-release>`__ - `Download <https://releases.mattermost.com/5.33.4/mattermost-5.33.4-linux-amd64.tar.gz?src=arc>`__
+  - ``https://releases.mattermost.com/5.33.4/mattermost-5.33.4-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``4bd42146649aa12b7c6c878b497da9276d46393c697d3a900512e931a46e1546``
+  - GPG Signature: https://releases.mattermost.com/5.33.4/mattermost-5.33.4-linux-amd64.tar.gz.sig
 Mattermost Enterprise Edition v5.32.1 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-32-feature-release>`__ - `Download <https://releases.mattermost.com/5.32.1/mattermost-5.32.1-linux-amd64.tar.gz?src=arc>`__
   - ``https://releases.mattermost.com/5.32.1/mattermost-5.32.1-linux-amd64.tar.gz``
   - SHA-256 Checksum: ``9117ab9777d8453ae8b63f3a008152a2bdc6a638400640a67a0a359acf479a44``
@@ -234,18 +234,18 @@ The open source Mattermost Team Edition is functionally identical to the commerc
 
 We generally recommend installing Enterprise Edition, even if you don't currently need a license. This provides the flexibility to seamlessly unlock Enterprise features should you need them. However, if you only want to install software with a fully open source code base, then Team Edition is the best choice for you.
 
-Mattermost Team Edition v5.35.1 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-35-feature-release>`__ - `Download <https://releases.mattermost.com/5.35.1/mattermost-team-5.35.1-linux-amd64.tar.gz?src=arc>`__
-  - ``https://releases.mattermost.com/5.35.1/mattermost-team-5.35.1-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``45a0b34e7f32948da6f2a1e1e3862b967f728bb962d9bc74b07b5868d6882ccf``
-  - GPG Signature: https://releases.mattermost.com/5.35.1/mattermost-team-5.35.1-linux-amd64.tar.gz.sig
-Mattermost Team Edition v5.34.2 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-34-feature-release>`__ - `Download <https://releases.mattermost.com/5.34.2/mattermost-team-5.34.2-linux-amd64.tar.gz?src=arc>`__
-  - ``https://releases.mattermost.com/5.34.2/mattermost-team-5.34.2-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``7346b4ac5132c69c677b4f738a18c6d0969ad4ae466f29d6f02b361878801ec6``
-  - GPG Signature: https://releases.mattermost.com/5.34.2/mattermost-team-5.34.2-linux-amd64.tar.gz.sig
-Mattermost Team Edition v5.33.3 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-33-feature-release>`__ - `Download <https://releases.mattermost.com/5.33.3/mattermost-team-5.33.3-linux-amd64.tar.gz?src=arc>`__
-  - ``https://releases.mattermost.com/5.33.3/mattermost-team-5.33.3-linux-amd64.tar.gz``
-  - SHA-256 Checksum: ``ea98115c9a886aaa319cbdf3720fb26143e9ffc800fb08bd1823d3b102823484``
-  - GPG Signature: https://releases.mattermost.com/5.33.3/mattermost-team-5.33.3-linux-amd64.tar.gz.sig
+Mattermost Team Edition v5.35.2 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-35-feature-release>`__ - `Download <https://releases.mattermost.com/5.35.2/mattermost-team-5.35.2-linux-amd64.tar.gz?src=arc>`__
+  - ``https://releases.mattermost.com/5.35.2/mattermost-team-5.35.2-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``5bb085a69d847fc5f95c39491c0dc93476b2c06748606ecf964347a39af7a4b0``
+  - GPG Signature: https://releases.mattermost.com/5.35.2/mattermost-team-5.35.2-linux-amd64.tar.gz.sig
+Mattermost Team Edition v5.34.3 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-34-feature-release>`__ - `Download <https://releases.mattermost.com/5.34.3/mattermost-team-5.34.3-linux-amd64.tar.gz?src=arc>`__
+  - ``https://releases.mattermost.com/5.34.3/mattermost-team-5.34.3-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``9fe4a2539d9a2c2caafba13d0bad1a2043b2c8c209c4955fdc2559f920d32b53``
+  - GPG Signature: https://releases.mattermost.com/5.34.3/mattermost-team-5.34.3-linux-amd64.tar.gz.sig
+Mattermost Team Edition v5.33.4 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-33-feature-release>`__ - `Download <https://releases.mattermost.com/5.33.4/mattermost-team-5.33.4-linux-amd64.tar.gz?src=arc>`__
+  - ``https://releases.mattermost.com/5.33.4/mattermost-team-5.33.4-linux-amd64.tar.gz``
+  - SHA-256 Checksum: ``0b181c43d4d5624eeae428a54802fc84ed99f841f69f0187c2ed9479a6d1371c``
+  - GPG Signature: https://releases.mattermost.com/5.33.4/mattermost-team-5.33.4-linux-amd64.tar.gz.sig
 Mattermost Team Edition v5.32.1 - `View Changelog <https://docs.mattermost.com/administration/changelog.html#release-v5-32-feature-release>`__ - `Download <https://releases.mattermost.com/5.32.1/mattermost-team-5.32.1-linux-amd64.tar.gz?src=arc>`__
   - ``https://releases.mattermost.com/5.32.1/mattermost-team-5.32.1-linux-amd64.tar.gz``
   - SHA-256 Checksum: ``86fd99e49b6ed687004d46813e51fd91e761a87dff58fa2878e752728fac555a``


### PR DESCRIPTION
Documenting v5.35.2, 5.34.3 and 5.33.4 dot releases.
@jwilander v5.33.4 includes perf fix for the customer.
I'm holding off on v5.32.x and v5.31.x for now as there may be other customer bug fixes backported https://community.mattermost.com/core/pl/qg8rp4jok3d88yspu4b316p34h.