### PR TITLE
v6.0 Desktop and Mobile Compatibility Updates

### DIFF
--- a/source/install/desktop-app-install.rst
+++ b/source/install/desktop-app-install.rst
@@ -18,7 +18,9 @@ Below is a list of additional resources:
 - `Source code <https://github.com/mattermost/desktop>`__
 - Contributor’s guide (coming soon)
 
-You can `download the apps directly from our downloads page <https://mattermost.com/download/#mattermostApps>`__. You may also use the following installation guides for Windows, Mac, and Linux.
+You can `download the Mobile Apps directly from our Downloads page <https://mattermost.com/download/#mattermostApps>`__. You may also use the following installation guides for Windows, Mac, and Linux.
+
+.. include:: ../upgrade/upgrading-to-v60.rst
 
 .. contents::
     :backlinks: top

--- a/source/install/install-android-app.rst
+++ b/source/install/install-android-app.rst
@@ -15,3 +15,5 @@ Your Mattermost teams can be accessed on Android mobile devices by downloading t
 .. _documentation: https://docs.mattermost.com/deployment/sso-saml.html
 .. _App Store: https://geo.itunes.apple.com/us/app/mattermost/id984966508?mt=8
 .. _Google Play Store: https://play.google.com/store/apps/details?id=com.mattermost.mattermost&hl=en
+
+.. include:: ../upgrade/upgrading-to-v60.rst

--- a/source/install/install-ios-app.rst
+++ b/source/install/install-ios-app.rst
@@ -9,3 +9,5 @@ Your Mattermost teams can be accessed on iOS mobile devices via the Mattermost M
 
    a. **Enter Server URL:** This is the web address you go to when you want to access Mattermost. It's in the format ``https://domain.com``. You can find the Server URL by asking your System Admin, or by looking at the address bar in a desktop browser tab with Mattermost open. 
    b. **Sign in to Mattermost:** This is your account login information as described by one of the sign in methods above.
+
+.. include:: ../upgrade/upgrading-to-v60.rst

--- a/source/install/installing-mattermost-desktop-app.rst
+++ b/source/install/installing-mattermost-desktop-app.rst
@@ -1,10 +1,10 @@
 Install the Mattermost Desktop App
 ==================================
 
-The Mattermost Desktop App is  available for Windows, macOS, and Linux operating systems.
+The Mattermost Desktop App is available for Windows, macOS, and Linux operating systems.
 
 .. image:: ../images/desktop.png
 
-You can `download the apps directly from our download page <https://mattermost.com/download/#mattermostApps>`__ and visit our `installation guides <https://docs.mattermost.com/install/desktop.html>`__ for help during setup and for troubleshooting tips.
+You can `download the Desktop App directly from our Download page <https://mattermost.com/download/#mattermostApps>`__, and visit our `installation guides <https://docs.mattermost.com/install/desktop-app-install.html>`__ for help during setup and for troubleshooting tips.
 
-To view the latest updates, please see our `changelog <https://docs.mattermost.com/help/apps/desktop-changelog.html>`__.
+.. include:: ../upgrade/upgrading-to-v60.rst

--- a/source/upgrade/release-lifecycle.rst
+++ b/source/upgrade/release-lifecycle.rst
@@ -119,6 +119,12 @@ During each monthly release, Mattermost backports high severity or high impact s
 Desktop and Mobile App Server Compatibility
 -------------------------------------------
 
-Desktop and mobile apps are required to be used with the `latest Extended Support Release or a newer version <https://docs.mattermost.com/upgrade/release-lifecycle.html>`_. Also, certain features that involve the operating system require a specific desktop or mobile app version. E.g., in Desktop App 4.6 we added a setting for choosing desktop notification sounds which requires server v5.28+. Please review `the Desktop App changelog <https://docs.mattermost.com/install/desktop-app-changelog.html>`_ and `the Mobile App changelog <https://docs.mattermost.com/deploy/mobile-app-changelog.html>`_ notes for any specific self-hosted version requirements for features and functionalities, as well as notes on security fixes.
+Mattermost Desktop and Mobile Apps must be used with the latest Extended Support Release or a newer version of Mattermost server. 
 
-Bug fixes are not normally backported to previous desktop or mobile app versions. It is also recommended to upgrade to the latest desktop and mobile app versions to stay up to date with security fixes.
+.. include:: upgrading-to-v60.rst
+
+In cases where Mattermost features or functionality involve the operating system, a specific Desktop App or Mobile App version may be required. For example, the Mattermost Desktop App v4.6 included a setting for choosing desktop notification sounds which required Mattermost server v5.28 or later.
+
+.. note::
+
+  Bug fixes aren't typically backported to previous Desktop App or Mobile App versions. Upgrading to the latest Desktop and Mobile App versions helps you stay updated with the latest bug and security fixes.

--- a/source/upgrade/upgrading-to-v60.rst
+++ b/source/upgrade/upgrading-to-v60.rst
@@ -1,0 +1,8 @@
+Upgrading to Mattermost v6.0
+----------------------------
+
+Upgrading Mattermost Desktop and Mobile Apps to the latest version is not mandatory when upgrading to Mattermost server v6.0. Earlier 4.x versions of Mattermost Desktop App, and earlier v1.4 versions of the Mobile App, will continue to be supported with a Mattermost v6.0 server.  
+
+However, for an optimal user experience, we strongly recommend upgrading both your Mattermost Desktop and Mobile Apps to the latest version. The latest versions of include the latest security fixes, and supports the oldest supported `extended support release <https://docs.mattermost.com/upgrade/extended-support-release.html>`__ of Mattermost server to ensure backwards compatibility.
+
+Please review the `Desktop App changelog <https://docs.mattermost.com/install/desktop-app-changelog.html>`__ and the `Mobile App changelog <https://docs.mattermost.com/deploy/mobile-app-changelog.html>`__ notes for any self-hosted or cloud-specific version requirements for features and functionalities, as well as notes on security fixes.


### PR DESCRIPTION
Added new shared subsection titled "Upgrading to Mattermost v6.0" to the following topics:
- Deploy Mattermost
   - Upgrade Mattermost > Release Lifecycle
   - Install Guides > Desktop/Mobile App Installation
      - Install the Mattermost Desktop App
      - Desktop Application Installation Guides
      - iOS Setup
      - Android Setup
