### PR TITLE
Added mmctl equivalents

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -527,6 +527,8 @@ redirects = {
     "mobile/mobile-faq.html#how-do-push-notifications-work":
         "https://docs.mattermost.com/deploy/mobile-faq.html#how-do-push-notifications-work",
     "mobile/mobile-testing-notifications": "https://docs.mattermost.com/deploy/mobile-testing-notifications.html",
+    "onboard/ad-ldap#active-directory-ldap-setup-e10-e20": 
+        "https://docs.mattermost.com/onboard/ad-ldap.html#active-directory-ldap-setup",
     "overview/product": "https://docs.mattermost.com/about/product.html",
     "overview/security": "https://docs.mattermost.com/about/security.html",
     "overview/integrations": "https://docs.mattermost.com/about/integrations.html",

--- a/source/configure/configuation-in-mattermost-database.rst
+++ b/source/configure/configuation-in-mattermost-database.rst
@@ -22,7 +22,9 @@ These instructions cover migrating the Mattermost configuration to the database 
 Get your database connection string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The first step is to get your master database connection string. There are several ways to do this, but the easiest is to use the ``mattermost config get`` command:
+The first step is to get your master database connection string. We recommend using the `mmctl config get command <https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-config-get>`__, or using the CLI's ``mattermost config get`` command to do this.  
+
+To use the ``mattermost config get`` command:
 
 .. code-block:: bash
 
@@ -37,9 +39,9 @@ Example output:
    SqlSettings.DataSource: "mmuser:really_secure_password@tcp(127.0.0.1:3306)/mattermost?charset=utf8mb4,utf8\u0026writeTimeout=30s"
 
 .. note::
-   Be sure to run this command as the *mattermost* user and not *root*. Running the Mattermost binary as *root* will cause permissions errors.
+   Be sure to run this CLI command as the *mattermost* user and not *root*. Running the Mattermost binary as *root* will cause permissions errors.
 
-Another way is to view your ``config.json`` file and get the value in ``SqlSettings.DataSource``.
+Another way to get your database connection string is to view your ``config.json`` file and get the value in ``SqlSettings.DataSource``.
 
 If ``SqlSettings.DataSource`` does not start with ``postgres://`` or ``mysql://``, then you have to add this line to the beginning based on the database in use. Also, if you see ``\u0026`` replace it with ``&``.
 
@@ -62,7 +64,7 @@ Create an environment file
 
 .. note::
    
-   If you're running Mattermost in a High Availability cluster this step must be done on all servers in the cluster.
+   If you're running Mattermost in a High Availability cluster, this step must be done on all servers in the cluster.
 
 Create the file ``/opt/mattermost/config/mattermost.environment`` to set the ``MM_CONFIG`` environment variable to the database connection string. For example:
 
@@ -144,11 +146,13 @@ Here's a complete ``mattermost.service`` file with the ``EnvironmentFile`` line 
 Migrate configuration from ``config.json``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+You can use the `mmctl config migrate <https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-config-migrate>`__ command, or you can use the CLI mattermost config migrate command for this step, as described below.
+
 .. note::
  
-   If you're using a High Availability cluster you only need to run this on a single server in the cluster.
+   If you're using a High Availability cluster, you only need to run this on a single server in the cluster.
 
-The command to migrate the config to the database should always be run as the *mattermost* user.
+The CLI command to migrate the config to the database should always be run as the *mattermost* user.
 
 .. code-block:: bash
 

--- a/source/getting-started/admin-onboarding-tasks.rst
+++ b/source/getting-started/admin-onboarding-tasks.rst
@@ -26,7 +26,7 @@ These settings can also be set in the ``config.json`` file.  Please see our `con
 3. Begin to onboard users by enabling account creation or by connecting an authentication service to assist with user provisioning.
 
 - Users can be pre-provisioned with migration and bulk loading data processes based on prior collaboration systems. Please see our `migration guide <https://docs.mattermost.com/onboard/migrating-to-mattermost.html#migration-guide>`_ and `bulk loading documentation <https://docs.mattermost.com/onboard/bulk-loading-data.html>`_ for additional details.
-- `AD/LDAP authentication <https://docs.mattermost.com/onboard/ad-ldap.html#active-directory-ldap-setup-e10-e20>`_ and `SAML authentication <https://docs.mattermost.com/onboard/sso-saml.html>`_ are available for some subscription plans, providing identity management, single sign-on, and automatic account provisioning.
+- `AD/LDAP authentication <https://docs.mattermost.com/onboard/ad-ldap.html#active-directory-ldap-setup>`_ and `SAML authentication <https://docs.mattermost.com/onboard/sso-saml.html>`_ are available for some subscription plans, providing identity management, single sign-on, and automatic account provisioning.
 
 If your organization requires more structure and project management artifacts for the implementation of Mattermost, please see our `Enterprise roll out checklist <https://docs.mattermost.com/getting-started/enterprise-roll-out-checklist.html>`__.
 
@@ -35,31 +35,31 @@ Important Administration Notes
 
 **DO NOT manipulate the Mattermost database**
 
- - In particular, DO NOT manually delete data from the database directly. Mattermost is designed as a continuous archive and cannot be supported after manual manipulation.
- - If you need to permanently delete a team or user, use the `Command Line Tool <https://docs.mattermost.com/manage/command-line-tools.html>`__.
+- In particular, DO NOT manually delete data from the database directly. Mattermost is designed as a continuous archive and cannot be supported after manual manipulation.
+- If you need to permanently delete a team or user, use the `mattermost user delete <https://docs.mattermost.com/manage/command-line-tools.html#mattermost-user-delete>`__ CLI command, or use the `mmctl user delete <https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-user-delete>`__ command.
 
 Common Tasks
 ------------
 
 **Creating System Admin account from the command line**
 
- - If the System Admin leaves the organization or is otherwise unavailable, you can use the command line interface to assign the *system_admin* role to an existing user. In the ``/opt/mattermost`` directory, type ``sudo -u mattermost bin/mattermost roles system_admin {user-name}``, where *{user-name}* is the username of the person with the new role. For more information about using the command line interface, see `Command Line Tools <https://docs.mattermost.com/manage/command-line-tools.html>`_.
- - The user needs to log out and log back in before the *system_admin* role is applied.
+- If the System Admin leaves the organization or is otherwise unavailable, you can use the command line interface to assign the *system_admin* role to an existing user. In the ``/opt/mattermost`` directory, type ``sudo -u mattermost bin/mattermost roles system_admin {user-name}``, where *{user-name}* is the username of the person with the new role. For more information about using the command line interface, see `Command Line Tools <https://docs.mattermost.com/manage/command-line-tools.html>`__.
+- The user needs to log out and log back in before the *system_admin* role is applied.
   
 **Migrating to AD/LDAP or SAML from email-based authentication**
 
- - If you have Professional or Enterprise plans, you can migrate from email authentication to Active Directory/LDAP or to SAML Single Sign-on. To set up Active Directory/LDAP, see `Active Directory/LDAP Setup <https://docs.mattermost.com/onboard/ad-ldap.html#active-directory-ldap-setup-e10-e20>`_. To set up SAML Single Sign-on, see `SAML Single-Sign-On <https://docs.mattermost.com/onboard/sso-saml.html>`_.
- - After the new authentication method is enabled, existing users cannot use the new method until they go to **Account Settings > Security > Sign-in method** and select **Switch to using AD/LDAP** or **Switch to using SAML Single Sign-on**. After they have switched, they can no longer use their email and password to sign in.  
+- If you have Professional or Enterprise plans, you can migrate from email authentication to Active Directory/LDAP or to SAML Single Sign-on. To set up Active Directory/LDAP, see `Active Directory/LDAP Setup <https://docs.mattermost.com/onboard/ad-ldap.html#active-directory-ldap-setup-e10-e20>`_. To set up SAML Single Sign-on, see `SAML Single-Sign-On <https://docs.mattermost.com/onboard/sso-saml.html>`_.
+- After the new authentication method is enabled, existing users cannot use the new method until they go to **Account Settings > Security > Sign-in method** and select **Switch to using AD/LDAP** or **Switch to using SAML Single Sign-on**. After they have switched, they can no longer use their email and password to sign in.  
 
 **Deactivating a user**
 
- - System Admins can go to **System Console > Users** for a list of all users on the server. The list can be searched and filtered to make finding the user easier. Click the user's role and in the menu that opens, click **Deactivate**.
- - To preserve audit history, users are typically never deleted from the system. If permanently deleting a user is necessary (e.g. for the purposes of `GDPR <https://gdpr-info.eu/>`__), a `CLI tool <https://docs.mattermost.com/manage/command-line-tools.html>`_ can be used to do so.
- - Note that AD/LDAP user accounts cannot be deactivated from Mattermost; they must be deactivated from your Active Directory.
+- System Admins can go to **System Console > Users** for a list of all users on the server. The list can be searched and filtered to make finding the user easier. Click the user's role and in the menu that opens, click **Deactivate**.
+- To preserve audit history, users are typically never deleted from the system. If permanently deleting a user is necessary (e.g. for the purposes of `GDPR <https://gdpr-info.eu/>`__), a `CLI tool <https://docs.mattermost.com/manage/command-line-tools.html>`_ can be used to do so.
+- Note that AD/LDAP user accounts cannot be deactivated from Mattermost; they must be deactivated from your Active Directory.
 
 **Checking for a valid license in Enterprise Edition without logging in**
 
- - Open the log file ``mattermost.log``. It's usually in the ``mattermost/logs/`` directory but might be elsewhere on your system. Find the last occurrence of a log entry that starts with the text ``[INFO] License key``. If the license key is valid, the complete line should be similar to the following example:
+- Open the log file ``mattermost.log``. It's usually in the ``mattermost/logs/`` directory but might be elsewhere on your system. Find the last occurrence of a log entry that starts with the text ``[INFO] License key``. If the license key is valid, the complete line should be similar to the following example:
 
 .. code-block:: text
 
@@ -99,7 +99,7 @@ Explore all plugins and integrations available in the `Mattermost Plugin Marketp
 
 **Enable and manage integrations**
 
-To enable integrations such as webhooks, slash commands, OAuth2.0, and bots, to go **System Console > Integrations**. More information on these integrations can be found `here <https://docs.mattermost.com/guides/integration.html>`_. 
+To enable integrations such as webhooks, slash commands, OAuth2.0, and bots, to go **System Console > Integrations**. More information on these integrations can be found `here <https://developers.mattermost.com/integrate/other-integrations/>`_. 
 
 **3. Enable Automatically Extended Sessions**
 
@@ -115,7 +115,7 @@ Enable full content push notifications, including the sender’s name, the chann
 
   - Mattermost subscription plans allow you to `enable HPNS <https://docs.mattermost.com/deploy/mobile-hpns.html>`__ that includes production-level uptime SLAs.
 
-  - Mattermost Enterprise customers can `enable ID-Only push notifications <https://docs.mattermost.com/configure/configuration-settings.html>`__ so push notification content is not passed through Apple Push Notification Service (APNS) or Google Firebase Cloud Messaging (FCM) before reaching the device. The ID-only push notification setting `offers a high level of privacy <https://mattermost.com/blog/id-only-push-notifications/>`__ while allowing team members to benefit from mobile push notifications.
+  - Mattermost Enterprise customers can `enable ID-Only push notifications <https://docs.mattermost.com/configure/configuration-settings.html#push-notification-contents>`__ so push notification content is not passed through Apple Push Notification Service (APNS) or Google Firebase Cloud Messaging (FCM) before reaching the device. The ID-only push notification setting `offers a high level of privacy <https://mattermost.com/blog/id-only-push-notifications/>`__ while allowing team members to benefit from mobile push notifications.
 
 **5. Enable Custom Emoji**
 


### PR DESCRIPTION
Added links to mmctl equivalent commands for the following topics:
- https://docs.mattermost.com/configure/configuation-in-mattermost-database.html
- https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html#administrator-onboarding-tasks