### PR TITLE
MM-37578 - Add setting for onboarding

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -4640,6 +4640,17 @@ Enable Tutorial (Experimental)
 | This feature's ``config.json`` setting is ``"EnableTutorial": true`` with options ``true`` and ``false``.                                  |
 +--------------------------------------------------------------------------------------------------------------------------------------------+
 
+Enable Onboarding (Experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**True**: New Mattermost users are shown key tasks to complete as part of initial onboarding.
+
+**False**: User onboarding tasks are disabled. Users are placed in Town Square when they open Mattermost for the first time after account creation.
+
++--------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"EnableOnboarding": true`` with options ``true`` and ``false``.                                |
++--------------------------------------------------------------------------------------------------------------------------------------------+
+
 Enable User Typing Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/18068

Updated:
- Setup, Manage, Onboard, and Comply > Set Up Mattermost > Self-Managed Deployments > Configuration Settings > Experimental
   - Added new configuration setting **Enable Onboarding (Experimental)**