### PR TITLE
v6.0 Deprecations

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -74,6 +74,9 @@ redirects = {
     "getting-started/welcome_email": "https://docs.mattermost.com/getting-started/welcome-email-to-end-users.html",
     "guides/orchestration": "https://docs.mattermost.com/about/orchestration.html",
     "guides/administrator": "https://docs.mattermost.com/guides/install-deploy-upgrade-scale.html",
+    "guides/administrator#upgrade-mattermost": "https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html",
+    "guides/administrator#installing-mattermost": 
+        "https://docs.mattermost.com/guides/install-deploy-upgrade-scale.html#install-mattermost",
     "install/requirements": "https://docs.mattermost.com/install/software-hardware-requirements.html",
     "install/install-ubuntu-2004": "https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html",
     "install/install-ubuntu-1804": "https://docs.mattermost.com/install/installing-ubuntu-1804-LTS.html",
@@ -120,7 +123,15 @@ redirects = {
     "administration/config-in-database":
         "https://docs.mattermost.com/configure/configuation-in-mattermost-database.html",
     "administration/branding": "https://docs.mattermost.com/configure/custom-branding-tools.html",
+    "administration/upgrade#upgrade-team-edition-to-enterprise-edition": 
+        "https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html#upgrading-team-edition-to-enterprise-edition",
+    "administration/migrating#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import": 
+        "https://docs.mattermost.com/onboard/migrating-to-mattermost.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
+    "administration/config-settings#enable-legacy-sidebar": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
     "deployment/deployment": "https://docs.mattermost.com/deploy/deployment-overview.html",
+    "deployment/advanced-permissions#read-only-channels": 
+        "https://docs.mattermost.com/onboard/advanced-permissions.html#read-only-channels-e20",
     "deployment/bots": "https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
     "deployment/on-boarding": "https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html",
     "deployment/ha": "https://docs.mattermost.com/deployment/cluster.html",

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -9,7 +9,9 @@ Mattermost configuration settings are maintained in the ``config.json`` configur
 
    On new installations from v5.14, the ``default.json`` file used to create the initial ``config.json`` has been removed from the binary and replaced with a build step that generates a fresh ``config.json``. This is to ensure the initial configuration file has all the correct defaults provided in the server code. Existing ``config.json`` files are not affected by this change.
 
-   From Mattermost v5.38 (released August 16, 2021), the “config watcher” (the mechanism that automatically reloads the ``config.json`` file) has been deprecated in favor of the mmctl command `mmctl config reload <https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-config-reload>`__ that must be run to apply configuration changes after they're made. This change will improve configuration performance and robustness.
+   From Mattermost v5.38 (released August 16, 2021), the “config watcher” (the mechanism that automatically reloads the ``config.json`` file) has been deprecated in favor of the `mmctl config reload command <https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-config-reload>`__ that must be run to apply configuration changes after they're made. This change will improve configuration performance and robustness.
+
+   See the `Deprecated configuration settings documentation <https://docs.mattermost.com/configure/deprecated-configuration-settings.html>`__ for details on all deprecated Mattermost configuration settings.  
 
 Configuration in Database
 --------------------------
@@ -282,17 +284,6 @@ Set an explicit idle timeout in the HTTP server. This is the maximum time allowe
 +-----------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"IdleTimeout": 60`` with numerical input.   |
 +-----------------------------------------------------------------------------------------+
-
-Allow use of API v3 endpoints
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-Set to ``false`` to disable all version 3 endpoints of the REST API. Integrations that rely on API v3 will fail and can then be identified for migration to API v4. API v3 is deprecated and will be removed in the near future. See https://api.mattermost.com for details.
-
-+---------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableAPIv3": false`` with options ``true`` and ``false``. |
-+---------------------------------------------------------------------------------------------------------+
 
 Webserver Mode
 ^^^^^^^^^^^^^^^
@@ -1127,27 +1118,7 @@ The port used for streaming data between servers.
 | This feature's ``config.json`` setting is ``"StreamingPort": 8075`` with numerical input.    |
 +----------------------------------------------------------------------------------------------+
 
-Inter-Node Listen Address
-^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*Deprecated. Not used in version 4.0 and later*
-
-The address the Mattermost Server will listen on for inter-node communication. When setting up your network you should secure the listen address so that only machines in the cluster have access to that port. This can be done in different ways, for example, using IPsec, security groups, or routing tables.
-
-+-----------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"InterNodeListenAddress": ":8075"`` with string input.  |
-+-----------------------------------------------------------------------------------------------------+
-
-Inter-Node URLs
-^^^^^^^^^^^^^^^
-
-*Deprecated. Not used in version 4.0 and later*
-
-A list of all the machines in the cluster, such as ``["http://10.10.10.2", "http://10.10.10.4"]``. It is recommended to use the internal IP addresses so all the traffic can be secured.
-
-+--------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"InterNodeUrls": []`` with string array input consisting of the machines in the cluster. |
-+--------------------------------------------------------------------------------------------------------------------------------------+
 
 Rate Limiting
 ~~~~~~~~~~~~~~
@@ -4398,27 +4369,6 @@ Allow Authentication Transfer (Experimental)
 | This feature's ``config.json`` setting is ``"ExperimentalEnableAuthenticationTransfer": true`` with options ``true`` and ``false``.                                  |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Autoclose Direct Messages in Sidebar (Experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Not available in Mattermost Cloud.*
-
-This setting applies to the legacy sidebar only. You must enable the `Enable Legacy Sidebar <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
-
-.. note::
-
-  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
-
-We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`_ for more information about these features.
-
-**True**: By default, direct message conversations with no activity for 7 days will be hidden from the sidebar. Users can disable this in **Account Settings > Sidebar**.
-
-**False**: Conversations remain in the sidebar until they are manually closed.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"CloseUnusedDirectMessages": false`` with options ``true`` and ``false``.                                                |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
 Link Metadata Timeout
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -4658,26 +4608,7 @@ This setting defines how frequently "user is typing..." messages are updated, me
 | This feature's ``config.json`` setting is ``"TimeBetweenUserTypingUpdatesMilliseconds": 5000`` with numerical input.                                                 |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Enable X to Leave Channels from Left-Hand Sidebar (Experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*Not available in Mattermost Cloud.*
-
-This setting applies to the legacy sidebar only. You must first enable the `Enable Legacy Sidebar <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__ configuration setting if you want to see and enable this functionality in the System Console.
-
-.. note::
-
-  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
-
-We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`_ for more information about these features.
-
-**True**: Users can leave Public and Private Channels by clicking the "x" beside the channel name.
-
-**False**: Users must use the **Leave Channel** option from the channel menu to leave channels.
-
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableXToLeaveChannelsFromLHS": false`` with options ``true`` and ``false``.                                               |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Primary Team (Experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -4736,109 +4667,6 @@ Specify the color of the SAML login button text for white labeling purposes. Use
 +-------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"LoginButtonTextColor": ""`` with string input.                                   |
 +-------------------------------------------------------------------------------------------------------------------------------+
-
-Experimental Sidebar Features
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note::
-   This experimental configuration setting has been deprecated, and the ability to organize channels in the sidebar has been promoted to general availability from Mattermost v5.32. See the `Organizing Your Sidebar <https://docs.mattermost.com/messaging/organizing-your-sidebar.html#customizing-your-sidebar>`__ product documentation for details on customizing the sidebar. 
-
-**Disabled**: Users cannot access the experimental channel sidebar feature set.
-
-**Enabled (Default On)**: Enables the experimental sidebar features for all users on this server. Users can disable the features in **Account Settings > Sidebar > Experimental Sidebar Features**. Features include custom collapsible channel categories, drag and drop to reorganize channels, and unread filtering.
-
-**Enabled (Default Off)**: Users must enable the experimental sidebar features in **Account Settings**.
-
-+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ExperimentalChannelSidebarOrganization": off`` with options ``off``, ``default_on`` and ``default_off``.                                         |
-+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable Legacy Sidebar
-^^^^^^^^^^^^^^^^^^^^^
-
-*Not available in Mattermost Cloud.*
-
-This setting re-enables the legacy sidebar functionality for all users on this server. We strongly recommend System Admins disable this setting so users can access `enhanced sidebar features <https://mattermost.com/blog/custom-collapsible-channel-categories/>`__, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more.
-
-**False**: Users can access all new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`_ for more information about these features.
-
-**True**: When enabled, the legacy sidebar is enabled for all users on this server and users cannot access any new channel sidebar features. The legacy channel sidebar is scheduled to be deprecated, and is only recommended if your deployment is experiencing bugs or other issues with the new channel sidebar.
-
-+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableLegacySidebar": false`` with options ``true`` or ``false``.                                                                                |
-+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Sidebar Organization
-^^^^^^^^^^^^^^^^^^^^
-
-*Not available in Mattermost Cloud.*
-
-This setting applies to the legacy sidebar only. You must enable the `Enable Legacy Sidebar <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
-
-.. note::
-
-  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
-
-We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`_ for more information about these features.
-
-**True**: Enables channel sidebar organization options in **Account Settings > Sidebar > Channel grouping and sorting**. Includes options for grouping unread channels, sorting channels by most recent post, and combining all channel types into a single list.
-
-**False**: Hides the channel sidebar organization options in **Account Settings > Sidebar > Channel grouping and sorting**.
-
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ExperimentalChannelOrganization": false`` with options ``true`` and ``false``.                                         |
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Timezone
-^^^^^^^^^^
-
-Select the timezone used for timestamps in the user interface and email notifications.
-
-**True**: The **Timezone** setting is visible in the Account Settings and a timezone is automatically assigned in the next active session.
-
-**False**: The **Timezone** setting is hidden in the Account Settings.
-
-+------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ExperimentalTimezone": true`` with options ``true`` and ``false``.  |
-+------------------------------------------------------------------------------------------------------------------+
-
-Town Square is Hidden in Left-Hand Sidebar (Experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Available in Enterprise Edition E10 and higher*
-
-This setting applies to the legacy sidebar only. You must enable the `Enable Legacy Sidebar <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
-
-.. note::
-
-  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
-
-We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`_ for more information about these features.
-
-**True**: Hides Town Square in the left-hand sidebar if there are no unread messages in the channel.
-
-**False**: Town Square is always visible in the left-hand sidebar even if all messages have been read.
-
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ExperimentalHideTownSquareinLHS": false`` with options ``true`` and ``false``.                                                  |
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Town Square is Read-Only (Experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Available in Enterprise Edition E10 and higher*
-
-**True**: Only System Admins can post in Town Square. Other members are not able to post, reply, upload files, emoji react, or pin messages to Town Square, nor are they able to change the channel name, header, or purpose.
-
-**False**: Anyone can post in Town Square.
-
-.. note::
-
-  This feature will be deprecated in a future release in favor of `channel moderation settings <https://docs.mattermost.com/deployment/advanced-permissions.html#read-only-channels>`_ which allow you to set any channel as read-only, including Town Square 
-
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ExperimentalTownSquareIsReadOnly": false`` with options ``true`` and ``false``.                                                 |
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Use Channel Name in Email Notifications (Experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -5614,7 +5442,7 @@ Service Settings
 Group Unread Channels (Experimental)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This setting applies to the new sidebar only. You must disable the `Enable Legacy Sidebar <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
+This setting applies to the new sidebar only. You must disable the `Enable Legacy Sidebar <https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
 
 **Default Off**: Disables the unread channels sidebar section for all users by default. Users can enable it in **Account Settings > Sidebar > Group unread channels separately**.
 
@@ -6123,313 +5951,3 @@ Shared Channels (Experimental)
 +---------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableSharedChannels": false`` with options ``true`` and ``false``.                |
 +---------------------------------------------------------------------------------------------------------------------------------+ 
-
-Deprecated Configuration Settings
------------------------------------
-
-Policy
-~~~~~~~
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-  
-   Permission policy settings are available in Enterprise Edition E10 and E20. From v5.0, these settings are found in the `Advanced Permissions <https://docs.mattermost.com/deployment/advanced-permissions.html>`__ page instead of configuration settings.
-
-Enable sending team invites from
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Set policy on who can invite others to a team using the **Send Email Invite**, **Get Team Invite Link**, and **Add Members to Team** options on the Main Menu. If **Get Team Invite Link** is used to share a link, you can expire the invite code from **Team Settings > Invite Code** after the desired users have joined the team. Options include:
-
-**All team members**: Allows any team member to invite others using an email invitation, team invite link, or by adding members to the team directly.
-
-**Team and System Admins**: Hides the email invitation, team invite link, and the add members to team buttons in the Main Menu from users who are not Team Admins or System Admins.
-
-**System Admins**: Hides the email invitation, team invite link, and add members to team buttons in the Main Menu from users who are not System Admins.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictTeamInvite": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable public channel creation for
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Restrict the permission level required to create public channels.
-
-**All team members**: Allow all team members to create public channels.
-
-**Team Admins and System Admins**: Restrict creating public channels to Team Admins and System Admins.
-
-**System Admins**: Restrict creating public channels to System Admins.
-
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPublicChannelCreation": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable public channel renaming for
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Restrict the permission level required to rename and set the header or purpose for Public channels.
-
-**All channel members**: Allow all channel members to rename Public channels.
-
-**Channel Admins, Team Admins, and System Admins**: Restrict renaming Public channels to Channel Admins, Team Admins, and System Admins who are members of the channel.
-
-**Team Admins and System Admins**: Restrict renaming Public channels to Team Admins and System Admins who are members of the channel.
-
-**System Admins**: Restrict renaming Public channels to System Admins who are members of the channel.
-
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPublicChannelManagement": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable public channel deletion for
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Restrict the permission level required to delete Public channels. Deleted channels can be recovered from the database using a `command line tool <https://docs.mattermost.com/administration/command-line-tools.html>`__.
-
-**All channel members**: Allow all channel members to delete Public channels.
-
-**Channel Admins, Team Admins, and System Admins**: Restrict deleting Public channels to Channel Admins, Team Admins, and System Admins who are members of the channel.
-
-**Team Admins and System Admins**: Restrict deleting Public channels to Team Admins and System Admins who are members of the channel.
-
-**System Admins**: Restrict deleting Public channels to System Admins who are members of the channel.
-
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPublicChannelDeletion": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable private channel creation for
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Restrict the permission level required to create Private channels.
-
-**All team members**: Allow all team members to create Private channels.
-
-**Team Admins and System Admins**: Restrict creating Private channels to Team Admins and System Admins.
-
-**System Admins**: Restrict creating Private channels to System Admins.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPrivateChannelCreation": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable private channel renaming for
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Restrict the permission level required to rename and set the header or purpose for Private channels.
-
-**All channel members**: Allow all channel members to rename Private channels.
-
-**Channel Admins, Team Admins, and System Admins**: Restrict renaming Private channels to Channel Admins, Team Admins, and System Admins who are members of the Private channel.
-
-**Team Admins and System Admins**: Restrict renaming Private channels to Team Admins and System Admins who are members of the private channel.
-
-**System Admins**: Restrict renaming Private channels to System Admins who are members of the Private channel.
-
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPrivateChannelManagement": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable managing of private channel members for
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Set policy on who can add and remove members from Private channels.
-
-**All team members**: Allow all team members to add and remove members.
-
-**Team Admins, Channel Admins, and System Admins**: Allow only Team Admins, Channel Admins, and System Admins to add and remove members.
-
-**Team Admins, and System Admins**: Allow only Team Admins and System Admins to add and remove members.
-
-**System Admins**: Allow only System Admins to add and remove members.
-
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPrivateChannelManageMembers": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Enable private channel deletion for
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Restrict the permission level required to delete Private channels. Deleted channels can be recovered from the database using a `command line tool <https://docs.mattermost.com/administration/command-line-tools.html>`__.
-
-**All channel members**: Allow all channel members to delete Private channels.
-
-**Channel Admins, Team Admins, and System Admins**: Restrict deleting Private channels to Channel Admins, Team Admins, and System Admins who are members of the Private channel.
-
-**Team Admins and System Admins**: Restrict deleting private channels to Team Admins and System Admins who are members of the Private channel.
-
-**System Admins**: Restrict deleting Private channels to System Admins who are members of the Private channel.
-
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPrivateChannelDeletion": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Allow which users to delete messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Restrict the permission level required to delete messages. Team Admins, Channel Admins, and System Admins can delete messages only in channels where they are members. Messages can be deleted any time.
-
-**Message authors can delete their own messages, and Administrators can delete any message**: Allow authors to delete their own messages, and allow Team Admins, Channel Admins, and System Admins to delete any message.
-
-**Team Admins and System Admins**: Allow only Team Admins and System Admins to delete messages.
-
-**System Admins**: Allow only System Admins to delete messages.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"RestrictPostDelete": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Allow users to edit their messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in June 16, 2018 release*
-
-.. note:: 
-
-   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/deployment/advanced-permissions.html>`_ for more details.
-
-Set the time limit that users have to edit their messages after posting.
-
-**Any time**: Allow users to edit their messages at any time after posting.
-
-**Never**: Do not allow users to edit their messages.
-
-**{n} seconds after posting**: Users can edit their messages within the specified time limit after posting. The time limit is applied using the ``config.json`` setting ``PostEditTimeLimit`` described below.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"AllowEditPost": "always"`` with options ``"always"``, ``"never"``, and ``"time_limit"`` for the above settings, respectively. |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Post edit time limit
-^^^^^^^^^^^^^^^^^^^^
-
-When post editing is permitted, setting this to ``-1`` allows editing any time, and setting this to a positive integer restricts editing time in seconds. If post editing is disabled, this setting does not apply.
-
-+--------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"PostEditTimeLimit": -1`` with numerical input.      |
-+--------------------------------------------------------------------------------------------------+
-
-Images
-~~~~~~
-
-Attachment Thumbnail Width
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in July 16th, 2017 release*
-
-Width of thumbnails generated from uploaded images. Updating this value changes how thumbnail images render in future, but does not change images created in the past.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ThumbnailWidth": 120`` with numerical input.                                                                            |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Attachment Thumbnail Height
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in July 16th, 2017 release*
-
-Height of thumbnails generated from uploaded images. Updating this value changes how thumbnail images render in future, but does not change images created in the past.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ThumbnailHeight": 100`` with numerical input.                                                                           |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Image Preview Width
-^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in July 16th, 2017 release*
-
-Maximum width of preview image. Updating this value changes how preview images render in future, but does not change images created in the past.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"PreviewWidth": 1024`` with numerical input.                                                                             |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Image Preview Height
-^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in July 16th, 2017 release*
-
-Maximum height of preview image. Setting this value to ``0`` instructs Mattermost to auto-size the preview image height based on the source image aspect ratio and the preview image width. Updating this value changes how preview images render in future, but does not change images created in the past.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"PreviewHeight": 0`` with numerical input.                                                                               |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Profile Picture Width
-^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in July 16th, 2017 release*
-
-The width to which profile pictures are resized after being uploaded via Account Settings.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ProfileWidth": 128`` with numerical input.                                                                              |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-Profile Picture Height
-^^^^^^^^^^^^^^^^^^^^^^^
-
-*Removed in July 16th, 2017 release*
-
-The height to which profile pictures are resized after being uploaded via Account Settings.
-
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ProfileHeight": 128`` with numerical input.                                                                             |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/source/configure/deprecated-configuration-settings.rst
+++ b/source/configure/deprecated-configuration-settings.rst
@@ -1,0 +1,516 @@
+Deprecated Configuration Settings
+=================================
+
+.. contents::
+    :backlinks: top
+    :local:
+
+Legacy Sidebar
+--------------
+
+Enable Legacy Sidebar
+^^^^^^^^^^^^^^^^^^^^^
+
+*Not available in Mattermost Cloud.*
+*Deprecated. Not used in Mattermost v6.0 and later*
+
+This setting re-enables the legacy sidebar functionality for all users on this server. We strongly recommend System Admins disable this setting so users can access `enhanced sidebar features <https://mattermost.com/blog/custom-collapsible-channel-categories/>`__, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more.
+
+**False**: Users can access all new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`_ for more information about these features.
+
+**True**: When enabled, the legacy sidebar is enabled for all users on this server and users cannot access any new channel sidebar features. The legacy channel sidebar is scheduled to be deprecated, and is only recommended if your deployment is experiencing bugs or other issues with the new channel sidebar.
+
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"EnableLegacySidebar": false`` with options ``true`` or ``false``.                                                                                |
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Experimental Sidebar Features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Deprecated. Not used in Mattermost v5.32 and later*
+
+.. note::
+   This experimental configuration setting has been deprecated, and the ability to organize channels in the sidebar has been promoted to general availability from Mattermost v5.32. See the `Organizing Your Sidebar documentation <https://docs.mattermost.com/messaging/organizing-your-sidebar.html#customizing-your-sidebar>`__ for details on customizing the sidebar. 
+
+**Disabled**: Users cannot access the experimental channel sidebar feature set.
+
+**Enabled (Default On)**: Enables the experimental sidebar features for all users on this server. Users can disable the features in **Account Settings > Sidebar > Experimental Sidebar Features**. Features include custom collapsible channel categories, drag and drop to reorganize channels, and unread filtering.
+
+**Enabled (Default Off)**: Users must enable the experimental sidebar features in **Account Settings**.
+
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalChannelSidebarOrganization": off`` with options ``off``, ``default_on`` and ``default_off``.                                         |
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Sidebar Organization
+^^^^^^^^^^^^^^^^^^^^
+
+*Not available in Mattermost Cloud.*
+*Deprecated. Not used in Mattermost v6.0 and later*
+
+This setting applies to the legacy sidebar only. You must enable the `Enable Legacy Sidebar <https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
+
+.. note::
+
+  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
+
+We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the channel sidebar documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`__ for more information about these features.
+
+**True**: Enables channel sidebar organization options in **Account Settings > Sidebar > Channel grouping and sorting**. Includes options for grouping unread channels, sorting channels by most recent post, and combining all channel types into a single list.
+
+**False**: Hides the channel sidebar organization options in **Account Settings > Sidebar > Channel grouping and sorting**.
+
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalChannelOrganization": false`` with options ``true`` and ``false``.                                         |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable X to Leave Channels from Left-Hand Sidebar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Not available in Mattermost Cloud.*
+*Deprecated. Not used in Mattermost v6.0 and later*
+
+This setting applies to the legacy sidebar only. You must first enable the `Enable Legacy Sidebar <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__ configuration setting if you want to see and enable this functionality in the System Console.
+
+.. note::
+
+  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
+
+We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the channel sidebar documentation <https://docs.mattermost.com/messaging/organizing-your-sidebar.html>`_ for more information about these features.
+
+**True**: Users can leave Public and Private Channels by clicking the "x" beside the channel name.
+
+**False**: Users must use the **Leave Channel** option from the channel menu to leave channels.
+
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"EnableXToLeaveChannelsFromLHS": false`` with options ``true`` and ``false``.                                               |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Autoclose Direct Messages in Sidebar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Not available in Mattermost Cloud.*
+*Deprecated. Not used in Mattermost v6.0 and later*
+
+This setting applies to the legacy sidebar only. You must enable the `Enable Legacy Sidebar <https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
+
+.. note::
+
+  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
+
+We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the channel sidebar documentation <https://docs.mattermost.com/messaging/organizing-your-sidebar.html>`_ for more information about these features.
+
+**True**: By default, direct message conversations with no activity for 7 days will be hidden from the sidebar. Users can disable this in **Account Settings > Sidebar**.
+
+**False**: Conversations remain in the sidebar until they are manually closed.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"CloseUnusedDirectMessages": false`` with options ``true`` and ``false``.                                                |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Town Square
+-----------
+
+Town Square is Hidden in Left-Hand Sidebar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Available in legacy Enterprise Edition E10 and higher*
+*Deprecated. Not used in Mattermost v6.0 and later*
+
+This setting applies to the legacy sidebar only. You must enable the `Enable Legacy Sidebar <https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar>`__ configuration setting to see and enable this functionality in the System Console.
+
+.. note::
+
+  This experimental setting is not recommended for production environments. The new channel sidebar matches and exceeds the feature set offered by this configuration setting.
+
+We strongly recommend that you leave the **Enable Legacy Sidebar** configuration setting disabled so users can access new channel sidebar features, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more. See `the channel sidebar documentation <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar.html>`_ for more information about these features.
+
+**True**: Hides Town Square in the left-hand sidebar if there are no unread messages in the channel.
+
+**False**: Town Square is always visible in the left-hand sidebar even if all messages have been read.
+
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalHideTownSquareinLHS": false`` with options ``true`` and ``false``.                                                  |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Town Square is Read-Only
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Available in legacy Enterprise Edition E10 and higher*
+*Deprecated. Not used in Mattermost v6.0 and later*
+
+**True**: Only System Admins can post in Town Square. Other members are not able to post, reply, upload files, react using emojis,  pin messages to Town Square, nor are they able to change the channel name, header, or purpose.
+
+**False**: Anyone can post in Town Square.
+
+.. note::
+
+  In Mattermost v.6.0, this feature has been deprecated in favor of `channel moderation settings <https://docs.mattermost.com/onboard/advanced-permissions.html#read-only-channels-e20>`_ which allow you to set any channel as read-only, including Town Square 
+
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalTownSquareIsReadOnly": false`` with options ``true`` and ``false``.                                                 |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Timezone
+--------
+
+Timezone
+^^^^^^^^^
+
+*Deprecated. Not used in Mattermost v6.0 and later*
+
+Select the timezone used for timestamps in the user interface and email notifications.
+
+**True**: The **Timezone** setting is visible in the Account Settings and a timezone is automatically assigned in the next active session.
+
+**False**: The **Timezone** setting is hidden in the Account Settings.
+
++------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalTimezone": true`` with options ``true`` and ``false``.  |
++------------------------------------------------------------------------------------------------------------------+
+
+High-Availability
+-----------------
+
+Inter-Node Listen Address
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Deprecated. Not used in version 4.0 and later*
+
+The address the Mattermost Server will listen on for inter-node communication. When setting up your network you should secure the listen address so that only machines in the cluster have access to that port. This can be done in different ways, for example, using IPsec, security groups, or routing tables.
+
++-----------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"InterNodeListenAddress": ":8075"`` with string input.  |
++-----------------------------------------------------------------------------------------------------+
+
+Inter-Node URLs
+^^^^^^^^^^^^^^^
+
+*Deprecated. Not used in version 4.0 and later*
+
+A list of all the machines in the cluster, such as ``["http://10.10.10.2", "http://10.10.10.4"]``. It is recommended to use the internal IP addresses so all the traffic can be secured.
+
++--------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"InterNodeUrls": []`` with string array input consisting of the machines in the cluster. |
++--------------------------------------------------------------------------------------------------------------------------------------+
+
+REST API V3
+-----------
+
+Allow use of API v3 endpoints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+Set to ``false`` to disable all version 3 endpoints of the REST API. Integrations that rely on API v3 will fail and can then be identified for migration to API v4. API v3 is deprecated and will be removed in the near future. See https://api.mattermost.com for details.
+
++---------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"EnableAPIv3": false`` with options ``true`` and ``false``. |
++---------------------------------------------------------------------------------------------------------+
+
+Policy
+------
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+  
+   Permission policy settings are available in Enterprise Edition E10 and E20. From v5.0, these settings are found in the `Advanced Permissions <https://docs.mattermost.com/onboard/advanced-permissions.html>`__ page instead of configuration settings.
+
+Enable sending team invites from
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Set policy on who can invite others to a team using the **Send Email Invite**, **Get Team Invite Link**, and **Add Members to Team** options on the Main Menu. If **Get Team Invite Link** is used to share a link, you can expire the invite code from **Team Settings > Invite Code** after the desired users have joined the team. Options include:
+
+**All team members**: Allows any team member to invite others using an email invitation, team invite link, or by adding members to the team directly.
+
+**Team and System Admins**: Hides the email invitation, team invite link, and the add members to team buttons in the Main Menu from users who are not Team Admins or System Admins.
+
+**System Admins**: Hides the email invitation, team invite link, and add members to team buttons in the Main Menu from users who are not System Admins.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictTeamInvite": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable public channel creation for
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Restrict the permission level required to create public channels.
+
+**All team members**: Allow all team members to create public channels.
+
+**Team Admins and System Admins**: Restrict creating public channels to Team Admins and System Admins.
+
+**System Admins**: Restrict creating public channels to System Admins.
+
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPublicChannelCreation": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable public channel renaming for
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Restrict the permission level required to rename and set the header or purpose for Public channels.
+
+**All channel members**: Allow all channel members to rename Public channels.
+
+**Channel Admins, Team Admins, and System Admins**: Restrict renaming Public channels to Channel Admins, Team Admins, and System Admins who are members of the channel.
+
+**Team Admins and System Admins**: Restrict renaming Public channels to Team Admins and System Admins who are members of the channel.
+
+**System Admins**: Restrict renaming Public channels to System Admins who are members of the channel.
+
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPublicChannelManagement": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable public channel deletion for
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Restrict the permission level required to delete Public channels. Deleted channels can be recovered from the database using a `command line tool <https://docs.mattermost.com/manage/command-line-tools.html>`__.
+
+**All channel members**: Allow all channel members to delete Public channels.
+
+**Channel Admins, Team Admins, and System Admins**: Restrict deleting Public channels to Channel Admins, Team Admins, and System Admins who are members of the channel.
+
+**Team Admins and System Admins**: Restrict deleting Public channels to Team Admins and System Admins who are members of the channel.
+
+**System Admins**: Restrict deleting Public channels to System Admins who are members of the channel.
+
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPublicChannelDeletion": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable private channel creation for
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Restrict the permission level required to create Private channels.
+
+**All team members**: Allow all team members to create Private channels.
+
+**Team Admins and System Admins**: Restrict creating Private channels to Team Admins and System Admins.
+
+**System Admins**: Restrict creating Private channels to System Admins.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPrivateChannelCreation": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable private channel renaming for
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Restrict the permission level required to rename and set the header or purpose for Private channels.
+
+**All channel members**: Allow all channel members to rename Private channels.
+
+**Channel Admins, Team Admins, and System Admins**: Restrict renaming Private channels to Channel Admins, Team Admins, and System Admins who are members of the Private channel.
+
+**Team Admins and System Admins**: Restrict renaming Private channels to Team Admins and System Admins who are members of the private channel.
+
+**System Admins**: Restrict renaming Private channels to System Admins who are members of the Private channel.
+
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPrivateChannelManagement": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable managing of private channel members for
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Set policy on who can add and remove members from Private channels.
+
+**All team members**: Allow all team members to add and remove members.
+
+**Team Admins, Channel Admins, and System Admins**: Allow only Team Admins, Channel Admins, and System Admins to add and remove members.
+
+**Team Admins, and System Admins**: Allow only Team Admins and System Admins to add and remove members.
+
+**System Admins**: Allow only System Admins to add and remove members.
+
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPrivateChannelManageMembers": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Enable private channel deletion for
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Restrict the permission level required to delete Private channels. Deleted channels can be recovered from the database using a `command line tool <https://docs.mattermost.com/manage/command-line-tools.html>`__.
+
+**All channel members**: Allow all channel members to delete Private channels.
+
+**Channel Admins, Team Admins, and System Admins**: Restrict deleting Private channels to Channel Admins, Team Admins, and System Admins who are members of the Private channel.
+
+**Team Admins and System Admins**: Restrict deleting private channels to Team Admins and System Admins who are members of the Private channel.
+
+**System Admins**: Restrict deleting Private channels to System Admins who are members of the Private channel.
+
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPrivateChannelDeletion": "all"`` with options ``"all"``, ``"channel_admin"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Allow which users to delete messages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Restrict the permission level required to delete messages. Team Admins, Channel Admins, and System Admins can delete messages only in channels where they are members. Messages can be deleted any time.
+
+**Message authors can delete their own messages, and Administrators can delete any message**: Allow authors to delete their own messages, and allow Team Admins, Channel Admins, and System Admins to delete any message.
+
+**Team Admins and System Admins**: Allow only Team Admins and System Admins to delete messages.
+
+**System Admins**: Allow only System Admins to delete messages.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"RestrictPostDelete": "all"`` with options ``"all"``, ``"team_admin"``, and ``"system_admin"`` for the above settings, respectively. |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Allow users to edit their messages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in June 16, 2018 release*
+
+.. note:: 
+
+   From v5.0 this has been replaced by advanced permissions which offers Admins a way to restrict actions in Mattermost to authorized users only. See the `Advanced Permissions documentation <https://docs.mattermost.com/onboard/advanced-permissions.html>`_ for more details.
+
+Set the time limit that users have to edit their messages after posting.
+
+**Any time**: Allow users to edit their messages at any time after posting.
+
+**Never**: Do not allow users to edit their messages.
+
+**{n} seconds after posting**: Users can edit their messages within the specified time limit after posting. The time limit is applied using the ``config.json`` setting ``PostEditTimeLimit`` described below.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"AllowEditPost": "always"`` with options ``"always"``, ``"never"``, and ``"time_limit"`` for the above settings, respectively. |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Post edit time limit
+^^^^^^^^^^^^^^^^^^^^
+
+When post editing is permitted, setting this to ``-1`` allows editing any time, and setting this to a positive integer restricts editing time in seconds. If post editing is disabled, this setting does not apply.
+
++--------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"PostEditTimeLimit": -1`` with numerical input.      |
++--------------------------------------------------------------------------------------------------+
+
+Images
+------
+
+Attachment Thumbnail Width
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in July 16th, 2017 release*
+
+Width of thumbnails generated from uploaded images. Updating this value changes how thumbnail images render in future, but does not change images created in the past.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ThumbnailWidth": 120`` with numerical input.                                                                            |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Attachment Thumbnail Height
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in July 16th, 2017 release*
+
+Height of thumbnails generated from uploaded images. Updating this value changes how thumbnail images render in future, but does not change images created in the past.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ThumbnailHeight": 100`` with numerical input.                                                                           |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Image Preview Width
+^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in July 16th, 2017 release*
+
+Maximum width of preview image. Updating this value changes how preview images render in future, but does not change images created in the past.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"PreviewWidth": 1024`` with numerical input.                                                                             |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Image Preview Height
+^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in July 16th, 2017 release*
+
+Maximum height of preview image. Setting this value to ``0`` instructs Mattermost to auto-size the preview image height based on the source image aspect ratio and the preview image width. Updating this value changes how preview images render in future, but does not change images created in the past.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"PreviewHeight": 0`` with numerical input.                                                                               |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Profile Picture Width
+^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in July 16th, 2017 release*
+
+The width to which profile pictures are resized after being uploaded via Account Settings.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ProfileWidth": 128`` with numerical input.                                                                              |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Profile Picture Height
+^^^^^^^^^^^^^^^^^^^^^^^
+
+*Removed in July 16th, 2017 release*
+
+The height to which profile pictures are resized after being uploaded via Account Settings.
+
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ProfileHeight": 128`` with numerical input.                                                                             |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/source/messaging/team-settings.rst
+++ b/source/messaging/team-settings.rst
@@ -51,7 +51,7 @@ The **Invite Code** is used as part of the URL in the team invitation link retri
 Import
 ------
 
-Import from Slack (Beta)
-~~~~~~~~~~~~~~~~~~~~~~~~
+Import from Slack
+~~~~~~~~~~~~~~~~~
 
-You can import channels and users from Slack into Mattermost. Please review our documentation on `Slack Import <https://docs.mattermost.com/administration/migrating.html#migrating-from-slack>`__ for more details.
+You can import channels and users from Slack into Mattermost. Please review our documentation on `Slack Import <https://docs.mattermost.com/onboard/migrating-to-mattermost.html#migrating-from-slack>`__ for more details.

--- a/source/onboard/migrating-to-mattermost.rst
+++ b/source/onboard/migrating-to-mattermost.rst
@@ -9,17 +9,17 @@ This guide summarizes different approaches to migrating from one Mattermost depl
   :backlinks: top
   :local:
 
-Migrating the Mattermost Server
--------------------------------
+Migrating Mattermost Server
+----------------------------
 
 The following instructions migrate Mattermost from one server to another by backing up and restoring the Mattermost database and ``config.json`` file. For these instructions **SOURCE** refers to the Mattermost server *from which* your system will be migrated and **DESTINATION** refers to the Mattermost server *to which* your system will be migrated.
 
 1. Back up your SOURCE Mattermost server.
-    1. See `Backup Guide <https://docs.mattermost.com/administration/backup.html>`__.
+    1. See `Backup and Disaster Recovery documentation <https://docs.mattermost.com/deploy/backup-disaster-recovery.html>`__.
 2. Upgrade your SOURCE Mattermost server to the latest major build version.
-    1. See `Mattermost Upgrade Guide <https://docs.mattermost.com/guides/administrator.html#upgrade-mattermost>`__.
+    1. See `Upgrading Mattermost Server documentation <https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html>`__.
 3. Install the latest major build of Mattermost server as your DESTINATION.
-    1. See `Installing Mattermost <https://docs.mattermost.com/guides/administrator.html#installing-mattermost>`__ for install guides. Make sure your new instance is properly configured and tested. The database type (MySQL or PostgreSQL) and version of SOURCE and DESTINATION deployments need to match.
+    1. See `Install Mattermost documentation <https://docs.mattermost.com/guides/install-deploy-upgrade-scale.html#install-mattermost>`__ for details. Make sure your new instance is properly configured and tested. The database type (MySQL or PostgreSQL) and version of SOURCE and DESTINATION deployments need to match.
     2. Stop the DESTINATION server using ``sudo stop mattermost``, then back up the database and ``config.json`` file.
 4. Migrate database from SOURCE to DESTINATION.
     1. Backup the database from the SOURCE Mattermost server and restore it in place of the database to which the DESTINATION server is connected.
@@ -34,7 +34,7 @@ The following instructions migrate Mattermost from one server to another by back
 8. Test that the system is working by going to the URL of an existing team.
     1. You may need to refresh your Mattermost browser page in order to get the latest updates from the upgrade.
 
-Once your migration is complete and verified, you can optionally `upgrade the Team Edition of Mattermost to Enterprise Edition using the upgrade guide <https://docs.mattermost.com/administration/upgrade.html#upgrade-team-edition-to-enterprise-edition>`__.
+Once your migration is complete and verified, you can optionally `upgrade the Team Edition of Mattermost to Enterprise Edition using the upgrade guide <https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html#upgrading-team-edition-to-enterprise-edition>`__.
 
 Migrating to Mattermost From Other Messaging Solutions
 ------------------------------------------------------
@@ -72,7 +72,7 @@ Why IT Teams Choose Mattermost over Bespoke Solutions
 
 Mattermost is designed to replace bespoke messaging solutions through a platform that is unmatched in flexibility. From the `hundreds of open source projects extending and customizing Mattermost through APIs and drivers <https://github.com/search?utf8=✓&q=mattermost&type=>`__, to an innovative client and server plugin framework for adapting the Mattermost user experience to the specific workflows and needs, thousands of high performance teams rely on Mattermost daily.
 
-In addition, IT teams prefer Mattermost for its specific `security assurances <https://docs.mattermost.com/overview/security.html>`__:
+In addition, IT teams prefer Mattermost for its specific `security assurances <https://docs.mattermost.com/about/security.html>`__:
 
 1. Mattermost products are backed by Mattermost, Inc., which has commercial contracts with hundreds of enterprises around the world, many with Fortune 500 and Global 2000 organizations who require significant obligations and assurances from vendors of critical infrastructure.
 2. Mattermost offers a `security bulletin <https://mattermost.com/security-updates/#sign-up>`__ to alert IT teams and customers of high priority security updates, with step-by-step instructions for upgrade and options for commercial support.
@@ -87,7 +87,7 @@ Migrating from bespoke messengers to Mattermost can be challenging. Because of t
 
 If your data in the bespoke messenger is vital, consider:
 
-1. `Mattermost Bulk Load tool <https://docs.mattermost.com/deployment/bulk-loading.html>`__: Use the Mattermost Bulk Load tool to ETL from your bespoke system to Mattermost.
+1. `Mattermost Bulk Load tool <https://docs.mattermost.com/onboard/bulk-loading-data.html>`__: Use the Mattermost Bulk Load tool to ETL from your bespoke system to Mattermost.
 2. `Mattermost ETL framework from BrightScout <https://github.com/Brightscout/mattermost-etl>`__: Consider the Mattermost ETL framework from BrightScout to custom-configure an adapter to plug in to the Bulk Load tool mentioned above.
 3. **Legacy Slack import:** If you only recently switched from Slack to a bespoke tool, consider going back to import the data and users from the old Slack instance directly into Mattermost, leveraging the extensive support for Slack-import provided.
 4. **Export to Slack, then import to Mattermost:** `Export HipChat, Flowdock, Campfire, Chatwork, Hall, or CSV files to Slack <https://get.slack.help/hc/en-us/articles/201748703-Import-message-history>`__ and then export to a Slack export file and import the file into Mattermost.
@@ -111,25 +111,28 @@ Slack offers two ways to `export your data from their product <https://get.slack
 
 .. note::
 
-  As a proprietary SaaS service, Slack is able to change its export format quickly and without notice. If you encounter issues not mentioned in the documentation below, please alert the product team by `filing an issue <https://mattermost.org/filing-issues/>`__.
+  As a proprietary SaaS service, Slack is able to change its export format quickly and without notice. If you encounter issues not mentioned in the following documentation, please let the Mattermost Product Team know by `filing an issue <https://mattermost.org/filing-issues/>`__.
 
 Migrating from Slack Using the Mattermost mmetl Tool and Bulk Import
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
   
-  This method is the recommended way to import Slack's corporate export file. It can be used with Mattermost v5.0 and onwards.
+  This method is the recommended way to import Slack's corporate export file. It can be used from Mattermost v5.0.
 
 1. Use the `slack-advanced-exporter <https://github.com/grundleborg/slack-advanced-exporter>`_ to download attachments and add users' email addresses to your Slack corporate export file.
 2. Use the `mmetl tool <https://github.com/mattermost/mmetl>`_ to transform Slack's corporate export file into the ``jsonl`` format required by the bulk import tool.
-3. Bulk load the files using the steps provided in the `bulk loading documentation <https://docs.mattermost.com/deployment/bulk-loading.html#bulk-loading-data>`_.
+3. Bulk load the files using the steps provided in the `bulk loading documentation <https://docs.mattermost.com/onboard/bulk-loading-data.html>`_.
 
 Migrating from Slack using the Mattermost Web App
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. important::
+  In Mattermost v6.0, the ability to migrate from Slack using the Mattermost Web App has been deprecated and removed in favor of using the Mattermost mmetl tool with bulk import.
+
 .. note::
   
-  For larger imports, particularly those where you have used the `slack-advanced-exporter tool` to add Slack post attachments to the archive or the Corporate Export file, it is recommended to import the Slack data using the `mmetl tool and bulk loading tool <https://docs.mattermost.com/administration/migrating.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import>`__.
+  For larger imports, particularly those where you have used the `slack-advanced-exporter tool` to add Slack post attachments to the archive or the Corporate Export file, it is recommended to import the Slack data using the `mmetl tool and bulk loading tool <https://docs.mattermost.com/onboard/migrating-to-mattermost.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import>`__.
 
 1. Generate a Slack export file from **Slack > Administration > Workspace Settings > Import/Export Data > Export > Start Export**. Alternatively, use the Slack Corporate Export file after receiving it from Slack.
 2. In Mattermost go to **Main Menu > Team Settings > Import > Import from Slack**. Team Admin or System Admin permission is required to access this menu option.
@@ -138,6 +141,9 @@ Migrating from Slack using the Mattermost Web App
 Migrating from Slack Using the Mattermost CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+  In Mattermost v6.0, the CLI has been deprecated in favor of the mmctl `CLI <https://docs.mattermost.com/manage/mmctl-command-line-tool.html>`__.
+
 1. Generate a Slack export file from **Slack > Administration > Workspace Settings > Import/Export Data > Export > Start Export**.
 2. Run the following Mattermost CLI command, with the name of a team you've already created:
 
@@ -145,7 +151,7 @@ Migrating from Slack Using the Mattermost CLI
    
 .. note::
 
-  To run the CLI command, you must be in the directory that contains the Mattermost installation. On a default installation of Mattermost, the directory is ``/opt/mattermost/``. Also, if you followed our `installation process <../guides/administrator.html#installing-mattermost>`__, you must run the command as the user *mattermost*. The executable is in the ``bin`` subdirectory and is called ``mattermost``.
+  To run the CLI command, you must be in the directory that contains the Mattermost installation. On a default installation of Mattermost, the directory is ``/opt/mattermost/``. Also, if you followed our `installation process <https://docs.mattermost.com/guides/install-deploy-upgrade-scale.html#install-mattermost>`__, you must run the command as the user *mattermost*. The executable is in the ``bin`` subdirectory and is called ``mattermost``.
 
 Using the Imported Team
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +172,7 @@ For more information about letter case in MySQL table names and the ``--lower-ca
 Migrating from HipChat Server and HipChat Data Center to Mattermost
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please see `HipChat Migration Guide <https://docs.mattermost.com/administration/hipchat-migration-guidelines.html>`__.
+Please see `HipChat Migration Guide <https://docs.mattermost.com/onboard/migrating-from-hipchat-to-mattermost.html>`__.
 
 Migrating from Jabber to Mattermost
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Moved all deprecated configuration settings to a new page; included a link to the new page from the existing Configuration Settings page
- Marked v6.0 deprecated settings accordingly
- Added missing 301 mid-page redirects
- Cleaned up source link URLs