### PR TITLE
Unintentional no-op in rm command after improvement

### DIFF
--- a/source/upgrade/upgrading-mattermost-server.rst
+++ b/source/upgrade/upgrading-mattermost-server.rst
@@ -114,11 +114,11 @@ Upgrading Mattermost Server
  
     sudo find mattermost/ mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/client -o -path mattermost/client/plugins -o -path mattermost/config -o -path mattermost/logs -o -path mattermost/plugins -o -path mattermost/data -o -path  mattermost/yourFolderHere \) -prune \) | sort
     
-  When you're ready to execute the command, append ``xargs echo rm -r`` to the command above to delete the files. Note that the following example includes ``-o -path mattermost/yourFolderHere``:
+  When you're ready to execute the command, append ``xargs rm -r`` to the command above to delete the files. Note that the following example includes ``-o -path mattermost/yourFolderHere``:
   
   .. code-block:: sh
   
-    sudo find mattermost/ mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/client -o -path mattermost/client/plugins -o -path mattermost/config -o -path mattermost/logs -o -path mattermost/plugins -o -path mattermost/data -o -path  mattermost/yourFolderHere \) -prune \) | sort | sudo xargs echo rm -r
+    sudo find mattermost/ mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/client -o -path mattermost/client/plugins -o -path mattermost/config -o -path mattermost/logs -o -path mattermost/plugins -o -path mattermost/data -o -path  mattermost/yourFolderHere \) -prune \) | sort | sudo xargs rm -r
   
   **Using Bleve Search**
 


### PR DESCRIPTION
#### Summary

##### Fixes a bug that could result in no upgrade being performed at all.

The existing example was already a dry-run/no-op. After 09c34e28ac5a1c88ca6b9243830df60432ec4058, the actual deletion was moved to a separate command, but the `echo` was not removed from it, so it does nothing. This will result in no upgrade being performed at all because the later copy command uses the no-clobber flag, therefore will not overwrite the old files at all.
