### PR TITLE
Added CRT notifications docs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -225,6 +225,20 @@ redirects = {
         "https://docs.mattermost.com/onboard/migrating-to-mattermost.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
     "administration/config-settings#enable-legacy-sidebar": 
         "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
+    "administration/config-settings#enable-automatic-replies-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-automatic-replies-experimental",
+    "administration/config-settings#teammate-name-display": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#teammate-name-display",
+    "administration/config-settings#group-unread-channels-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#group-unread-channels-experimental",
+    "administration/config-settings#enable-legacy-sidebar": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
+    "administration/config-settings#autoclose-direct-messages-in-sidebar-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental",
+    "administration/config-settings#timezone": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#timezone",
+    "administration/config-settings#link-previews": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-link-previews",
     "deployment/deployment": "https://docs.mattermost.com/deploy/deployment-overview.html",
     "deployment/advanced-permissions#read-only-channels": 
         "https://docs.mattermost.com/onboard/advanced-permissions.html#read-only-channels-e20",
@@ -467,6 +481,9 @@ redirects = {
     "incident-collaboration/playbook-planning": 
         "https://docs.mattermost.com/incident-collaboration/setting-up-playbooks.html",
     "help/settings/custom-emoji": "https://docs.mattermost.com/messaging/using-emoji.html#creating-custom-emojis",
+    "help/getting-started/messaging-basics#messaging-basics": "https://docs.mattermost.com/messaging/messaging-basics.html",
+    "help/messaging/formatting-text#in-line-images": "https://docs.mattermost.com/messaging/formatting-text.html#in-line-images",
+    "help/getting-started/organizing-your-sidebar": "https://docs.mattermost.com/messaging/organizing-your-sidebar.html",
     "incident-collaboration/launching-playbooks": 
         "https://docs.mattermost.com/incident-collaboration/running-playbooks.html",
     "incident-collaboration/playbook-planning":

--- a/source/guides/channels.rst
+++ b/source/guides/channels.rst
@@ -32,7 +32,7 @@ Work With Messages
 
    Messaging Basics </messaging/messaging-basics>
    Send and Receive Messages </messaging/sending-receiving-messages>
-   Collapsed Reply Threads </messaging/organizing-conversations>
+   Organize Conversations </messaging/organizing-conversations>
    Text Formatting </messaging/formatting-text>
    Use Emojis </messaging/using-emoji>
    Mention Teammates </messaging/mentioning-teammates>

--- a/source/messaging/configuring-notifications.rst
+++ b/source/messaging/configuring-notifications.rst
@@ -12,12 +12,13 @@ You can configure your Mattermost account for how and when you want to be notifi
 - Sends you a Direct Message
 - Mentions your username or first name in a channel
 - Notifies a channel you're in using @channel or @all
+- Responds to a thread you're following
 - Uses any `keywords you've configured <https://docs.mattermost.com/help/settings/account-settings.html#words-that-trigger-mentions>`_ 
 
 Desktop Notifications
 ----------------------
 
-Desktop notifications are pop-ups that appear in the corner of your main monitor when using Chrome, Firefox, Edge, Safari, or the `Mattermost Desktop Apps <https://mattermost.com/download/#mattermostApps>`_. You can change the default preference to trigger desktop notifications for all messages sent in channels you're a member of, or turn them off entirely. You can also choose what sound plays when a desktop notification is triggered on supported browsers and the Mattermost Desktop Apps.
+Desktop notifications are pop-ups that appear in the corner of your main monitor when using Chrome, Edge, Firefox, and Safari, or the `Mattermost Desktop Apps <https://mattermost.com/download/#mattermostApps>`_. You can change the default preference to trigger desktop notifications for all messages sent in channels you're a member of, or turn them off entirely. You can also choose what sound plays when a desktop notification is triggered on supported browsers and the Mattermost Desktop Apps.
 
 .. image:: ../images/desktop_notification.png
 

--- a/source/messaging/managing-account-settings.rst
+++ b/source/messaging/managing-account-settings.rst
@@ -156,6 +156,9 @@ When `Collapsed Reply Threads (Beta) <https://docs.mattermost.com/messaging/mana
 - You are considered to start a thread when you post a message to which other members of your team reply. 
 - You are considered to participate in a thread when you post a message using the `Reply button <https://docs.mattermost.com/help/getting-started/messaging-basics.html#messaging-basics>`__ in an pre-existing thread.
 
+.. note::
+  This setting is hidden when Collapsed Reply Threads (Beta) is enabled.
+
 Automatic Direct Message Replies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/messaging/managing-account-settings.rst
+++ b/source/messaging/managing-account-settings.rst
@@ -92,24 +92,28 @@ Sessions are created when you log in with your email and password to a new brows
 Notifications
 -------------
 
-Settings to configure desktop notifications, desktop notification sounds, email notifications, and words that trigger mentions.
+Settings to configure desktop notifications, desktop notification sounds, email notifications, mobile push notifications, and words that trigger mentions.
 
 Desktop Notifications
 ~~~~~~~~~~~~~~~~~~~~~
 
-Desktop notifications appear in the corner of your main monitor when there is activity in Mattermost.
-
-When `Desktop App <https://mattermost.com/download/#mattermostApps>`__ notifications are set to "Only for mentions and direct messages", an empty red circle is displayed over the upper right corner of the Mattermost dock icon when any message without an at-mention is received. A solid red circle with a post count is displayed when a message with an at-mention is received.
+Desktop notifications appear in the top corner of your main monitor when there is activity in Mattermost.
 
 Send Desktop Notifications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Choose what activity triggers a desktop notification. This setting applies globally, but this preference is customizable for each channel from the channel name drop-down menu. Desktop notifications are available on Firefox, Safari, and Chrome.
+Choose what activity triggers a desktop notification. This setting applies globally, but this preference is customizable for each channel from the channel name drop-down menu. Desktop notifications are available on Chrome, Edge, Firefox, and Safari.
+
+When `Desktop App <https://mattermost.com/download/#mattermostApps>`__ notifications are set to "Only for mentions and direct messages":
+
+- An empty red circle is displayed over the upper right corner of the Mattermost dock icon when any message without an at-mention is received. 
+- A solid red circle with a post count is displayed when a message with an at-mention is received.
+- And when `Collapsed Reply Threads (Beta) <https://docs.mattermost.com/messaging/managing-account-settings.html#collapsed-reply-threads-beta>`__ is enabled, you can choose to receive desktop notifications about `threads you're following <https://docs.mattermost.com/messaging/organizing-conversations.html#start-or-reply-to-threads>`__.
 
 Notification Sound
 ^^^^^^^^^^^^^^^^^^
 
-Notification sounds fire for any activity that would trigger a desktop notification. Notification sounds are available on Edge, Safari and Chrome.
+Notification sounds fire for any activity that would trigger a desktop notification. Notification sounds are available on Chrome, Edge, Firefox, and Safari in addition to the Mattermost Desktop App.
 
 Notification Duration
 ^^^^^^^^^^^^^^^^^^^^^
@@ -121,16 +125,18 @@ In Mattermost v5.0 and later, desktop notifications will stay onscreen for 5 sec
 Email Notifications
 ~~~~~~~~~~~~~~~~~~~
 
-Email notifications are sent for mentions and direct messages after you’ve been offline for more than 60 seconds or away from Mattermost for more than 5 minutes. Change the email where notifications are sent in **Account Settings > General > Email**.
+Email notifications are sent for mentions and direct messages after you’ve been offline for more than 60 seconds or away from Mattermost for more than five minutes. Change the email where notifications are sent in **Account Settings > General > Email**.
 
-If your System Admin has enabled **Email Batching**, you'll have additional options under this settings to select how often email notifications will be sent. All notifications received over this time period are combined and sent in a single email.
+If your System Admin has enabled `Email Batching <https://docs.mattermost.com/configure/configuration-settings.html#enable-email-batching>`__, you'll have additional options under this settings to select how often email notifications will be sent. All notifications received over this time period are combined and sent in a single email.
 
 Mobile Push Notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Push notifications can be sent to your mobile device if you have the Android or iOS app installed. You can choose the type of activity that will send a notification. By default, push notifications are sent "For mentions and direct messages". If push notifications are sent "Never", the Mattermost setting to trigger push notifications depending on your Mattermost `availability <https://docs.mattermost.com/help/getting-started/setting-your-status-availability.html>`__ is hidden. If your System Admin has not set up push notifications, this setting will be disabled.
+Push notifications can be sent to your mobile device if you have the Android or iOS app installed. You can choose the type of activity that will send a notification. 
 
-If you're actively viewing a channel (Public or Private), Direct Message, or Group Message on desktop or web, no push notifications will be sent for that channel. If a notification is viewed on desktop or web, the lockscreen notification will clear on Android, and on iOS the badge on the Mattermost app icon will decrement accordingly.
+By default, push notifications are sent "For mentions and direct messages". If push notifications are sent "Never", the Mattermost setting to trigger push notifications depending on your `Mattermost availability <https://docs.mattermost.com/help/getting-started/setting-your-status-availability.html>`__ is hidden. If your System Admin has not set up push notifications, this setting will be disabled.
+
+If you're actively viewing a channel (Public or Private), Direct Message, or Group Message using the Desktop App or a browser, no push notifications will be sent for that channel. If a notification is viewed using the Desktop App or a browser, the lockscreen notification will clear on Android, and on iOS the badge on the Mattermost app icon will count down accordingly.
 
 Trigger Mobile Push Notifications When
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -145,7 +151,10 @@ By default, you receive notifications when someone posts a message that contains
 Reply Notifications
 ~~~~~~~~~~~~~~~~~~~
 
-In addition to **Words that Trigger Mentions**, this setting allows you to receive mention notifications when someone replies to a thread that you started or participated in. You are considered to start a thread when you post a message to which other members of your team reply. You are considered to participate in a thread when you post a message using the `reply button <https://docs.mattermost.com/help/getting-started/messaging-basics.html#messaging-basics>`__ in an already existing thread.
+When `Collapsed Reply Threads (Beta) <https://docs.mattermost.com/messaging/managing-account-settings.html#collapsed-reply-threads-beta>`__ is disabled, you can choose to receive mention notifications when someone replies to a thread you have started or have participated in. 
+
+- You are considered to start a thread when you post a message to which other members of your team reply. 
+- You are considered to participate in a thread when you post a message using the `Reply button <https://docs.mattermost.com/help/getting-started/messaging-basics.html#messaging-basics>`__ in an pre-existing thread.
 
 Automatic Direct Message Replies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/messaging/managing-account-settings.rst
+++ b/source/messaging/managing-account-settings.rst
@@ -134,7 +134,7 @@ Mobile Push Notifications
 
 Push notifications can be sent to your mobile device if you have the Android or iOS app installed. You can choose the type of activity that will send a notification. 
 
-By default, push notifications are sent "For mentions and direct messages". If push notifications are sent "Never", the Mattermost setting to trigger push notifications depending on your `Mattermost availability <https://docs.mattermost.com/help/getting-started/setting-your-status-availability.html>`__ is hidden. If your System Admin has not set up push notifications, this setting will be disabled.
+By default, push notifications are sent "For mentions and direct messages". If push notifications are sent "Never", the Mattermost setting to trigger push notifications depending on your `Mattermost availability <https://docs.mattermost.com/messaging/setting-your-status-availability.html>`__ is hidden. If your System Admin has not set up push notifications, this setting will be disabled.
 
 If you're actively viewing a channel (Public or Private), Direct Message, or Group Message using the Desktop App or a browser, no push notifications will be sent for that channel. If a notification is viewed using the Desktop App or a browser, the lockscreen notification will clear on Android, and on iOS the badge on the Mattermost app icon will count down accordingly.
 
@@ -154,7 +154,7 @@ Reply Notifications
 When `Collapsed Reply Threads (Beta) <https://docs.mattermost.com/messaging/managing-account-settings.html#collapsed-reply-threads-beta>`__ is disabled, you can choose to receive mention notifications when someone replies to a thread you have started or have participated in. 
 
 - You are considered to start a thread when you post a message to which other members of your team reply. 
-- You are considered to participate in a thread when you post a message using the `Reply button <https://docs.mattermost.com/help/getting-started/messaging-basics.html#messaging-basics>`__ in an pre-existing thread.
+- You are considered to participate in a thread when you post a message using the `Reply button <https://docs.mattermost.com/messaging/messaging-basics.html>`__ in an pre-existing thread.
 
 .. note::
   This setting is hidden when Collapsed Reply Threads (Beta) is enabled.
@@ -162,7 +162,7 @@ When `Collapsed Reply Threads (Beta) <https://docs.mattermost.com/messaging/mana
 Automatic Direct Message Replies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Set an automated custom message that will be sent once per day in response to Direct Messages. Mentions in Public and Private Channels won't trigger the automated reply. Enabling Automatic Replies sets your availability to **Out of Office** and disables desktop, email, and push notifications. This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html?highlight=config%20settings#enable-automatic-replies-experimental>`__.
+Set an automated custom message that will be sent once per day in response to Direct Messages. Mentions in Public and Private Channels won't trigger the automated reply. Enabling Automatic Replies sets your availability to **Out of Office** and disables desktop, email, and push notifications. This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/configure/configuration-settings.html#enable-automatic-replies-experimental>`__.
 
 Display
 -------
@@ -178,7 +178,7 @@ Select **Custom Theme** to customize your theme colors and share them with other
 
 In Enterprise Edition, if you belong to multiple teams, you can optionally select the checkbox "Apply new theme to all my teams" to have the theme show up across teams. Otherwise, the changes will only apply to the current team.
 
-Learn more about the custom theme color selectors `here <https://docs.mattermost.com/help/settings/theme-colors.html#custom-themes>`__.
+Learn more about the custom theme color selectors `here <https://docs.mattermost.com/messaging/customizing-theme-colors.html>`__.
 
 Select **Import theme colors from Slack** to import a Slack theme. In Slack, go to **Preferences > Sidebar Theme** and open the custom theme option. From there, copy the theme color vector and then paste it into the *Input Slack Theme* input box in Mattermost. Any theme settings that are not customizable in Slack will default to the “Mattermost” standard theme settings.
 
@@ -197,7 +197,7 @@ Choose a 12-hour or 24-hour time preference that appears on the time stamp for a
 Teammate Name Display
 ~~~~~~~~~~~~~~~~~~~~~
 
-Configure how names are displayed in the user interface: nickname, username or full name. The default for this setting is dependent on the `configuration set by the System Admin <https://docs.mattermost.com/administration/config-settings.html#teammate-name-display>`__.
+Configure how names are displayed in the user interface: nickname, username or full name. The default for this setting is dependent on the `configuration set by the System Admin <https://docs.mattermost.com/configure/configuration-settings.html#teammate-name-display>`__.
 
 Show online availability on profile images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -211,17 +211,17 @@ Select the timezone used for timestamps in the user interface and for email noti
 
 .. note::
   
-  In Mattermost v5.38 or earlier, timezone functionality `must first be enabled by the System Admin <https://docs.mattermost.com/administration/config-settings.html#timezone>`__ by replacing ``false`` with ``true`` in ``config.json``. Timezone is enabled by default from Mattermost v6.0.
+  In Mattermost v5.38 or earlier, timezone functionality `must first be enabled by the System Admin <https://docs.mattermost.com/configure/configuration-settings.html#timezone>`__ by replacing ``false`` with ``true`` in ``config.json``. Timezone is enabled by default from Mattermost v6.0.
 
 Website Link Previews
 ~~~~~~~~~~~~~~~~~~~~~
 
-When available, the first web link in a message will show a preview of the website content below the message. This `setting must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html#link-previews>`__.
+When available, the first web link in a message will show a preview of the website content below the message. This `setting must be enabled by your System Admin <https://docs.mattermost.com/configure/configuration-settings.html#enable-link-previews>`__.
 
 Default Appearance of Image Previews
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When messages in Mattermost include images, an image preview can display directly below the message for image attachments, image link previews, and `in-line images <https://docs.mattermost.com/help/messaging/formatting-text.html#in-line-images.html>`__ over 100px in height. You can set this preference to **Expanded** or **Collapsed**.
+When messages in Mattermost include images, an image preview can display directly below the message for image attachments, image link previews, and `in-line images <https://docs.mattermost.com/messaging/formatting-text.html#in-line-images>`__ over 100px in height. You can set this preference to **Expanded** or **Collapsed**.
 
 .. tip::
   This setting can also be controlled using the slash commands ``/expand`` and ``/collapse``.
@@ -236,7 +236,7 @@ Collapsed Reply Threads (Beta)
 
 Collapsed Reply Threads (Beta) offers an enhanced experience for users communicating in threads and replying to messages. Collapsed Reply Threads are available in Mattermost Cloud and from self-hosted Mattermost v5.37 as an early access beta, and are disabled by default. If your System Admin has enabled **Collapsed Reply Threads** for your workspace, you can enable them in your Mattermost instance to start being notified about threads you're following in a new **Threads** option at the top of the channel sidebar.
 
-See our `Organizing Conversations using Collapsed Reply Threads (Beta) <https://docs.mattermost.com/help/messaging/organizing-conversations.html>`__ documentation to learn more about this feature.
+See our `Organizing Conversations using Collapsed Reply Threads (Beta) <https://docs.mattermost.com/messaging/organizing-conversations.html>`__ documentation to learn more about this feature.
 
 Channel Display
 ~~~~~~~~~~~~~~~
@@ -272,20 +272,20 @@ Select what language Mattermost displays in the user interface. Options include:
 Sidebar
 -------
 
-The channel sidebar includes `enhanced sidebar features <https://docs.mattermost.com/help/getting-started/organizing-your-sidebar>`__, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more.
+The channel sidebar includes `enhanced sidebar features <https://docs.mattermost.com/messaging/organizing-your-sidebar.html>`__, including custom, collapsible channel categories, drag and drop, unread filtering, channel sorting options, and more.
 
 The following sidebar settings apply to your current sidebar only:
 
 **Group unread channels separately**
 
-This feature groups unread channels at the top of the channel sidebar in an **Unreads** category. System Admins can `set the default of this setting <https://docs.mattermost.com/administration/config-settings.html#group-unread-channels-experimental>`__ for you. 
+This feature groups unread channels at the top of the channel sidebar in an **Unreads** category. System Admins can `set the default of this setting <https://docs.mattermost.com/configure/configuration-settings.html#group-unread-channels-experimental>`__ for you. 
 
 You can choose to enable it or disable it in **Account Settings > Sidebar**. 
 
 Legacy sidebar settings
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The legacy sidebar `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html#enable-legacy-sidebar>`__. The following sidebar settings apply only to the legacy sidebar:
+The legacy sidebar `must be enabled by your System Admin <https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar>`__. The following sidebar settings apply only to the legacy sidebar:
 
 Channel grouping
 ^^^^^^^^^^^^^^^^
@@ -305,7 +305,7 @@ Hide the channel switcher used to jump between channels quickly. The channel swi
 Autoclose Direct Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Hide Direct Message conversations with no activity for 7 days. These conversations can be reopened with the **+** button in the channel sidebar, or by using the Channel Switcher (CTRL+K). This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/administration/config-settings.html#autoclose-direct-messages-in-sidebar-experimental>`__.
+Hide Direct Message conversations with no activity for 7 days. These conversations can be reopened with the **+** button in the channel sidebar, or by using the Channel Switcher (CTRL+K). This setting is experimental and `must be enabled by your System Admin <https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental>`__.
 
 Advanced
 --------
@@ -320,7 +320,7 @@ If "On for all messages" is enabled, ENTER inserts a new line and CTRL+ENTER pos
 Enable Post Formatting
 ~~~~~~~~~~~~~~~~~~~~~~
 
-This setting controls whether post formatting is rendered. When "On", posts will be rendered with `markdown formatting <https://docs.mattermost.com/help/messaging/formatting-text.html>`__, emoji, autolinked URLs, and line breaks. When "Off", the raw text will be shown.
+This setting controls whether post formatting is rendered. When "On", posts will be rendered with `markdown formatting <https://docs.mattermost.com/messaging/formatting-text.html>`__, emoji, autolinked URLs, and line breaks. When "Off", the raw text will be shown.
 
 Enable Join/Leave Messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/messaging/managing-account-settings.rst
+++ b/source/messaging/managing-account-settings.rst
@@ -180,7 +180,7 @@ In Enterprise Edition, if you belong to multiple teams, you can optionally selec
 
 Learn more about the custom theme color selectors `here <https://docs.mattermost.com/messaging/customizing-theme-colors.html>`__.
 
-Select **Import theme colors from Slack** to import a Slack theme. In Slack, go to **Preferences > Sidebar Theme** and open the custom theme option. From there, copy the theme color vector and then paste it into the *Input Slack Theme* input box in Mattermost. Any theme settings that are not customizable in Slack will default to the “Mattermost” standard theme settings.
+Select **Import theme colors from Slack** to import a Slack theme. In Slack, go to **Preferences > Sidebar Theme** and open the custom theme option. From there, copy the theme color vector and then paste it into the *Input Slack Theme* input box in Mattermost. Any theme settings that are not customizable in Slack will default to the “Sapphire” standard theme settings.
 
 Display Font
 ~~~~~~~~~~~~

--- a/source/messaging/organizing-conversations.rst
+++ b/source/messaging/organizing-conversations.rst
@@ -46,7 +46,7 @@ Replies are collapsed under the first message of a thread. To reply to a thread,
 Follow Threads and Messages
 ---------------------------
 
-You can follow particular messages and threads so that any reply activity triggers notifications. Follow or unfollow any thread, at any time, by toggling the thread’s **Follow/Following** indicator, or by accessing the **More Actions** menu. 
+You can follow particular messages and threads so that any reply activity triggers `notifications <https://docs.mattermost.com/messaging/managing-account-settings.html#notifications>`__. Follow or unfollow any thread, at any time, by toggling the thread’s **Follow/Following** indicator, or by accessing the **More Actions** menu. 
 
 .. image:: ../images/crt-following-thread.png
    :alt: Follow threads to stay updated on replies.
@@ -57,7 +57,7 @@ You'll automatically follow every thread you participate or are mentioned in. If
    :alt: Follow, unfollow, and mark threads as unread from More Actions.
    
 .. tip::
-  Follow messages with no replies from the **More Actions** menu to be notified if someone replies to the message later.
+  Follow messages with no replies from the **More Actions** menu to be notified if someone replies to the message later based on your notification preferences.
 
 View All Threads
 ----------------


### PR DESCRIPTION
Added CRT notification documentation:
- Channels > Work with Messages > Organize Conversations: added link to notifications settings documentation
- Channels > Customize Mattermost > Configure Notifications: added bullet point for followed thread notifications
- Channels > Customize Mattermost > Account Settings > Notifications > Desktop Notifications  > Send Desktop Notifications:  added additional bullet point for enabling CRT thread notifications
- Channels > Customize Mattermost > Account Settings > Notifications > Reply Notifications: updated section to clarify that this setting applies when CRT is disabled