### PR TITLE
Updated minimum supported version of MySQL to 5.7

### DIFF
--- a/source/install/software-hardware-requirements.rst
+++ b/source/install/software-hardware-requirements.rst
@@ -90,7 +90,7 @@ While community support exists for Fedora, FreeBSD, and Arch Linux, Mattermost d
 Database Software
 ^^^^^^^^^^^^^^^^^
 
--  MySQL 5.6, 5.7, 8.0.12+ (see note below on MySQL 8 support)
+-  MySQL 5.7.12, 8.0.12+ (see note below on MySQL 8 support)
 -  PostgreSQL 10.0+
 -  Amazon Aurora MySQL 5.6+
 


### PR DESCRIPTION
Documentation ticket: https://mattermost.atlassian.net/browse/MM-37737

Updated: 
- Install, Deploy, Upgrade, and Scale > Install Mattermost > Mattermost Server > Software and Hardware Requirements > Software Requirements > Server Software > Database Software
   - Updated MySQL minimum version to 5.7.12