### PR TITLE
Fix environment pickling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@
 SOURCEDIR       = source
 BUILDDIR        = build
 WARNINGSFILE    = $(BUILDDIR)/warnings.log
-ERRORSFILE      = $(BUILDDIR)/errors.log
-SPHINXOPTS      ?= -j auto -w $(WARNINGSFILE)
+SPHINXOPTS      ?= -j auto
 SPHINXBUILD     ?= pipenv run sphinx-build
 SPHINXAUTOBUILD ?= pipenv run sphinx-autobuild
 
@@ -15,7 +14,7 @@ SPHINXAUTOBUILD ?= pipenv run sphinx-autobuild
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile livehtml clean
+.PHONY: help Makefile livehtml
 
 # Run `make livehtml` to start sphinx-autobuild
 livehtml:
@@ -26,7 +25,4 @@ livehtml:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@mkdir -p "$(BUILDDIR)"
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 2>>"$(ERRORSFILE)"
-
-clean: # clean the build directory
-	rm -rf build/
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 2>>"$(WARNINGSFILE)"

--- a/extensions/reredirects/__init__.py
+++ b/extensions/reredirects/__init__.py
@@ -70,14 +70,14 @@ def write_redirect_pages(app: Sphinx) -> List[Tuple[str, Dict[str, Any], str]]:
     return list()
 
 
-def env_purge_doc(_: Sphinx, __: BuildEnvironment, ___: str):
+def env_purge_doc(app: Sphinx, env: BuildEnvironment, docname: str):
     """
     Stub function for the `env-purge-doc` event; does nothing
     """
     return
 
 
-def env_merge_info(_: Sphinx, __: BuildEnvironment, ___: List[str], ____: BuildEnvironment):
+def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: List[str], other: BuildEnvironment):
     """
     Stub function for the `env-merge-info` event; does nothing
     """
