### PR TITLE
Updated minimum browser and Desktop App macOS support

### DIFF
--- a/source/install/software-hardware-requirements.rst
+++ b/source/install/software-hardware-requirements.rst
@@ -47,7 +47,7 @@ PC Web
     "Safari", "v12+"
     "Edge", "v44+"
 
-`*` Support for Internet Explorer (IE11) has been removed in Mattermost v5.16. We recommend using the `Mattermost Desktop App <https://mattermost.com/download/#mattermostApps>`_ or another supported browser. See `this forum post <https://forum.mattermost.org/t/mattermost-is-dropping-support-for-internet-explorer-ie11-in-v5-16/7575>`_ to learn more.
+`*` Support for Internet Explorer (IE11) has been removed since Mattermost v5.16. We recommend using the `Mattermost Desktop App <https://mattermost.com/download/#mattermostApps>`_ or another supported browser. See `this forum post <https://forum.mattermost.org/t/mattermost-is-dropping-support-for-internet-explorer-ie11-in-v5-16/7575>`_ to learn more.
 
 Mobile Apps
 ^^^^^^^^^^^


### PR DESCRIPTION
Updated minimum browser support for Chrome and Firefox, as well as minimum Desktop App macOS support to match the October 2021 Cloud change log.

Note: Minimum PC web browser support for Safari and Edge, as well as mobile app minimum iOS and Android support, and mobile web browser support haven't been updated, and should be reviewed for technical accuracy.