### PR TITLE
Removed legacy link no longer adding value

### DIFF
--- a/source/messaging/signing-in.rst
+++ b/source/messaging/signing-in.rst
@@ -1,7 +1,7 @@
 Signing In
 ==========
 
-To sign in, navigate to the Mattermost sign-in screen. You can `get the URL of the sign-in screen <https://docs.mattermost.com/messaging/accessing-your-workspace.html>`__ from your System Admin or from an email invitation.
+To sign in, navigate to the Mattermost sign-in screen. You'll receive a Mattermost URL from your System Admin or from an email invitation.
 
 .. tip::
   We recommend bookmarking the Mattermost URL provided by your System Admin or through an email invitation so signing in to Mattermost is easy in the future.


### PR DESCRIPTION
The first link on the page used to take users to a different page. Following a reorganization of this content, the link is no longer needed. Thanks to @stevemudie for alerting us to this issue!