### PR TITLE
Fixed formatting for Maximum Image Resolution

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -5077,9 +5077,9 @@ Maximum Image Resolution
 
 Maxiumum image resolution size for message attachments in megapixels. This setting can only be changed from ``config.json`` file, it cannot be changed from the System Console user interface.
 
-+---------------------------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"FileSettings.MaxImageResolution": 33177600`` with numerical input.     |
-+---------------------------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------------------------------+
 
 File Settings
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Config setting table formatting error was preventing the table from displaying.