### PR TITLE
updating supported languages and converting display to a table

### DIFF
--- a/source/messaging/formatting-text.rst
+++ b/source/messaging/formatting-text.rst
@@ -149,24 +149,9 @@ Or by indenting each line by four spaces:
 
 To add syntax highlighting, type the language to be highlighted after the ``````` at the beginning of the code block. Mattermost also offers four different code themes (GitHub, Solarized Dark, Solarized Light, and Monokai) that can be changed in **Account Settings > Display > Theme > Custom Theme > Center Channel Styles**.
 
-Supported languages include:
-``applescript``, ``as``, ``atom``, ``bas``, ``bash``, ``boot``, ``_coffee``, ``c++``, 
-``c``, ``cake``, ``cc``, ``cl2``, ``clj``, ``cljc``, ``cljs``, ``cljs.hl``,
-``cljscm``, ``cljx``, ``cjsx``, ``cson``, ``coffee``, ``cpp``, ``cs``, ``csharp``, 
-``css``, ``d``, ``dart``, ``dfm``, ``di``, ``delphi``, ``diff``, ``django``, ``docker``, 
-``dockerfile``, ``dpr``, ``erl``, ``fortran``, ``freepascal``,  ``fs``, ``fsharp``, 
-``gcode``, ``gemspec``, ``go``, ``groovy``, ``gyp``, ``h++``, ``h``, 
-``handlebars``, ``hbs``, ``hic``,  ``hpp``, ``html``, ``html.handlebars``, 
-``html.hbs``, ``hs``, ``hx``, ``iced``, ``irb``,
-``java``, ``jinja``, ``jl``, ``js``, ``json``, ``jsp``, ``jsx``, ``kt``,
-``ktm``, ``kts``, ``latexcode``, ``lazarus``, ``less``, ``lfm``, ``lisp``, ``lpr``,
-``lua``, ``m``, ``mak``, ``matlab``, ``md``, ``mk``, ``mkd``, ``mkdown``,
-``ml``, ``mm``, ``nc``, ``objc``, ``obj-c``, ``osascript``, ``pas``, ``pascal``,
-``perl``, ``pgsql``, ``php``, ``php3``, ``php4``, ``php5``, ``php6``, ``pl``, ``plist``,
-``podspec``, ``postgres``, ``postgresql``, ``ps``, ``ps1``, ``pp``, ``py``, ``r``, ``rb``,
-``rs``, ``rss``, ``ruby``, ``scala``, ``scm``, ``scpt``, ``scss``, ``sh``, ``sld``, ``st``, ``styl``,
-``sql``, ``swift``, ``tex``, ``texcode``, ``thor``, ``ts``, ``tsx``, ``v``, ``vb``, ``vbnet``, ``vbs``,
-``veo``, ``xhtml``, ``xml``, ``xsl``, ``yaml``, and ``zsh``.
+Supported languages and their aliases include:
+
+.. include:: syntax-highlighting.rst
 
 Example:
 

--- a/source/messaging/syntax-highlighting.rst
+++ b/source/messaging/syntax-highlighting.rst
@@ -1,0 +1,255 @@
+.. raw:: html
+
+  <table width="100%" border="1" cellpadding="5px" style="margin-bottom:20px;">
+    <tr class="row-odd">
+      <th class="head">Language</th>
+      <th class="head">Aliases</th>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">ActionScript</td>
+      <td valign="middle">actionscript, as, as3</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">AppleScript</td>
+      <td valign="middle">applescript</td>
+    </tr>  
+    <tr class="row-odd">
+      <td valign="middle">Bash</td>
+      <td valign="middle">bash, sh</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Clojure</td>
+      <td valign="middle">clojure</td>
+    </tr>  
+    <tr class="row-odd">
+      <td valign="middle">CoffeeScript</td>
+      <td valign="middle">coffescript, coffee, coffee-script</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">C/C++</td>
+      <td valign="middle">cpp, c++, c</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">C#</td>
+      <td valign="middle">cs, c#, csharp</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">CSS</td>
+      <td valign="middle">css</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">D</td>
+      <td valign="middle">d, dlang</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Dart</td>
+      <td valign="middle">dart</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Delphi</td>
+      <td valign="middle">delphi</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Diff</td>
+      <td valign="middle">diff, patch, udiff</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Django</td>
+      <td valign="middle">django</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Dockerfile</td>
+      <td valign="middle">dockerfile, docker</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Elixir</td>
+      <td valign="middle">elixir, ex, exs</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Erlang</td>
+      <td valign="middle">erlang, erl</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Fortran</td>
+      <td valign="middle">fortran</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">F#</td>
+      <td valign="middle">fsharp</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">G-Code</td>
+      <td valign="middle">gcode</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Go</td>
+      <td valign="middle">go, golang</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Groovy</td>
+      <td valign="middle">groovy</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Handlebars</td>
+      <td valign="middle">handlebars, hbs, mustache</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Haskell</td>
+      <td valign="middle">haskell, hs</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Haxe</td>
+      <td valign="middle">haxe</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Java</td>
+      <td valign="middle">java</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">JavaScript</td>
+      <td valign="middle">javascript, js</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">JSON</td>
+      <td valign="middle">json</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Julia</td>
+      <td valign="middle">julia, jl</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Kotlin</td>
+      <td valign="middle">kotlin</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">LaTeX</td>
+      <td valign="middle">latex, tex</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Less</td>
+      <td valign="middle">less</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Lisp</td>
+      <td valign="middle">lisp</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Lua</td>
+      <td valign="middle">lua</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Makefile</td>
+      <td valign="middle">makefile, make, mf, gnumake, bsdmake</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Markdown</td>
+      <td valign="middle">markdown, md, mkd</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Matlab</td>
+      <td valign="middle">matlab, m</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Objective C</td>
+      <td valign="middle">objectivec, objective_c, objc</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">OCaml</td>
+      <td valign="middle">ocaml</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Perl</td>
+      <td valign="middle">perl, pl</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">PostgreSQL</td>
+      <td valign="middle">pgsql, postgres, postgresql</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">PHP</td>
+      <td valign="middle">php, php3, php4, php5</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">PowerShell</td>
+      <td valign="middle">powershell, posh</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Puppet</td>
+      <td valign="middle">puppet, pp</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Python</td>
+      <td valign="middle">python, py</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">R</td>
+      <td valign="middle">r, s</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Ruby</td>
+      <td valign="middle">ruby, rb</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Rust</td>
+      <td valign="middle">rust, rs</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Scala</td>
+      <td valign="middle">scala</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Scheme</td>
+      <td valign="middle">scheme</td>
+    <tr class="row-odd">
+      <td valign="middle">SCSS</td>
+      <td valign="middle">scss</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Smalltalk</td>
+      <td valign="middle">smalltalk, st, squeak</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">SQL</td>
+      <td valign="middle">sql</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Stylus</td>
+      <td valign="middle">stylus, styl</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Swift</td>
+      <td valign="middle">swift</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Text</td>
+      <td valign="middle">text</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">TypeScript</td>
+      <td valign="middle">typescript, ts, tsx</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">VB.Net</td>
+      <td valign="middle">vbnet, vb, visualbasic</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">VBScript</td>
+      <td valign="middle">vbscript</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">Verilog</td>
+      <td valign="middle">verilog</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">VHDL</td>
+      <td valign="middle">vhdl</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">HTML, XML</td>
+      <td valign="middle">html, xml</td>
+    </tr>
+    <tr class="row-odd">
+      <td valign="middle">YAML</td>
+      <td valign="middle">yaml, yml</td>
+    </tr>
+  </table>


### PR DESCRIPTION
#### Summary
I updated the list of supported languages based on the list in [constants.jsx](https://github.com/mattermost/mattermost-webapp/blob/master/utils/constants.jsx)  which I believe to be accurate. I converted it from just a list of aliases to a table that now lists all of the available aliases for each supported language. I put the table in a separate file to make the main doc page a little cleaner, and I basically just copied the format from a table in a different page.

The table was maybe out of scope of the linked issue, but it seems a little more useful than the previous list format.

#### Ticket Link
https://github.com/mattermost/docs/issues/3326

