### PR TITLE
Update changelog.md

### DIFF
--- a/source/administration/changelog.md
+++ b/source/administration/changelog.md
@@ -147,11 +147,9 @@ The following deprecations are planned for the Mattermost v6.0 release, which is
 
 6. [DisableLegacyMFAEndpoint](https://docs.mattermost.com/administration/config-settings.html#disable-legacy-mfa-api-endpoint) configuration setting.
 
-7. [DisablePostMetaData](https://docs.mattermost.com/administration/config-settings.html#disable-post-metadata) configuration setting.
+7. [Experimental Timezone](https://docs.mattermost.com/administration/config-settings.html#timezone) configuration setting.
 
-8. [Experimental Timezone](https://docs.mattermost.com/administration/config-settings.html#timezone) configuration setting.
-
-9. All legacy channel sidebar experimental configuration settings. We encourage customers using these settings to upgrade to v5.32 or later to access [custom, collapsible channel categories](https://mattermost.com/blog/custom-collapsible-channel-categories/) among many other channel organization features. The settings being deprecated include:
+8. All legacy channel sidebar experimental configuration settings. We encourage customers using these settings to upgrade to v5.32 or later to access [custom, collapsible channel categories](https://mattermost.com/blog/custom-collapsible-channel-categories/) among many other channel organization features. The settings being deprecated include:
 
    - [EnableLegacySidebar](https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar)
    - [ExperimentalTownSquareIsReadOnly](https://docs.mattermost.com/administration/config-settings.html#town-square-is-read-only-experimental)
@@ -161,9 +159,9 @@ The following deprecations are planned for the Mattermost v6.0 release, which is
    - [ExperimentalChannelOrganization](https://docs.mattermost.com/administration/config-settings.html#sidebar-organization)
    - [ExperimentalChannelSidebarOrganization](https://docs.mattermost.com/administration/config-settings.html#experimental-sidebar-features)
 
-10. [All configuration settings previously marked as “Deprecated”](https://docs.mattermost.com/administration/config-settings.html#deprecated-configuration-settings).
+9. [All configuration settings previously marked as “Deprecated”](https://docs.mattermost.com/administration/config-settings.html#deprecated-configuration-settings).
 
-11. Plugin API changes:
+10. Plugin API changes:
 
     - Remove deprecated ``model.CommandArgs.Session``.
     - Restrict ``UserWillLogIn``, ``FileWillBeUploaded``, and ``MessageWillBe[Posted|Updated]`` hooks to enterprise licenced instances only.

--- a/source/overview/security.rst
+++ b/source/overview/security.rst
@@ -30,7 +30,7 @@ Centralized Security and Administration
 
    - Manage users, teams, access control, and system settings in a web-based `System Console user interface <https://docs.mattermost.com/administration/config-settings.html>`__.
    - Centralized authentication through AD/LDAP (Enterprise Edition E10 and Enterprise Edition E20) and SAML (Enterprise Edition E20).
-   - Synchronize users and groups through the built-in `AD/LDAP integration <https://docs.mattermost.com/deployment/sso-ldap.html>` (Enterprise Edition E20).
+   - Synchronize users and groups through the built-in `AD/LDAP integration <https://docs.mattermost.com/deployment/sso-ldap.html>`_ (Enterprise Edition E20).
 
 Transmission Security
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
According to Harrison, ``DisablePostMetadata`` is already deprecated, so removing it from v6.0 notes.

Edit: Also fixed a broken link that I noticed :)