### PR TITLE
Show confirmation for @here

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -2323,12 +2323,12 @@ Notifications
 
 Access the following configuration settings in the System Console by going to **Site Configuration > Notifications**.
 
-Show @channel and @all confirmation dialog
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Show @channel, @all, or @here confirmation dialog
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 |all-plans| |cloud| |self-hosted|
 
-**True**: Users will be prompted to confirm when posting @channel and @all in channels with over five members.
+**True**: Users will be prompted to confirm when posting @channel, @all, or @here in channels with over five members.
 
 **False**: No confirmation is required.
 

--- a/source/messaging/mentioning-teammates.rst
+++ b/source/messaging/mentioning-teammates.rst
@@ -64,7 +64,7 @@ You can ignore channel-wide mentions in specific channels in the **Channel Menu 
 
   @channel great work on interviews this week. I think we found some excellent potential candidates!
 
-If a channel has five or more members, you're prompted to confirm that you want notifications sent to everyone in the channel.
+If a channel has five or more members, you may be prompted to confirm that you want notifications sent to everyone in the channel.
 
 @here
 ~~~~~
@@ -75,9 +75,11 @@ You can mention everyone who is online in a channel by typing ``@here``. This se
 
 .. code-block:: none
 
-  @here can someone do a quick review of this?
+  @here can someone complete a quick review of this?
+
+If a channel has five or more members, you may be prompted to confirm that you want notifications sent to everyone in the channel.
   
-You can ignore channel-wide mentions in specific channels in the **Channel Menu > Notification Preferences > Ignore mentions for @channel, @here and @all**.
+You can ignore channel-wide mentions in specific channels by enabling the **Channel Menu > Notification Preferences > Ignore mentions for @channel, @here, and @all** option.
   
 @groupname (Beta)
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Documentation for https://github.com/mattermost/mattermost-webapp/pull/8852
- Updated the ``Show @channel and @all confirmation dialog`` configuration setting to include @here mentions
- Updated Channels > Work with Messages > Mentioning Teammates to clarify that a confirmation may be required if using @here in a channel of more than five members