### PR TITLE
MM-27312 Allow uploading 10 files per post

### DIFF
--- a/source/messaging/sharing-files.rst
+++ b/source/messaging/sharing-files.rst
@@ -52,6 +52,6 @@ Other document previews (such as Word, Excel, or PPT) are not yet supported.
 Attachment Limits and Sizes
 ---------------------------
 
-Up to five files can be attached per post. The default maximum file size is 100 MB, but this can be changed by the System Admin.
+Up to 10 files can be attached per post. The default maximum file size is 100 MB, but this can be changed by the System Admin.
 
 Image files can be a maximum size of 6048 pixels x 4032 pixels, or 24 MP (mega pixels), or a raw image file size of approximately 36 MB.


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/17948

Updated:
- Messaging (Channels) > Work with Messages > Sharing Files > Attachment Limits and Sizes
   - Updated file attachment limit to 10
