### PR TITLE
Detect broken documentation links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ livehtml:
 	@mkdir -p "$(BUILDDIR)"
 	@$(SPHINXAUTOBUILD) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+# Run `make linkcheck` to check external links
+# Overriding `exclude_patterns` configuration to exclude
+# directories or files not included in the documentation
+linkcheck:
+	@mkdir -p "$(BUILDDIR)"
+	@$(SPHINXBUILD) -M $@ -D exclude_patterns=archive/*,process/*,install/cloud-changelog.md,install/self-managed-changelog.md,install/desktop-app-changelog.rst,deploy/mobile-app-changelog.md:wq "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 2>>"$(WARNINGSFILE)"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ livehtml:
 # directories or files not included in the documentation
 linkcheck:
 	@mkdir -p "$(BUILDDIR)"
-	@$(SPHINXBUILD) -M $@ -D exclude_patterns=archive/*,process/*,install/cloud-changelog.md,install/self-managed-changelog.md,install/desktop-app-changelog.rst,deploy/mobile-app-changelog.md:wq "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 2>>"$(WARNINGSFILE)"
+	@$(SPHINXBUILD) -M $@ -D exclude_patterns=archive/*,process/* "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) 2>>"$(WARNINGSFILE)"
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/source/conf.py
+++ b/source/conf.py
@@ -664,3 +664,15 @@ html_use_index = False
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Mattermostdoc'
+
+# linkcheck settings
+linkcheck_ignore = [
+    # Ignore localhost
+    'http://localhost',
+    'http://127.0.0.1',
+    # Ignore anchors on github.com because linkcheck fails on them
+    '^https?://github.com/.*#',
+    # Ignore azuremarketplace because of no server response
+    'https://azuremarketplace.microsoft.com/.*',
+]
+linkcheck_timeout = 300


### PR DESCRIPTION
#### Summary

Implements `linkcheck` based on the discussions #4713 and #4488 in order to detect broken documentation links.


Resolves: #4713


#### Usage
Running `make linkcheck` generates two output reports `build/output.txt` & `build/output.json`
- `output.txt` contains information on broken and redirected links as identified by linkcheck
- `output.json` contains information on all links checked by linkcheck. This output can be further filtered and processed based on the desired action. Possibly with the help of [jq](https://stedolan.github.io/jq/). For example; filter out broken links using `cat build/output.json | jq -c 'select( .status == "broken" )'
`

#### Configuration
A little context on the linkcheck configuration made with this PR,
1. Based on the discussion over #4488, `exclude_patterns` is overridden in `Makefile` to exclude archive, process directories from source as they are not used in the documentation. Additional files can also be excluded using this.
2. Based on the local execution of this implementation, some links were found to be generating false-positives and were configured to be ignored in `source/conf.py` under the 'linkcheck_ignore' option. You will also find a lot of anchor links for "https://docs.mattermost.com/" reported as broken (which appear to be redirecting to different urls), this can also be ignored if that's the expected behavior.


Please see [Options for the linkcheck builder](https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder) for more info.