### PR TITLE
Experimental Sidebar config setting correction

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -4694,7 +4694,8 @@ Specify the color of the SAML login button text for white labeling purposes. Use
 Experimental Sidebar Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This configuration setting has been deprecated in favor of `Enable Legacy Sidebar <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__. 
+.. note::
+   This experimental configuration setting has been deprecated, and the ability to organize channels in the sidebar has been promoted to general availability from Mattermost v5.32. See the `Organizing Your Sidebar <https://docs.mattermost.com/messaging/organizing-your-sidebar.html#organizing-your-sidebar>`__ product documentation for details on customizing your sidebar. 
 
 **Disabled**: Users cannot access the experimental channel sidebar feature set.
 

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -4695,7 +4695,7 @@ Experimental Sidebar Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
-   This experimental configuration setting has been deprecated, and the ability to organize channels in the sidebar has been promoted to general availability from Mattermost v5.32. See the `Organizing Your Sidebar <https://docs.mattermost.com/messaging/organizing-your-sidebar.html#organizing-your-sidebar>`__ product documentation for details on customizing your sidebar. 
+   This experimental configuration setting has been deprecated, and the ability to organize channels in the sidebar has been promoted to general availability from Mattermost v5.32. See the `Organizing Your Sidebar <https://docs.mattermost.com/messaging/organizing-your-sidebar.html#organizing-your-sidebar>`__ product documentation for details on customizing the sidebar. 
 
 **Disabled**: Users cannot access the experimental channel sidebar feature set.
 

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -4696,7 +4696,7 @@ Experimental Sidebar Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
-   This experimental configuration setting has been deprecated, and the ability to organize channels in the sidebar has been promoted to general availability from Mattermost v5.32. See the `Organizing Your Sidebar <https://docs.mattermost.com/messaging/organizing-your-sidebar.html#organizing-your-sidebar>`__ product documentation for details on customizing the sidebar. 
+   This experimental configuration setting has been deprecated, and the ability to organize channels in the sidebar has been promoted to general availability from Mattermost v5.32. See the `Organizing Your Sidebar <https://docs.mattermost.com/messaging/organizing-your-sidebar.html#customizing-your-sidebar>`__ product documentation for details on customizing the sidebar. 
 
 **Disabled**: Users cannot access the experimental channel sidebar feature set.
 


### PR DESCRIPTION
Documentation task: https://mattermost.atlassian.net/browse/MM-37343

Updated:
- Setup, Manage, Onboard, and Comply > Set Up Mattermost > Self-Managed Deployments > Configuration Settings > Experimental Sidebar Features
   - Updated config setting to note that it has been deprecated because the functionality was promoted to GA as of v5.32.