### PR TITLE
Reliable Websockets: default to true

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -5379,7 +5379,7 @@ Enable Reliable Websockets
 Enable this setting to make websocket messages more reliable by buffering messages during a connection loss and then re-transmitting all unsent messages when the connection is revived.
 
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableReliableWebsockets": false`` with options ``true`` and ``false``.                                              |
+| This feature's ``config.json`` setting is ``"EnableReliableWebsockets": true`` with options ``true`` and ``false``.                                               |
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Remote Clusters


### PR DESCRIPTION
Documentation for: mattermost/mattermost-server#17890

Updated:
- Set Up, Manage, Onboard, and Comply > Set Up Mattermost > Self-Managed Deployments > Configuration Settings > Experimental Settings only in config.json > Enable Reliable Websockets
    - Updated the default value of the config setting to ``true``