### PR TITLE
Add bulk export options

### DIFF
--- a/source/administration/command-line-tools.rst
+++ b/source/administration/command-line-tools.rst
@@ -831,7 +831,9 @@ mattermost export bulk
   Options
     .. code-block:: none
 
-	--all-teams bool [REQUIRED]  Export all teams from the server.
+      --all-teams bool   [REQUIRED] Export all teams from the server.
+      --attachments bool Also export file attachments.
+      --archive bool     Outputs a single archive file.
 
 mattermost export csv
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary

https://github.com/mattermost/mattermost-server/pull/16614
The above PR adds two options (`--attachments` and `--archive`) for bulk export command, but documentation doesn't have it.

https://docs.mattermost.com/administration/command-line-tools.html#mattermost-export-bulk


#### Ticket Link
N/A