### PR TITLE
Fix "Inline emphasis start-string without end-string" warnings on build

### DIFF
--- a/source/deploy/mobile-apps-faq.rst
+++ b/source/deploy/mobile-apps-faq.rst
@@ -213,6 +213,7 @@ The app checks for platform-specific configuration on app install. If no configu
 2. In order to handle deep links, paste the following ``JSON`` into the ``apple-app-site-association`` file. Make sure to place your app ID in the ``appID`` property:
 
 ::
+
     {
         "applinks": {
             "apps": [],

--- a/source/deploy/mobile-faq.rst
+++ b/source/deploy/mobile-faq.rst
@@ -216,6 +216,7 @@ The app checks for platform-specific configuration on app install. If no configu
 2. In order to handle deep links, paste the following ``JSON`` into the ``apple-app-site-association`` file. Make sure to place your app ID in the ``appID`` property:
 
 ::
+
     {
         "applinks": {
             "apps": [],

--- a/source/developer/dev-setup-troubleshooting.rst
+++ b/source/developer/dev-setup-troubleshooting.rst
@@ -34,7 +34,7 @@ I get the following error when running ``make run``: "Error starting server, err
 
   If there isn't another copy of Mattermost running and you need to change the port that Mattermost is running on, you can do so by changing the ``ListenAddress`` setting in the *ServiceSettings* section of ``config/config.json``.
 
-macOS: I get the following error or something similar when running ``make run``: [EROR] Failed to ping DB retrying in 10 seconds err=Error 1045: Access denied for user ‘mmuser’@’localhost’ (using password: YES) 
+macOS: I get the following error or something similar when running ``make run``: [ERROR] Failed to ping DB retrying in 10 seconds err=Error 1045: Access denied for user ‘mmuser’@’localhost’ (using password: YES)
   It appears that 'mmuser' is not created as a user in your MySQL database. Hence create the new user by using the following command:
   ``CREATE USER 'mmuser'@'localhost' IDENTIFIED BY 'mostest';``
 
@@ -50,7 +50,7 @@ macOS: I get the following error or something similar when running ``make run``:
 Testing Errors
 --------------
 
-I get the following error when running ``make test``: t.Run undefined (type *testing.T has no field or method Run)
+I get the following error when running ``make test``: t.Run undefined (type \*testing.T has no field or method Run)
   You need to upgrade to Go 1.9. We don't support earlier versions than that.
 
 Other Errors


### PR DESCRIPTION
#### Summary
This was a proper warning that was rendered fine and two false positives that uncovered a more pressing problem.

- Proper warning:
  In some place we had something like `*t.Testing`. The `*` is used as the emphasis marker. Since there are no other `*` to close the marker, hence the warning. We can escape it with a backslash. Looking at this, we should check for other * that are not properly escaped, since we may have more problems with those.
- False positive
The code blocks should have the `::` as a single paragraph (i.e. one empty line before and one empty line after). These ones did not have an empty line after. Therefore the parser did not recognize it as code, and started considering the `*` later as emphasis markers.

#### Ticket Link
Fix https://github.com/mattermost/docs/issues/4712