### PR TITLE
Update links to the exact section and update 1 broken link

### DIFF
--- a/source/messaging/signing-in.rst
+++ b/source/messaging/signing-in.rst
@@ -1,7 +1,7 @@
 Signing In
 ==========
 
-To sign in, navigate to the Mattermost sign-in screen. You can `get the URL of the sign-in screen <https://docs.mattermost.com/help/getting-started/access-your-workspace.html>`__ from your System Admin or from an email invitation.
+To sign in, navigate to the Mattermost sign-in screen. You can `get the URL of the sign-in screen <https://docs.mattermost.com/messaging/accessing-your-workspace.html>`__ from your System Admin or from an email invitation.
 
 .. tip::
   We recommend bookmarking the Mattermost URL provided by your System Admin or through an email invitation so signing in to Mattermost is easy in the future.
@@ -66,6 +66,6 @@ SAML Single Sign-On (SSO)
 
 *Available in Mattermost Enterprise Edition E20*
 
-When enabled by your System Admin, you can sign in with your SAML credentials. This lets you use the same username and password for Mattermost that you use for various other company services. Mattermost officially supports `Okta <https://docs.mattermost.com/deployment/sso-saml-okta.html>`__, `OneLogin <https://docs.mattermost.com/deployment/sso-saml-onelogin.html>`__, and Microsoft ADFS as an identity provider (IDP) for SAML, but you may use other SAML IDPs as well. Please see our `SAML Single Sign-On documentation <https://docs.mattermost.com/deployment/sso-saml.html>`__ to learn more about configuring SAML for Mattermost.
+When enabled by your System Admin, you can sign in with your SAML credentials. This lets you use the same username and password for Mattermost that you use for various other company services. Mattermost officially supports `Okta <https://docs.mattermost.com/onboard/sso-saml-okta.html>`__, `OneLogin <https://docs.mattermost.com/onboard/sso-saml-onelogin.html>`__, and Microsoft ADFS as an identity provider (IDP) for SAML, but you may use other SAML IDPs as well. Please see our `SAML Single Sign-On documentation <https://docs.mattermost.com/onboard/sso-saml.html>`__ to learn more about configuring SAML for Mattermost.
 
 .. image:: ../images/sign-in_with_saml.png


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

- A few links were broken (ie, redirected back to the home page of the documentation section) 
- A few links redirected to a the relevant page but not to the exact section (ie, if someone wanted to know how about _Integrity and Audit Controls_, the link would go to "security.html" and not "security.html#integrity-and-audit-controls" (I suspect this happened as the pages/path were renamed from deployment to deploy for example which breaks the # value after the redirect happens).

#### Ticket Link

N/A

Similar to #4792, #4795 and #4804 