### PR TITLE
Delete DisablePostMetadata config setting

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -5741,17 +5741,6 @@ Experimental Settings
 
 *Available in Enterprise Edition E20*
 
-Disable Post Metadata
-^^^^^^^^^^^^^^^^^^^^^^
-
-**True**: Disabling post metadata is only recommended if you are experiencing a significant decrease in performance around channel and post load times.
-
-**False**: Load channels with more accurate scroll positioning by loading post metadata.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"DisablePostMetadata": false`` with options ``true`` and ``false``.                                                      |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
 Analytics Settings
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documentation task: https://mattermost.atlassian.net/browse/MM-36877

Updated:
- Setup, Manage, Onboard, and Comply > Set Up Mattermost > Self-Managed Deployments > Configuration Settings
   - Removed the configuration setting documentation for ``DisablePostMetadata``

Note: This config setting was intentionally deleted, rather than being marked deprecated, since it was a temporary, short-lived option.