### PR TITLE
MM-10166 Add MaxImageResolution config setting

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -5238,7 +5238,7 @@ Maximum Image Resolution
 Maxiumum image resolution size for message attachments in megapixels. This setting can only be changed from ``config.json`` file, it cannot be changed from the System Console user interface.
 
 +---------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"FileSettings.MaxImageResolution": 33`` with numerical input.     |
+| This feature's ``config.json`` setting is ``"FileSettings.MaxImageResolution": 33177600`` with numerical input.     |
 +---------------------------------------------------------------------------------------------------------------+
 
 File Settings

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -5235,7 +5235,7 @@ Image Settings
 Maximum Image Resolution
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Maxiumum image resolution size for message attachments in mega pixels. This setting can only be changed from ``config.json`` file, it cannot be changed from the System Console user interface.
+Maxiumum image resolution size for message attachments in megapixels. This setting can only be changed from ``config.json`` file, it cannot be changed from the System Console user interface.
 
 +---------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"FileSettings.MaxImageResolution": 33`` with numerical input.     |

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -643,15 +643,15 @@ Maximum File Size
 
 Maximum file size for message attachments entered in megabytes in the System Console UI. Converted to bytes in ``config.json`` at 1048576 bytes per megabyte.
 
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"MaxFileSize": 104857600`` with numerical input.                                                                         |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"MaxFileSize": 104857600`` with numerical input.                  |
++---------------------------------------------------------------------------------------------------------------+
 
 .. warning:: Verify server memory can support your setting choice. Large file sizes increase the risk of server crashes and failed uploads due to network disruptions.
 
 .. note::
   If you use a proxy or load balancer in front of Mattermost its settings need to be adjusted accordingly. For NGINX use ``client_max_body_size``. For Apache use ``LimitRequestBody``.
-
+  
 Enable Document Search by Content
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -5089,7 +5089,7 @@ mmctl local mode ignores this setting and behaves as though ``EnableAPITeamDelet
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Enable API User Deletion
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **True**: The ``api/v4/users/{userid}?permanent=true`` API endpoint can be called by System Admins, or users with appropriate permissions, to permanently delete a user.
 
@@ -5228,6 +5228,18 @@ For MySQL Group Replication, the absolute lag can be measured from the number of
 .. code-block:: sh
 
    select member_id, count_transactions_remote_in_applier_queue FROM performance_schema.replication_group_member_stats where member_id=<>
+
+Image Settings
+~~~~~~~~~~~~~~
+
+Maximum Image Resolution
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Maxiumum image resolution size for message attachments in mega pixels. This setting can only be changed from ``config.json`` file, it cannot be changed from the System Console user interface.
+
++---------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"FileSettings.MaxImageResolution": 33`` with numerical input.     |
++---------------------------------------------------------------------------------------------------------------+
 
 File Settings
 ~~~~~~~~~~~~~~

--- a/source/messaging/sharing-files.rst
+++ b/source/messaging/sharing-files.rst
@@ -54,4 +54,4 @@ Attachment Limits and Sizes
 
 Up to five files can be attached per post. The default maximum file size is 100 MB, but this can be changed by the System Admin.
 
-Image files can be a maximum size of 6048 pixels x 4032 pixels, with a maximum image resolution of 33 MP (mega pixels) or 8K resolution, and a maximum raw image file size of approximately 36 MB. System Admins can customize the maximum image resolution size within the ``conf.json`` file. See our `Configuration Settings <URL>`__ product documentation for details.
+Image files can be a maximum size of 6048 pixels x 4032 pixels, with a maximum image resolution of 33 MP (mega pixels) or 8K resolution, and a maximum raw image file size of approximately 36 MB. System Admins can customize the maximum image resolution size within the ``config.json`` file. See our `Configuration Settings <URL>`__ product documentation for details.

--- a/source/messaging/sharing-files.rst
+++ b/source/messaging/sharing-files.rst
@@ -54,4 +54,4 @@ Attachment Limits and Sizes
 
 Up to five files can be attached per post. The default maximum file size is 100 MB, but this can be changed by the System Admin.
 
-Image files can be a maximum size of 6048 pixels x 4032 pixels, or 24 MP (mega pixels), or a raw image file size of approximately 36 MB.
+Image files can be a maximum size of 6048 pixels x 4032 pixels, with a maximum image resolution of 33 MP (mega pixels) or 8K resolution, and a maximum raw image file size of approximately 36 MB. System Admins can customize the maximum image resolution size within the ``conf.json`` file. See our `Configuration Settings <URL>`__ product documentation for details.

--- a/source/messaging/sharing-files.rst
+++ b/source/messaging/sharing-files.rst
@@ -54,4 +54,4 @@ Attachment Limits and Sizes
 
 Up to five files can be attached per post. The default maximum file size is 100 MB, but this can be changed by the System Admin.
 
-Image files can be a maximum size of 6048 pixels x 4032 pixels, with a maximum image resolution of 33 MP (mega pixels) or 8K resolution, and a maximum raw image file size of approximately 36 MB. System Admins can customize the maximum image resolution size within the ``config.json`` file. See our `Configuration Settings <URL>`__ product documentation for details.
+Image files can be a maximum size of 6048 pixels x 4032 pixels, with a maximum image resolution of 33 MP (mega pixels) or 8K resolution, and a maximum raw image file size of approximately 36 MB. System Admins can customize the maximum image resolution size within the ``config.json`` file. See our `Configuration Settings <https://docs.mattermost.com/configure/configuration-settings.html#maximum-image-resolution>`__ product documentation for details.

--- a/source/messaging/sharing-files.rst
+++ b/source/messaging/sharing-files.rst
@@ -54,4 +54,4 @@ Attachment Limits and Sizes
 
 Up to five files can be attached per post. The default maximum file size is 100 MB, but this can be changed by the System Admin.
 
-Image files can be a maximum size of 6048 pixels x 4032 pixels, with a maximum image resolution of 33 MP (mega pixels) or 8K resolution, and a maximum raw image file size of approximately 36 MB. System Admins can customize the maximum image resolution size within the ``config.json`` file. See our `Configuration Settings <https://docs.mattermost.com/configure/configuration-settings.html#maximum-image-resolution>`__ product documentation for details.
+Image files can be a maximum size of 7680 pixels x 4320 pixels, with a maximum image resolution of 33 MP (mega pixels) or 8K resolution, and a maximum raw image file size of approximately 253 MB. System Admins can customize the maximum image resolution size within the ``config.json`` file. See our `Configuration Settings <https://docs.mattermost.com/configure/configuration-settings.html#maximum-image-resolution>`__ product documentation for details.


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/17941

Updated: 
- Messaging (Channels) > Work with Messages > Sharing Files > Attachment Limits and Sizes
   - Updated maximum image resolution details and included link to configuration settings