### PR TITLE
Remove invisible paragraph icon from docs html

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -574,7 +574,7 @@ html_theme_options = {
     "titles_only": False,
 }
 
-html_permalinks_icon = ""
+html_permalinks_icon = " "
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []

--- a/source/conf.py
+++ b/source/conf.py
@@ -476,7 +476,8 @@ redirects = {
     "messaging/welcome-to-mattermost-messaging.html": "https://docs.mattermost.com/overview/index.html",
     "messaging/accessing-your-workspace.html": "https://docs.mattermost.com/messaging/signing-in.html",
     "guides/messaging": "https://docs.mattermost.com/guides/channels.html",
-    "focalboard/installing-boards": "https://docs.mattermost.com/guides/boards.html"  
+    "focalboard/installing-boards": "https://docs.mattermost.com/guides/boards.html",
+    "configure/configuring-apache2.html": "https://forum.mattermost.org/c/docs/37"
 }
 
 # The master toctree document.

--- a/source/conf.py
+++ b/source/conf.py
@@ -574,6 +574,8 @@ html_theme_options = {
     "titles_only": False,
 }
 
+html_permalinks_icon = ""
+
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 


### PR DESCRIPTION
This PR removes the invisible paragraph icon that's being added to the html.
This should also make it disappear from the swiftype autocomplete results returning more useful descriptions when searching.

Side by side
![image](https://user-images.githubusercontent.com/7526550/134916503-76c0923b-0445-4f6b-aa3b-922950e8e34c.png)
![image](https://user-images.githubusercontent.com/7526550/134916532-6ddaefdc-6fd2-4e4f-91ec-ba8cdf9436d0.png)

I've tried a blank space as a substitution but it didn't get registered by sphinx when rendering the html. 
We could think about substituting with a less intrusive icon if this cosmetic change is unwanted.