### PR TITLE
Create basic Cloud Data Export page for Oct 13

### DIFF
--- a/source/guides/administration.rst
+++ b/source/guides/administration.rst
@@ -65,6 +65,7 @@ Workspace Management
     Statistics </manage/cloud-reporting>
     User Satisfaction Surveys </manage/cloud-user-satisfaction-surveys>
     Managing Team and Channel Members </manage/cloud-team-and-channel>
+    Cloud Data Export </manage/cloud-data-export>
 
 * :doc:`Mattermost Cloud Billing </manage/cloud-billing>` - Set up and manage billing for your Mattermost Cloud workspace.
 * :doc:`Statistics </manage/cloud-reporting>` - Get statistics about Mattermost usage.

--- a/source/manage/cloud-data-export.rst
+++ b/source/manage/cloud-data-export.rst
@@ -1,0 +1,8 @@
+Cloud Data Export
+=========================
+
+After completing your 14-day free Cloud trial, if you have decided to self-host your own Mattermost deployment, you may want to migrate your Cloud data to your Self-Hosted instance.
+
+We plan to publish documentation on how to perform a Cloud data export for channels, messages, users and other bulk export data self-serve, with some knowledge about running commands to export this data.
+
+In the meantime, if you are interested in migrating your Cloud data to Self-Hosted, please contact our support team via https://customers.mattermost.com/cloud/contact-us, or through the `Mattermost Help Center <https://support.mattermost.com/>`_. Once you've submitted your data export request, our team will `guide you through the process <https://handbook.mattermost.com/operations/research-and-development/engineering/cloud-data-export-process>`_. Typically the data export file will be provided within 2 weeks.


### PR DESCRIPTION
Marketing team will be directing more traffic to Cloud Trial instead of Enterprise Trial starting next week.

As a result, we anticipate a higher volume of users trying Mattermost on Cloud but later deciding to self-host their own Mattermost instance. We also anticipate this to increase the volume of Cloud data export requests.

@justinegeffen and I have previously talked about creating data import/export documentation for Cloud, with a target due date of Oct 23.

In the meantime, this page offers enough information for a Cloud admin to take steps to retrieve a Cloud data export file, which will be linked to said admins via email nurture campaigns.