### PR TITLE
Added 301 redirects for v6.0 blog links

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -104,8 +104,31 @@ redirects = {
     "install/config-apache2": "https://docs.mattermost.com/configure/configuring-apache2.html",
     "administration/telemetry": "https://docs.mattermost.com/manage/telemetry.html",
     "administration/changelog": "https://docs.mattermost.com/install/self-managed-changelog.html",
+    "administration/command-line-tools": "https://docs.mattermost.com/manage/command-line-tools.html",
+    "administration/compliance-export": "https://docs.mattermost.com/comply/compliance-export.html",
+    "administration/config-settings#allow-users-to-view-archived-channels-beta": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#allow-users-to-view-archived-channels-beta",
+    "administration/config-settings#timezone": "https://docs.mattermost.com/configure/configuration-settings.html#timezone",
+    "administration/config-settings#enable-legacy-sidebar": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
+    "administration/config-settings#town-square-is-read-only-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-read-only-experimental",
+    "administration/config-settings#town-square-is-hidden-in-left-hand-sidebar-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-hidden-in-left-hand-sidebar-experimental",
+    "administration/config-settings#enable-x-to-leave-channels-from-left-hand-sidebar-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-x-to-leave-channels-from-left-hand-sidebar-experimental",
+    "administration/config-settings#autoclose-direct-messages-in-sidebar-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental",
+    "administration/config-settings#sidebar-organization": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#sidebar-organization",
+    "administration/config-settings#experimental-sidebar-features": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#experimental-sidebar-features",
+    "administration/config-settings#deprecated-configuration-settings": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#deprecated-configuration-settings",
+    "administration/custom-terms-of-service": "https://docs.mattermost.com/comply/custom-terms-of-service.html",
     "administration/image-proxy": "https://docs.mattermost.com/deploy/image-proxy.html",
     "administration/encryption": "https://docs.mattermost.com/deploy/encryption-options.html",
+    "administration/extended-support-release": "https://docs.mattermost.com/upgrade/extended-support-release.html",
     "administration/backup": "https://docs.mattermost.com/deploy/backup-disaster-recovery.html",
     "administration/upgrade": "https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html",
     "administration/important-upgrade-notes": "https://docs.mattermost.com/upgrade/important-upgrade-notes.html",
@@ -114,14 +137,21 @@ redirects = {
     "administration/release-lifecycle": "https://docs.mattermost.com/upgrade/release-lifecycle.html",
     "administration/downgrade": "https://docs.mattermost.com/upgrade/downgrading-mattermost-server.html",
     "administration/open-source-components": "https://docs.mattermost.com/upgrade/open-source-components.html",
+    "administration/mmctl-cli-tool": "https://docs.mattermost.com/manage/mmctl-cli-tool.html",
+    "administration/migrating#migrating-from-slack-using-the-mattermost-web-app": 
+        "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-web-app",
+    "administration/migrating#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import": 
+        "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
     "administration/release-definitions": "https://docs.mattermost.com/upgrade/release-definitions.html",
     "administration/performance-alerting-guide": "https://docs.mattermost.com/scale/peformance-alerting.html",
     "administration/config-settings": "https://docs.mattermost.com/configure/configuration-settings.html",
     "administration/config-in-database":
         "https://docs.mattermost.com/configure/configuation-in-mattermost-database.html",
     "administration/branding": "https://docs.mattermost.com/configure/custom-branding-tools.html",
+    "deployment/admin-roles": "https://docs.mattermost.com/deploy/admin-roles.html",
     "deployment/deployment": "https://docs.mattermost.com/deploy/deployment-overview.html",
     "deployment/bots": "https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
+    "deployment/guest-accounts": "https://docs.mattermost.com/deploy/guest-accounts.html",
     "deployment/on-boarding": "https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html",
     "deployment/ha": "https://docs.mattermost.com/deployment/cluster.html",
     "deployment/webrtc": "https://docs.mattermost.com/deployment/video-and-audio-calling.html",


### PR DESCRIPTION
Most of the links in https://mattermost.com/blog/looking-forward-to-mattermost-v6-0/ weren't resolving as expected due to site architecture changes without 301 redirects in place.
