### PR TITLE
linkcheck_rate_limit_timeout must be a decimal value

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -1028,5 +1028,5 @@ linkcheck_ignore = [
     'https://azuremarketplace.microsoft.com/.*',
 ]
 linkcheck_timeout = 5
-linkcheck_rate_limit_timeout = 1
+linkcheck_rate_limit_timeout = 1.0
 linkcheck_anchors = False


### PR DESCRIPTION
This PR corrects the following docs build warning: ``The config value `linkcheck_rate_limit_timeout' has type `int', defaults to `float'.``