### PR TITLE
File Search Updates - Index file location

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -902,11 +902,11 @@ mattermost extract-documents-content
 -------------------------------------
 
   Description
-    Extracts and indexes the contents of files shared prior to upgrading to Mattermost Server v5.35. Running this command is strongly recommended since search results for past file contents may be incomplete. If this command isn't run, users can search older files based on filename only.
+    Extracts and indexes the contents of files shared prior to upgrading to Mattermost Server v5.35. Running this command is strongly recommended since search results for past file contents may be incomplete. If this command isn't run, users can search older files based on filename only. 
     
     If you're using `Elasticsearch <https://docs.mattermost.com/deployment/elasticsearch.html>`__ search, you must rebuild the search index after running the content extraction command.
     
-    If you're using `Bleve <https://docs.mattermost.com/deployment/bleve.html>`__ search, you must disable Bleve before running the content extraction command. Once extraction is complete, re-enable Bleve, then rebuild the search index.
+    If you're using `Bleve <https://docs.mattermost.com/deployment/bleve.html>`__ search, you must disable Bleve before running the content extraction command. Once extraction is complete, re-enable Bleve, then rebuild the search index. The content extraction command doesn't run on index files located somewhere other than ``/opt/mattermost``, such as ``/opt/mattermost/index``. 
 
     You can run this extraction command while the server is running. Running this command adds load to your server. For large deployments, or teams that share many large, text-heavy documents, we recommended you review our `hardware requirements <https://docs.mattermost.com/install/requirements.html#hardware-requirements>`__, and test `enabling content search <https://docs.mattermost.com/administration/config-settings.html#enable-document-search-by-content>`__ in a staging environment before enabling it in a production environment.
   


### PR DESCRIPTION
Documentation task: https://mattermost.atlassian.net/browse/MM-36617

Updated:
- Manage > Manage MM > Self-Managed Deployments > Command Line Tools > mattermost extract-documents-content
   - Updated Bleve details to mention that the extraction command doesn't run on index files located anywhere other than ``/opt/mattermost``