### PR TITLE
Added mac log location for desktop

### DIFF
--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -48,6 +48,8 @@ The desktop app log file can be found in the user directory:
 
 - **Windows:** ``%userprofile%\AppData\Roaming\Mattermost\logs``
 - **Linux:** ``~/.local/share/Mattermost/logs``
+- **MacOS:** ``~/Library/Logs/Mattermost``
+
 
 **Mattermost Browser App**
 


### PR DESCRIPTION
Missing the mac log location for the desktop application.