### PR TITLE
Update intro to remove old packaging language.

### DIFF
--- a/source/install/self-managed-changelog.md
+++ b/source/install/self-managed-changelog.md
@@ -1,6 +1,5 @@
 # Mattermost Changelog
-
-This changelog summarizes updates to [Mattermost Team Edition](https://mattermost.org/), an open source team messaging solution released monthly under an MIT license, and [Mattermost Enterprise Edition](https://mattermost.com/pricing-self-managed/), a commercial upgrade offering enterprise messaging for large organizations.
+[Mattermost](https://mattermost.com) is an open source platform for secure collaboration across the entire software development lifecycle. This changelog summarizes updates for all self-hosted versions of Mattermost.
 
 Also see [changelog in progress](https://bit.ly/2nK3cVf) for the next release.
 


### PR DESCRIPTION
#### Summary
This is a small fix to update the changelog intro to remove references to packaging. I'm assuming this page is only for self-hosted Mattermost, so feel free to remove that mention if I'm wrong.

#### Ticket Link
n/a

