### PR TITLE
Update installing-ubuntu-2004-LTS.rst

### DIFF
--- a/source/install/installing-ubuntu-2004-LTS.rst
+++ b/source/install/installing-ubuntu-2004-LTS.rst
@@ -14,7 +14,7 @@ Install a production-ready Mattermost system on up to three machines.
 .. include:: install-ubuntu-2004-server.rst
 .. include:: install-ubuntu-2004-mysql.rst
 .. include:: install-ubuntu-2004-postgresql.rst
-.. include:: install-ubuntu-1604-mattermost.rst
+.. include:: install-ubuntu-2004-mattermost.rst
 .. include:: config-mattermost-server.rst
 .. include:: config-tls-mattermost.rst
 .. include:: install-nginx.rst


### PR DESCRIPTION
the install-ubuntu-1604-mattermost.rst was showing as an orphan on the page and there were NO instructions on how to actually install the server portion.  I changed the number from 1604 to 2004

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

