### PR TITLE
Switching the setcap / chown

### DIFF
--- a/source/upgrade/upgrading-mattermost-server.rst
+++ b/source/upgrade/upgrading-mattermost-server.rst
@@ -140,14 +140,8 @@ Upgrading Mattermost Server
     
     The ``n`` (no-clobber) flag and trailing ``.`` on source are very important. The ``n`` (no-clobber) flag preserves existing configurations and logs in your installation path. The trailing ``.`` on source ensures all installation files are copied.
 
-9. If you want to use port 80 or 443 to serve your server, and/or if you have TLS set up on your Mattermost server, you **must** activate the CAP_NET_BIND_SERVICE capability to allow the new Mattermost binary to bind to ports lower than 1024. For example:
 
-  .. code-block:: sh
-
-    cd {install-path}/mattermost
-    sudo setcap cap_net_bind_service=+ep ./bin/mattermost
-
-10. Change ownership of the new files after copying them. For example:
+9. Change ownership of the new files after copying them. For example:
 
   .. code-block:: sh
          
@@ -157,6 +151,13 @@ Upgrading Mattermost Server
     
   - If you didn't use ``mattermost`` as the owner and group of the install directory, run ``sudo chown -hR {owner}:{group} tmp/mattermost-upgrade/``.
   - If you're uncertain what owner or group was defined, use the ``ls -l {install-path}/mattermost/bin/mattermost`` command to obtain them.
+  
+10. If you want to use port 80 or 443 to serve your server, and/or if you have TLS set up on your Mattermost server, you **must** activate the CAP_NET_BIND_SERVICE capability to allow the new Mattermost binary to bind to ports lower than 1024. For example:
+
+  .. code-block:: sh
+
+    cd {install-path}/mattermost
+    sudo setcap cap_net_bind_service=+ep ./bin/mattermost
 
 11. Start your Mattermost server.
 

--- a/source/upgrade/upgrading-mattermost-server.rst
+++ b/source/upgrade/upgrading-mattermost-server.rst
@@ -152,7 +152,7 @@ Upgrading Mattermost Server
   - If you didn't use ``mattermost`` as the owner and group of the install directory, run ``sudo chown -hR {owner}:{group} tmp/mattermost-upgrade/``.
   - If you're uncertain what owner or group was defined, use the ``ls -l {install-path}/mattermost/bin/mattermost`` command to obtain them.
   
-10. If you want to use port 80 or 443 to serve your server, and/or if you have TLS set up on your Mattermost server, you **must** activate the CAP_NET_BIND_SERVICE capability to allow the new Mattermost binary to bind to ports lower than 1024. For example:
+10. If you want to use port 80 or 443 to serve your server, and/or if you have TLS set up on your Mattermost server, you **must** activate the ``CAP_NET_BIND_SERVICE`` capability to allow the new Mattermost binary to bind to ports lower than 1024. For example:
 
   .. code-block:: sh
 


### PR DESCRIPTION
The order in which the steps are currently in will reset the `setcap` on the mattermost process by running `chown` after it. Reversed this order and it works properly.

```bash
vagrant@ubuntu-focal:/opt/mattermost$ sudo setcap cap_net_bind_service=+ep ./bin/mattermost
vagrant@ubuntu-focal:/opt/mattermost$ sudo chown -R mattermost:mattermost /opt/mattermost/
vagrant@ubuntu-focal:/opt/mattermost$ sudo systemctl start mattermost
Job for mattermost.service failed because the control process exited with error code.
See "systemctl status mattermost.service" and "journalctl -xe" for details.
vagrant@ubuntu-focal:/opt/mattermost$ sudo cat /opt/mattermost/logs/mattermost.log 
...
{"level":"info","ts":1630341467.161165,"caller":"mlog/sugar.go:21","msg":"Ensuring Surveybot exists","plugin_id":"com.mattermost.nps"}
{"level":"info","ts":1630341467.477441,"caller":"app/server.go:1177","msg":"Starting Server..."}
{"level":"error","ts":1630341467.4804962,"caller":"commands/server.go:105","msg":"Error starting server, err:listen tcp :443: bind: permission denied: listen tcp :443: bind: permission denied"}
{"level":"info","ts":1630341467.481407,"caller":"app/server.go:973","msg":"Stopping Server..."}
{"level":"info","ts":1630341467.481527,"caller":"app/web_hub.go:113","msg":"stopping websocket hub connections"}
vagrant@ubuntu-focal:/opt/mattermost$ sudo chown -R mattermost:mattermost /opt/mattermost/
vagrant@ubuntu-focal:/opt/mattermost$ sudo setcap cap_net_bind_service=+ep ./bin/mattermost
vagrant@ubuntu-focal:/opt/mattermost$ sudo systemctl start mattermost
vagrant@ubuntu-focal:/opt/mattermost$ sudo cat /opt/mattermost/logs/mattermost.log 
...
{"level":"info","ts":1630341499.7371416,"caller":"app/server.go:1177","msg":"Starting Server..."}
{"level":"info","ts":1630341499.7385483,"caller":"app/server.go:1253","msg":"Server is listening on [::]:443","address":"[::]:443"}
{"level":"info","ts":1630341499.7386847,"caller":"commands/server.go:129","msg":"Sending systemd READY notification."}
vagrant@ubuntu-focal:/opt/mattermost$
```

