### PR TITLE
Fix links in config docs

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -2492,7 +2492,7 @@ Advanced Logging
 Output logs to multiple targets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Allow any combination of console, local file, syslog, and TCP socket targets, and send log records to multiple targets. These targets have been chosen as they support the vast majority of log aggregators, and other log analysis tools, without needing additional software installed. Please see 'Audit Log v2 <https://docs.mattermost.com/comply/audit-log.html>`__ for more comprehensive documentation. 
+Allow any combination of console, local file, syslog, and TCP socket targets, and send log records to multiple targets. These targets have been chosen as they support the vast majority of log aggregators, and other log analysis tools, without needing additional software installed. Please see `Audit Log v2 <https://docs.mattermost.com/comply/audit-log.html>`__ for more comprehensive documentation.
 
 System Admins can define multiple log targets to:
 
@@ -9439,7 +9439,7 @@ Enable Experimental Features
 User Satisfaction Surveys
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This plugin enables Mattermost to send user satisfaction surveys to gather feedback and improve product quality directly from your Mattermost users. Please refer to the 'Mattermost Privacy Policy <https://mattermost.com/privacy-policy/>`__ for more information on the collection and use of information received through Mattermost services.
+This plugin enables Mattermost to send user satisfaction surveys to gather feedback and improve product quality directly from your Mattermost users. Please refer to the `Mattermost Privacy Policy <https://mattermost.com/privacy-policy/>`__ for more information on the collection and use of information received through Mattermost services.
 
 Access the following configuration settings in the System Console by going to **Plugins > User Satisfaction Surveys**.
 
@@ -9487,7 +9487,7 @@ Enable User Satisfaction Survey
   :target: https://mattermost.com/deploy
   :alt: Available for Mattermost Self-Hosted deployments.
 
-**True**: A user satisfaction survey will be sent out to all users on a quarterly basis. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to the 'Mattermost Privacy Policy <https://mattermost.com/privacy-policy/>`__ for more information on the collection and use of information received through Mattermost services.
+**True**: A user satisfaction survey will be sent out to all users on a quarterly basis. The survey results will be used by Mattermost, Inc. to improve the quality and user experience of the product. Please refer to the `Mattermost Privacy Policy <https://mattermost.com/privacy-policy/>`__ for more information on the collection and use of information received through Mattermost services.
 
 **False**: User satisfaction surveys are disabled. 
 


### PR DESCRIPTION
#### Summary
This fixes the syntax for a few links in the config settings documentation.

#### Ticket Link
N/A