### PR TITLE
Fixed slack advanced exporter link

### DIFF
--- a/source/onboard/migrating-to-mattermost.rst
+++ b/source/onboard/migrating-to-mattermost.rst
@@ -120,7 +120,7 @@ Migrating from Slack Using the Mattermost mmetl Tool and Bulk Import
   
   This method is the recommended way to import Slack's corporate export file. It can be used with Mattermost v5.0 and onwards.
 
-1. Use the `slack-advanced-exporter <https://github.com/grundleborg/slack-advanced-exporter>`_ to download attachments and add users' email addresses to your Slack corporate export file.
+1. Use the `slack-advanced-exporter <https://github.com/icelander/slack-advanced-exporter>`_ to download attachments and add users' email addresses to your Slack corporate export file.
 2. Use the `mmetl tool <https://github.com/mattermost/mmetl>`_ to transform Slack's corporate export file into the ``jsonl`` format required by the bulk import tool.
 3. Bulk load the files using the steps provided in the `bulk loading documentation <https://docs.mattermost.com/deployment/bulk-loading.html#bulk-loading-data>`_.
 


### PR DESCRIPTION
#### Summary

The version at the old link didn't authenticate to slack correctly, linking to a working version