### PR TITLE
Add swiftype annotations for better indexing

### DIFF
--- a/source/templates/breadcrumbs.html
+++ b/source/templates/breadcrumbs.html
@@ -6,7 +6,7 @@
   {% set suffix = source_suffix %}
 {% endif %}
 
-<div role="navigation" aria-label="breadcrumbs navigation">
+<div data-swiftype-index=false role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">
     <li><a href="{{ pathto(master_doc) }}">Docs</a> &raquo;</li>
     {% for doc in parents %}

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -1,4 +1,4 @@
-<div class="notification-bar sticky-top">
+<div data-swiftype-index=false class="notification-bar sticky-top">
     <div class="notification-bar__content">
         <a class="notification-bar__close" data-ol-has-click-handler="">
             <span aria-hidden="true">×</span>
@@ -6,7 +6,7 @@
         <div>We've updated this site to make content easier to find. Use the feedback option at the bottom of any page to share your feedback with us.</div>
     </div>
 </div>
-<header class="with-notification">
+<header data-swiftype-index=false class="with-notification">
 	<div class="header__container">
 		<div class="search__icon">
 			<i class="fa fa-search"></i>

--- a/source/templates/layout-notoc.html
+++ b/source/templates/layout-notoc.html
@@ -128,7 +128,7 @@
       <div class="wy-nav-content">
         <div class="rst-content">
           <div role="main" class="document" itemscope="itemscope" itemtype="https://schema.org/Article">
-           <div itemprop="articleBody">
+           <div data-swiftype-index=true itemprop="articleBody">
             {% block body %}{% endblock %}
            </div>
           </div>

--- a/source/templates/layout.html
+++ b/source/templates/layout.html
@@ -97,7 +97,7 @@
   {% block extrabody %} {% endblock %}
   <div class="wy-grid-for-nav">
     {# SIDE NAV, TOGGLES ON MOBILE #}
-    <nav data-toggle="wy-nav-shift" class="wy-nav-side">
+    <nav data-swiftype-index=false data-toggle="wy-nav-shift" class="wy-nav-side">
       <div class="wy-side-scroll">
         <div class="wy-side-nav-search" {% if theme_style_nav_header_background %} style="background: {{theme_style_nav_header_background}}" {% endif %}>
           {% block sidebartitle %}
@@ -177,13 +177,13 @@
         <div class="rst-content">
         {% endif %}
           {% include "breadcrumbs.html" %}
-          <article class="document" itemscope="itemscope" itemtype="https://schema.org/Article">
+          <article data-swiftype-index=false class="document" itemscope="itemscope" itemtype="https://schema.org/Article">
           {%- block document %}
-           <div itemprop="articleBody" role="main">
+           <div data-swiftype-index=true itemprop="articleBody" role="main">
             {% block body %}{% endblock %}
            </div>
            {% if self.comments()|trim %}
-           <div class="articleComments">
+           <div data-swiftype-index=false class="articleComments">
             {% block comments %}{% endblock %}
            </div>
            {% endif%}


### PR DESCRIPTION
This PR adds the needed annotations for swiftypes crawler so that it excludes navigational elements and only indexes the article body which should result in much more useful autocomplete previews.