### PR TITLE
Removed outdated configuration settings

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -6865,46 +6865,12 @@ Specify the `Chimera <https://github.com/mattermost/chimera>`__ URL used by Ma
 | This feature's ``config.json`` setting is ``"ChimeraOAuthProxyUrl": {}`` with string input.                             |
 +-------------------------------------------------------------------------------------------------------------------------+
 
-Custom User Attributes
-^^^^^^^^^^^^^^^^^^^^^^
-
-|all-plans| |self-hosted|
-
-This setting isn't available in the System Console and can only be set in ``config.json``.
-
-Learn more `in our documentation <https://github.com/mattermost/mattermost-plugin-custom-attributes/blob/master/README.md>`__.
-
-GitHub
-^^^^^^^
-
-|all-plans| |self-hosted|
-
-This setting isn't available in the System Console and can only be set in ``config.json``.
-
-Learn more `in our documentation <https://github.com/mattermost/mattermost-plugin-github/blob/master/README.md>`__.
-
-Jira
-^^^^
-
-|all-plans| |self-hosted|
-
-This setting isn't available in the System Console and can only be set in ``config.json``.
-
-Learn more `in our documentation <https://github.com/mattermost/mattermost-plugin-jira/blob/master/README.md>`__.
-
-Net Promoter Score
-^^^^^^^^^^^^^^^^^^
-
-This setting isn't available in the System Console and can only be set in ``config.json``.
-
-Learn more `in our documentation <https://docs.mattermost.com/manage/user-satisfaction-surveys.html>`__.
-
 Welcome Bot
 ^^^^^^^^^^^
 
 |all-plans| |self-hosted|
 
-This setting isn't available in the System Console and can only be set in ``config.json``.
+The settings for the WelcomeBot plugin aren't available in the System Console, and can only be set in ``config.json``.
 
 Learn more `in our documentation <https://github.com/mattermost/mattermost-plugin-welcomebot/blob/master/README.md>`__.
 


### PR DESCRIPTION
Removed the following plugin settings from the `configurable only via ``config.json`` section of the documentation as per Engineering: GitHub, Custom User Attributes, Jira, and Net Promoter Score.  The inclusion of these plugins in the config settings documentation was causing reader confusion by mixing up server config settings with plugin config settings. 

Also updated the WelcomeBot plugin configuration documentation to clarify that its the settings for the plugin itself that aren't available in System Console that can only be set via ``config.json``.