### PR TITLE
Update mis-worded RHEL7/8 install instructions - Issue4013

### DIFF
--- a/source/install/install-rhel-7-mattermost.rst
+++ b/source/install/install-rhel-7-mattermost.rst
@@ -89,9 +89,9 @@ Assume that the IP address of this server is 10.10.10.2
     .. note::
       If you are using MySQL, replace ``postgresql-9.4.service`` by ``mysqld.service`` in the ``[unit]`` section.
 
-  c. Make the service executable.
+  c. Set the file permissions.
 
-    ``sudo chmod 664 /etc/systemd/system/mattermost.service``
+    ``sudo chmod 644 /etc/systemd/system/mattermost.service``
 
   d. Reload the systemd services.
 

--- a/source/install/install-rhel-7-mattermost.rst
+++ b/source/install/install-rhel-7-mattermost.rst
@@ -89,7 +89,7 @@ Assume that the IP address of this server is 10.10.10.2
     .. note::
       If you are using MySQL, replace ``postgresql-9.4.service`` by ``mysqld.service`` in the ``[unit]`` section.
 
-  c. Set the file permissions.
+  c. Set the service file permissions.
 
     ``sudo chmod 644 /etc/systemd/system/mattermost.service``
 

--- a/source/install/install-rhel-8-mattermost.rst
+++ b/source/install/install-rhel-8-mattermost.rst
@@ -94,9 +94,9 @@ Assume that the IP address of this server is ``10.10.10.2``.
     .. note::
       If you are using MySQL, replace ``postgresql.service`` with ``mysqld.service`` in the ``[unit]`` section.
 
-  c. Make the service executable.
+  c. Set the file permissions.
 
-    ``sudo chmod 664 /etc/systemd/system/mattermost.service``
+    ``sudo chmod 644 /etc/systemd/system/mattermost.service``
 
   d. Reload the systemd services.
 

--- a/source/install/install-rhel-8-mattermost.rst
+++ b/source/install/install-rhel-8-mattermost.rst
@@ -94,7 +94,7 @@ Assume that the IP address of this server is ``10.10.10.2``.
     .. note::
       If you are using MySQL, replace ``postgresql.service`` with ``mysqld.service`` in the ``[unit]`` section.
 
-  c. Set the file permissions.
+  c. Set the service file permissions.
 
     ``sudo chmod 644 /etc/systemd/system/mattermost.service``
 


### PR DESCRIPTION
#### Summary

Updates the RHEL 7 and 8 install instructions to correct a minor issue around service file permissions.

The service file does not need to be executable as the instructions state (although the permissions it listed didn't actually set it executable regardless), and I also changed the mode from 664 to 644. 

It's a pretty minor change, but I was able to compile the docs locally after committing.

#### Ticket Link

Fixes https://github.com/mattermost/docs/issues/4103

