### PR TITLE
MM-35722: CRT, post click open thread

### DIFF
--- a/source/messaging/organizing-conversations.rst
+++ b/source/messaging/organizing-conversations.rst
@@ -33,7 +33,7 @@ Replies are collapsed under the first message of a thread. To reply to a thread,
 
 .. tip:: 
     
-    - Select anywhere on a message in a channel to view it, or reply to it, on the right-hand side.
+    - Select anywhere on a message in a channel in the center pane to view it, or reply to it, on the right-hand side.
     - In channels, a dot next to the thread participants indicates there are unread replies. You'll only see unreads for threads you're following.
 
 .. image:: ../images/crt-new-unread-threads.png


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-webapp/pull/8342

Updated:
- Messages > Work with Messages > Organizing Conversations using Collapsed Reply Threads (Beta) > Start or Reply to Threads
   - Updated Tip bullet point #1 to clarify that uses can click anywhere in a message in the center pane to view it/reply to it