### PR TITLE
Update links and link to the exact section

### DIFF
--- a/source/install/install-common-intro.rst
+++ b/source/install/install-common-intro.rst
@@ -5,6 +5,6 @@ For the database, you can install either MySQL or PostgreSQL. The proxy is NGINX
 .. note::
   If you have any problems installing Mattermost, see the `troubleshooting guide <https://docs.mattermost.com/install/troubleshooting.html>`__, or `join the Mattermost user community for troubleshooting help <https://mattermost.com/pl/default-ask-mattermost-community/>`_.
   
-  For help with inviting users to your system, see `inviting team members <https://docs.mattermost.com/help/getting-started/managing-members.html#inviting-team-members>`__ and other `getting started information <https://docs.mattermost.com/guides/user.html#getting-started>`__.
+  For help with inviting users to your system, see `inviting team members <https://docs.mattermost.com/messaging/managing-members.html#inviting-team-members>`__ and other `getting started information <https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html#getting-started-tasks>`__.
   
   To submit an improvement or correction to this page, click **Edit** in the top-right corner of the page.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

- A few links redirected to a the relevant page but not to the exact section (ie, if someone wanted to know how about _Integrity and Audit Controls_, the link would go to "security.html" and not "security.html#integrity-and-audit-controls" (I suspect this happened as the pages/path were renamed from deployment to deploy for example which breaks the # value after the redirect happens).

#### Ticket Link

N/A

Similar to PR #4792 and #4795 :)