### PR TITLE
Allow uploading .jpeg files on Linux

### DIFF
--- a/source/help/settings/account-settings.rst
+++ b/source/help/settings/account-settings.rst
@@ -38,7 +38,7 @@ Profile Picture
 
 Profile pictures appear next to all posts and at the top of the channel sidebar next to your name. 
 
-To change your profile picture, select **Select**, then choose an image. For best results, choose an image that is at least 128 x 128 pixels in size. Supported image formats include: BMP, JPG, JPEG, and PNG. The GIF file format is not supported.
+To change your profile picture, select **Select**, then choose an image. For best results, choose an image that's at least 128 x 128 pixels in size. Supported image formats include: BMP, JPG, JPEG, and PNG. The GIF file format is not supported.
 
 Security
 --------

--- a/source/help/settings/account-settings.rst
+++ b/source/help/settings/account-settings.rst
@@ -36,7 +36,9 @@ Email is used for signing in, notifications, and password reset. Email requires 
 Profile Picture
 ~~~~~~~~~~~~~~~
 
-Profile pictures appear next to all posts and in the top of the channels pane next to your name. Change your profile picture by selecting **Select** and then choosing a picture. For best results, choose an image that is at least 128 x 128 pixels in size. The GIF format is not supported.
+Profile pictures appear next to all posts and at the top of the channel sidebar next to your name. 
+
+To change your profile picture, select **Select**, then choose an image. For best results, choose an image that is at least 128 x 128 pixels in size. Supported image formats include: BMP, JPG, JPEG, and PNG. The GIF file format is not supported.
 
 Security
 --------


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-webapp/pull/8224

Updated:
- Messaging > Customize Mattermost Messaging > Account Settings > General > Profile Picture
   - Clarified that BMP, JPG, JPEG, and PNG file formats are supported