### PR TITLE
chown only the Mattermost directory not the parent

### DIFF
--- a/source/upgrade/upgrading-mattermost-server.rst
+++ b/source/upgrade/upgrading-mattermost-server.rst
@@ -149,7 +149,7 @@ Upgrading Mattermost Server
 
   .. code-block:: sh
          
-    sudo chown -R mattermost:mattermost {install-path}
+    sudo chown -R mattermost:mattermost {install-path}/mattermost
      
 .. note::
     


### PR DESCRIPTION
#### Summary

Change 

```
sudo chown -R mattermost:mattermost {install-path}
```

to:
```
sudo chown -R mattermost:mattermost {install-path}/mattermost
```

Rationale

I followed these instructions to upgrade MM but I ended up accidentally breaking my installation because I have Mattermost installed in `/srv/` and that happens to be where `mysql` is also installed. So after the upgrade I couldn't launch mysql again until I chowned the permissions back.

Isn't it safer to only chown the Mattermost directory and everything in it instead?


