### PR TITLE
Nit pick: Focalboard revision number

### DIFF
--- a/source/install/self-managed-changelog.md
+++ b/source/install/self-managed-changelog.md
@@ -23,7 +23,7 @@ Mattermost v5.38.0 contains low to medium level security fixes. [Upgrading](http
 
 ### Important Upgrade Notes
  - v5.38 adds fixes for some of the incorrect mention counts and unreads around threads and channels since the introduction of Collapsed Reply Threads (Beta). This fix is done through a SQL migration, and it may take several minutes to complete for large databases. The ``fixCRTChannelMembershipCounts`` fix takes 1 minute and 20 seconds for a database containing approximately 4 million channel memberships and about 130,000 channels. The ``fixCRTThreadCountsAndUnreads`` fix takes about 3 minutes and 30 seconds for a database containing 56367 threads, 124587 thread memberships, and 220801 channel memberships. These are on MySQL v5.6.51.
- - Focalboard v0.8.0 (released with Mattermost v5.38.0) requires Mattermost v5.37 due to the new database connection system.
+ - Focalboard v0.8.2 (released with Mattermost v5.38.0) requires Mattermost v5.37 due to the new database connection system.
 
 **IMPORTANT:** If you upgrade from a release earlier than v5.37, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
 
@@ -39,7 +39,7 @@ Mattermost v5.38.0 contains low to medium level security fixes. [Upgrading](http
  - ``Incident Collaboration`` was rebranded to ``Playbooks``. Also the channel right-hand sidebar is redesigned, our own playbooks are shared as templates, and more triggers and actions were added.
 
 #### Focalboard Updates
- - Added created-by property and improved performance with shared database connections. Focalboard 0.8.0 requires Mattermost v5.37+ due to a new database connection system.
+ - Added created-by property and improved performance with shared database connections. Focalboard 0.8.2 requires Mattermost v5.37+ due to a new database connection system.
 
 ### Improvements
 

--- a/source/upgrade/important-upgrade-notes.rst
+++ b/source/upgrade/important-upgrade-notes.rst
@@ -17,7 +17,7 @@ Important Upgrade Notes
 |                                                    | and 20 seconds for a database containing approximately 4 million channel memberships and about 130,000 channels. The ``fixCRTThreadCountsAndUnreads`` fix takes  |
 |                                                    | about 3 minutes and 30 seconds for a database containing 56367 threads, 124587 thread memberships, and 220801 channel memberships. These are on MySQL v5.6.51.   | 
 |                                                    +------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|                                                    | Focalboard v0.8.0 (released with Mattermost v5.38.0) requires Mattermost v5.37 due to the new database connection system.                                        |
+|                                                    | Focalboard v0.8.2 (released with Mattermost v5.38.0) requires Mattermost v5.37 due to the new database connection system.                                        |
 +----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | v5.37.0                                            | The ``platform`` binary and “--platform” flag have been removed. If you are using the “--platform” flag or are using the ``platform`` binary directly to run     |
 |                                                    | the Mattermost server application via a systemd file or custom script, you will be required to use only the mattermost binary.                                   |


### PR DESCRIPTION
Change the focalboard revision number to the correctly delivered. I upgraded to 0.8.2 and later i discovered that it is already within 5.38