### PR TITLE
Make Banner text more generic

### DIFF
--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -3,7 +3,7 @@
         <a class="notification-bar__close" data-ol-has-click-handler="">
             <span aria-hidden="true">×</span>
         </a>
-        <div>We've updated this site to make content easier to find. Use the feedback option in the bottom right corner of any page to share your feedback with us.</div>
+        <div>We've updated this site to make content easier to find. Use the feedback option at the bottom of any page to share your feedback with us.</div>
     </div>
 </div>
 <header class="with-notification">


### PR DESCRIPTION
Existing documentation banner text is helpful for users on the Web App/Desktop App but not as helpful for those on mobile. Updated the banner text to simply the message and make it more applicable to all supported platforms.