### PR TITLE
Update links and link to the exact section

### DIFF
--- a/source/about/product.rst
+++ b/source/about/product.rst
@@ -5,7 +5,7 @@ Product Overview
 
 Thousands of organizations use Mattermost around the world in 20 languages for its unmatched benefits:
 
-- **Security.** Keep vital communications, including access to mobile and desktop apps, within your private environments. Deploy using `dozens of security features <https://docs.mattermost.com/overview/security.html>`__ vetted by global information security communities. Data stays on servers you control, encrypted using keys you control.
+- **Security.** Keep vital communications, including access to mobile and desktop apps, within your private environments. Deploy using `dozens of security features <https://docs.mattermost.com/about/security.html>`__ vetted by global information security communities. Data stays on servers you control, encrypted using keys you control.
 
 - **Configurability.** Adapt your deployment to your needs, preferences, policies and existing systems. Mattermost integrates with your evolving security, compliance and monitoring infrastructure and offers a host of app integrations, webhooks, APIs, and drivers to bring all your communication and workflow into one place.
 
@@ -35,14 +35,14 @@ Features include:
 - Tools for custom branding
 - Continuous archiving
 - Multi-factor authentication
-- Highly customizable `third-party bots, integrations <https://about.mattermost.com/community-applications/#publicApps>`__, and `command line tools <https://docs.mattermost.com/administration/command-line-tools.html>`__
+- Highly customizable `third-party bots, integrations <https://about.mattermost.com/community-applications/#publicApps>`__, and `command line tools <https://docs.mattermost.com/manage/command-line-tools.html>`__
 - Extensive integration support via `webhooks, APIs, drivers <https://docs.mattermost.com/guides/integration.html>`__, and `third-party extensions <https://about.mattermost.com/default-app-directory/>`__
 - Easily scalable to dozens of users per team
-- `Runtime profiling data and system monitoring reports <https://docs.mattermost.com/deployment/metrics.html#standard-go-metrics>`__
+- `Runtime profiling data and system monitoring reports <https://docs.mattermost.com/scale/performance-monitoring.html>`__
 - New features and improvements released regularly
 - Multiple languages including U.S. English, Australian English, Bulgarian, Chinese (Simplified and Traditional), Dutch, French, German, Hungarian, Italian, Japanese, Korean, Polish, Brazilian Portuguese, Romanian, Russian, Turkish, Spanish, Swedish, and Ukrainian
 
-To get started, `download the open source Mattermost Team Edition server <https://docs.mattermost.com/administration/version-archive.html#mattermost-team-edition-server-archive>`__ under an MIT license.
+To get started, `download the open source Mattermost Team Edition server <https://docs.mattermost.com/upgrade/version-archive.html#mattermost-team-edition-server-archive>`__ under an MIT license.
 
 Mattermost Enterprise Edition
 -----------------------------


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

- A few links redirected to a the relevant page but not to the exact section (ie, if someone wanted to know how about _Integrity and Audit Controls_, the link would go to "security.html" and not "security.html#integrity-and-audit-controls" (I suspect this happened as the pages/path were renamed from deployment to deploy for example which breaks the # value after the redirect happens).

#### Ticket Link

N/A

Similar to PR #4792 