### PR TITLE
Add Shared Channels topic to LHS

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -4650,11 +4650,11 @@ Enable Shared Channels (Experimental)
 
 *Available in Enterprise Edition E20*
 
-Enable Shared Channels to establish secure connections between Mattermost instances, and invite secured connections to shared channels where secure connections can participate as they would in any Public and Private channel.
+Shared Channels enables the ability to establish secure connections between Mattermost instances, and invite secured connections to shared channels where secure connections can participate as they would in any Public and Private channel.
 
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` settings are ``"ExperimentalSettings:EnableSharedChannels": false ""`` with options ``true`` or ``false``, and ``"ExperimentalSettings:EnableRemoteClusterService": false ""`` with options ``true`` or ``false``. Both configuration settings must be enabled in order to share channels with secure connections.       |
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's two ``config.json`` settings include ``"ExperimentalSettings:EnableSharedChannels": false`` with options ``true`` or ``false``, and ``"ExperimentalSettings:EnableRemoteClusterService": false`` with options ``true`` or ``false``. Both configuration settings must be enabled in order to share channels with secure connections.   |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. note::
 

--- a/source/guides/setup-onboard-manage-comply.rst
+++ b/source/guides/setup-onboard-manage-comply.rst
@@ -48,6 +48,7 @@ All Mattermost Instances
    /onboard/advanced-permissions-backend-infrastructure.rst
    /onboard/system-admin-roles.rst
    /onboard/guest-accounts.rst
+   /onboard/shared-channels.rst
    /onboard/ad-ldap.md
    /onboard/multi-factor-authentication.rst
    /onboard/sso-openidconnect.rst

--- a/source/onboard/shared-channels.rst
+++ b/source/onboard/shared-channels.rst
@@ -14,7 +14,7 @@ Setting Up Shared Channels
 
 The process of sharing channels involves the following three steps:
 
-1. System Admins must enable Shared Channels functionality for their Mattermost instance. See our `Configuration Settings <https://docs.mattermost.com/administration/config-settings.html#enable-shared-channels-experimental>`__ documentation for details.
+1. System Admins must enable Shared Channels functionality for their Mattermost instance. See our `Configuration Settings <https://docs.mattermost.com/configure/configuration-settings.html#enable-shared-channels-experimental>`__ documentation for details.
 
 2. System Admins `use a slash command <https://docs.mattermost.com/help/messaging/executing-commands.html>`__ to establish a secure and trusted relationship between other Mattermost Enterprise Edition E20 instances. This process involves creating a password-protected, encrypted invitation, creating a strong decryption password, then sending the invitation and password to the System Admin of a remote Mattermost instance. We strongly recommend that you share an invitation separately from its password to ensure that, if the message were compromised, someone doesn't have all of the data necessary to take action.
 
@@ -69,6 +69,7 @@ Use the following slash command to review the current status of all secure conne
 ``/secure-connection status``
 
 Status details include:
+
 - Connection ID
 - Connection URL
 - Description


### PR DESCRIPTION
Documentation ticket: https://mattermost.atlassian.net/browse/MM-37374

Updated:
- Set Up, Manage, Onboard, and Comply > Onboard Users > All Mattermost Instances
   - Added new Shared Channels (Experimental) (E20) topic to the LHS
- Set Up, Manage, Onboard, and Comply > Set Up Mattermost > Self-Managed Deployments > Enable Shared Channels (Experimental)
   - Corrected formatting issues that were hiding the ``config.json`` setting options on the page