### PR TITLE
Make format of action ID clear

### DIFF
--- a/source/developer/interactive-messages.rst
+++ b/source/developer/interactive-messages.rst
@@ -301,7 +301,7 @@ Context
         }
       }
 
-  Then, when the integration receives the request, it can act based on the action ID.
+  Then, when the integration receives the request, it can act based on the action ID, which should match the `[a-zA-Z0-9]+` regular expression.
 
 Tips and Best Practices
 ------------------------


### PR DESCRIPTION
#### Summary

In accordance with the server-side route matching an action depending on a post,
an action should contain letters or numbers only.

See https://github.com/mattermost/mattermost-server/blob/33edd645c765ffed2951427c0ca0879fe41c4321/api4/integration_action.go#L14

I've added the action ID format next to it.

#### Ticket Link

There is no ticket link