### PR TITLE
Create sharing-messages.rst

### DIFF
--- a/source/messaging/sharing-messages.rst
+++ b/source/messaging/sharing-messages.rst
@@ -1,0 +1,1 @@
+Docs link for permalink previews and sharing messages


### PR DESCRIPTION
cc// @cwarnermm here's the proposed new page to link to from in product. I don't think the v6.0 branch exists but please feel free to rebase as needed once it does

Docs changes that are needed, include:

1. Config doc change as per this PR: https://github.com/mattermost/mattermost-server/pull/17796
2. Screenshot and description on this page of how permalink previews work (ie when a permalink is posted in a channel it generates a preview of the original message. Only users who have access to the original post will see a preview (other users will only see the regular permalink))

There will be more to add to this page once the "share message" feature is added on top of this feature (after v6.0) - ie a new icon added to the post hover menu that adds some UI to share a permalink to a different channel