@@ -85,6 +85,14 @@ def env_merge_info(_: Sphinx, __: BuildEnvironment, ___: List[str], ____: BuildE
 
 
 def old_status_iterator(mapping: Mapping[str, str], summary: str, color: str = "darkgreen") -> Tuple[str, str]:
+    """
+    Displays the status of iterating through a Dict/Mapping of strings. Taken from the Sphinx sources.
+
+    :param mapping: The iterable to iterate through
+    :param summary: A description of the action or operation
+    :param color: The color of the status text; defaults to `darkgreen`
+    :return: A tuple containing the next key-value pair from the iterable
+    """
     line_count = 0
     for item in mapping.items():
         if line_count == 0:
@@ -99,6 +107,17 @@ def old_status_iterator(mapping: Mapping[str, str], summary: str, color: str = "
 
 def status_iterator(mapping: Mapping[str, str], summary: str, color: str = "darkgreen",
                     length: int = 0, verbosity: int = 0) -> Tuple[str, str]:
+    """
+    Displays the status of iterating through a Dict/Mapping of strings. Taken from the Sphinx sources.
+    Status includes percent of records in the iterable that have been iterated through.
+
+    :param mapping: The iterable to iterate through
+    :param summary: A description of the action or operation
+    :param color:  The color of the status text; defaults to `darkgreen`
+    :param length: The number of records in the iterable
+    :param verbosity: Flag which writes a newline after each status message
+    :return: A tuple containing the next key-value pair from the iterable
+    """
     if length == 0:
         yield from old_status_iterator(mapping, summary, color)
         return
@@ -119,6 +138,12 @@ def status_iterator(mapping: Mapping[str, str], summary: str, color: str = "dark
 
 class Reredirects:
     def __init__(self, app: Sphinx):
+        """
+        Class constructor.
+        Retrieves configuration values from the supplied Sphinx Application instance.
+
+        :param app: The Sphinx Application instance
+        """
         self.app = app
         self.redirects_option: Dict[str,
                                     str] = getattr(app.config,
@@ -159,8 +184,9 @@ class Reredirects:
 
     def create_redirects(self, to_be_redirected: Mapping[str, str]):
         """
-        Create actual redirect file for each pair in passed mapping of
-        docnames to targets.
+        Create a redirect file for each pair in passed mapping of docnames to targets.
+
+        :param to_be_redirected: A mapping of docnames to targets to create redirect files for
         """
         for doc, target in status_iterator(to_be_redirected, 'writing redirects...', 'darkgreen',
                                            len(to_be_redirected.items())):
@@ -179,20 +205,34 @@ class Reredirects:
 
     @staticmethod
     def _apply_placeholders(source: str, target: str) -> str:
-        """Expand "source" placeholder in target and return it"""
+        """
+        Expand `source` placeholder in target and return it
+
+        :param source: The string value of the `source` parameter to render
+        :param target: The template to render
+        :return: The rendered template
+        """
         return Template(target).substitute({"source": source})
 
     def _create_redirect_file(self, at_path: Path, to_uri: str):
-        """Actually create a redirect file according to redirect template"""
+        """
+        Create a redirect file according to the redirect template
 
+        :param at_path: The Path in which to write the redirect file
+        :param to_uri: The value of the `to_uri` parameter to render in the redirect template
+        """
         content = self._render_redirect_template(to_uri)
-
         # create any missing parent folders
         at_path.parent.mkdir(parents=True, exist_ok=True)
-
         at_path.write_text(content)
 
-    def _render_redirect_template(self, to_uri) -> str:
+    def _render_redirect_template(self, to_uri: Any) -> str:
+        """
+        Render the redirect template by substituting the `to_uri` parameter
+
+        :param to_uri: The value of the `to_uri` parameter to render
+        :return: The rendered redirect template
+        """
         # HTML used as redirect file content
         redirect_template = REDIRECT_FILE_DEFAULT_TEMPLATE
         if self.template_file_option:

--- a/extensions/sitemap/__init__.py
+++ b/extensions/sitemap/__init__.py
@@ -95,15 +95,14 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     }
 
 
-def env_purge_doc(_: Sphinx, env: BuildEnvironment, docname: str):
+def env_purge_doc(app: Sphinx, env: BuildEnvironment, docname: str):
     """
     Purge an existing document from the pickled document list.
     This function is called when the Sphinx `env-purge-doc` event is fired.
 
-    :param _: The Sphinx instance; unused
+    :param app: The Sphinx instance; unused
     :param env: The Sphinx BuildEnvironment
     :param docname: The name of the document to purge
-    :return: None
     """
     logger.debug('env_purge_doc: docname=%s' % docname)
     if hasattr(env, 'sitemap_links'):
@@ -122,7 +121,6 @@ def env_merge_info(app: Sphinx, env: BuildEnvironment, docnames: List[str], othe
     :param env: The master Sphinx BuildEnvironment
     :param docnames: A list of the document names to merge
     :param other: The Sphinx BuildEnvironment from the reader worker
-    :return: None
     """
     # Create a `sitemap_links` attribute in the environment if it doesn't already exist
     if not hasattr(env, 'sitemap_links'):
@@ -203,7 +201,6 @@ def record_builder_type(app: Sphinx):
     application environment.
 
     :param app: The Sphinx Application instance
-    :return: None
     """
     # builder isn't initialized in the setup so we do it here
     # we rely on the class name, not the actual class, as it was moved 2.0.0

--- a/source/conf.py
+++ b/source/conf.py
@@ -6,9 +6,10 @@
 
 import sys
 import os
+from sphinx.application import Sphinx
 
 
-def setup(app):
+def setup(_: Sphinx):
     return
 
 
@@ -57,7 +58,6 @@ source_suffix = ['.rst', '.md']
 
 # Redirects using: https://pypi.org/project/sphinx-reredirects/
 redirects = {
-
     "integrations/jira": "https://mattermost.gitbook.io/plugin-jira/",
     "integrations/zoom": "https://mattermost.gitbook.io/plugin-zoom/",
     "integrations/net-promoter-score": "https://docs.mattermost.com/manage/user-satisfaction-surveys.html",
@@ -120,24 +120,24 @@ redirects = {
     "administration/changelog": "https://docs.mattermost.com/install/self-managed-changelog.html",
     "administration/command-line-tools": "https://docs.mattermost.com/manage/command-line-tools.html",
     "administration/compliance-export": "https://docs.mattermost.com/comply/compliance-export.html",
-    "administration/config-settings#allow-users-to-view-archived-channels-beta": 
+    "administration/config-settings#allow-users-to-view-archived-channels-beta":
         "https://docs.mattermost.com/configure/configuration-settings.html#allow-users-to-view-archived-channels-beta",
     "administration/config-settings#timezone": "https://docs.mattermost.com/configure/configuration-settings.html#timezone",
-    "administration/config-settings#enable-legacy-sidebar": 
+    "administration/config-settings#enable-legacy-sidebar":
         "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
-    "administration/config-settings#town-square-is-read-only-experimental": 
+    "administration/config-settings#town-square-is-read-only-experimental":
         "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-read-only-experimental",
-    "administration/config-settings#town-square-is-hidden-in-left-hand-sidebar-experimental": 
+    "administration/config-settings#town-square-is-hidden-in-left-hand-sidebar-experimental":
         "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-hidden-in-left-hand-sidebar-experimental",
-    "administration/config-settings#enable-x-to-leave-channels-from-left-hand-sidebar-experimental": 
+    "administration/config-settings#enable-x-to-leave-channels-from-left-hand-sidebar-experimental":
         "https://docs.mattermost.com/configure/configuration-settings.html#enable-x-to-leave-channels-from-left-hand-sidebar-experimental",
-    "administration/config-settings#autoclose-direct-messages-in-sidebar-experimental": 
+    "administration/config-settings#autoclose-direct-messages-in-sidebar-experimental":
         "https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental",
-    "administration/config-settings#sidebar-organization": 
+    "administration/config-settings#sidebar-organization":
         "https://docs.mattermost.com/configure/configuration-settings.html#sidebar-organization",
-    "administration/config-settings#experimental-sidebar-features": 
+    "administration/config-settings#experimental-sidebar-features":
         "https://docs.mattermost.com/configure/configuration-settings.html#experimental-sidebar-features",
-    "administration/config-settings#deprecated-configuration-settings": 
+    "administration/config-settings#deprecated-configuration-settings":
         "https://docs.mattermost.com/configure/configuration-settings.html#deprecated-configuration-settings",
     "administration/custom-terms-of-service": "https://docs.mattermost.com/comply/custom-terms-of-service.html",
     "administration/image-proxy": "https://docs.mattermost.com/deploy/image-proxy.html",
@@ -152,9 +152,9 @@ redirects = {
     "administration/downgrade": "https://docs.mattermost.com/upgrade/downgrading-mattermost-server.html",
     "administration/open-source-components": "https://docs.mattermost.com/upgrade/open-source-components.html",
     "administration/mmctl-cli-tool": "https://docs.mattermost.com/manage/mmctl-cli-tool.html",
-    "administration/migrating#migrating-from-slack-using-the-mattermost-web-app": 
+    "administration/migrating#migrating-from-slack-using-the-mattermost-web-app":
         "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-web-app",
-    "administration/migrating#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import": 
+    "administration/migrating#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import":
         "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
     "administration/release-definitions": "https://docs.mattermost.com/upgrade/release-definitions.html",
     "administration/performance-alerting-guide": "https://docs.mattermost.com/scale/peformance-alerting.html",


### PR DESCRIPTION
I noticed that my previous PR had introduced an issue with the Sphinx "environment pickling" process. The net result of the issue is the loss of incremental builds, although the build speed has improved. Please accept this PR as a fix to the issue including further code cleanups and documentation. :)

--

# Fix Environment Pickling

## Goals

### Primary

- Repair the recently-broken Sphinx environment pickling process

### Secondary

- Improve documentation of the `reredirects` and `sitemap` extensions

## Background

### Sphinx Environment Pickling

- The Sphinx build process consists of [5 phases](https://www.sphinx-doc.org/en/master/extdev/index.html#build-phases):
  - Initialization
  - Reading
  - Consistency checks
  - Resolving
  - Writing
- During the _Reading_ phase, Sphinx gathers a list of all documents to be built
- This list of documents, among other build information, is persisted in the `build/doctrees` directory as a "pickle" file named `environment.pickle`
  - [pickle](https://docs.python.org/3.7/library/pickle.html) is Python's built-in object serialization library
  - It allows arbitrary objects to be serialized into binary and deserialized back from binary
- Prior to Sphinx's _Reading_ phase the existing `environment.pickle` file is loaded if it exists
  - The list of documents read during previous builds is included with this information
- When Sphinx determines the list of files to build, the existing list of documents is taken into account
  - Only added documents, deleted documents, and modified documents are affected
  - This dramatically reduces the time to complete the build as only necessary changes are built

### Pickling Issue

- The recent [environment-cleanup](https://github.com/mattermost/docs/pull/4843) PR introduced parallel read and write support to the `sitemap` extension
- The parallel read support, while technically functional, inadvertently caused the environment picking process to fail when reading the existing `environment.pickle` file
- This issue results in a full build of all documents regardless of their current build status
  - In effect, it is the same as executing `make clean html` for each build

#### Technical Details

- The parallel read solution was implemented using a first-class [multiprocessing.Queue](https://docs.python.org/3.7/library/multiprocessing.html#multiprocessing.Queue) object
- This `Queue` object, while technically suited to parallel processing, is not easily serializable with Python's `pickle` library

## Changes

### `sitemap` extension

#### Added

- Documentation for all functions
- Status output in a format consistent with Sphinx
- Improved parallel read support, including:
  - Functionality to prune documents from the pickled environment when they are no longer included in the build
  - Functionality to merge document names collected from parallel readers

#### Changed

- Changed the `Queue` implementation of parallel read to [List](https://docs.python.org/3.7/library/stdtypes.html#list), a Python built-in object which is known to serialize without issue
- Changed the phase at which document information is collected from the _Writing_ phase to the _Reading_ phase

### `reredirects` extension

#### Added

- Documentation for all functions
- Status output in a format consistent with Sphinx

## Usage Notes

- Run `make clean` before using the code in this PR to ensure the existing pickled environment files are removed.
