### PR TITLE
Removed unnecessary heading

### DIFF
--- a/source/install/setting-up-local-machine-using-docker.rst
+++ b/source/install/setting-up-local-machine-using-docker.rst
@@ -98,15 +98,10 @@ If you don't have Docker installed, follow the step-by-step instructions below b
 
     3. When Docker is done fetching the image and starting the container, open ``http://localhost:8065/`` in your browser.
 
-Setting up SMTP email (Recommended)
------------------------------------
-
-The default single-container Docker instance for Mattermost is designed for product evaluation, and sets ``SendEmailNotifications=false`` so the product can function without enabling email. 
-
 Configuration Settings
 ----------------------
 
-See the `Configuration Settings <https://docs.mattermost.com/configure/configuration-settings.html>`__ documentation to customize your deployment.
+The default single-container Docker instance for Mattermost is designed for product evaluation, and sets ``SendEmailNotifications=false`` so the product can function without enabling email. See the `Configuration Settings <https://docs.mattermost.com/configure/configuration-settings.html>`__ documentation to customize your deployment.
 
 Updating Mattermost Preview
 ---------------------------

--- a/source/install/setting-up-local-machine-using-docker.rst
+++ b/source/install/setting-up-local-machine-using-docker.rst
@@ -18,7 +18,7 @@ Local Machine Setup using Docker
 The following instructions use Docker to install Mattermost in *Preview Mode* using the `Mattermost Docker Preview Image <https://github.com/mattermost/mattermost-docker-preview>`__ for exploring product functionality on a single local machine.
 
 .. important::
-  This configuration shouldn't be used in production, as it uses a known password string, contains other non-production configuration settings, keeps no persitent data (all data lives inside the container) and doesn't support upgrades. For a production installation with Docker, see the `Mattermost Docker Setup README <https://github.com/mattermost/docker#mattermost-docker-setup>`__.
+  This configuration shouldn't be used in production, as it uses a known password string, contains other non-production configuration settings, keeps no persistent data (all data lives inside the container) and doesn't support upgrades. For a production installation with Docker, see the `Mattermost Docker Setup README <https://github.com/mattermost/docker#mattermost-docker-setup>`__.
 
 .. note::
   If you have problems installing Mattermost, see


### PR DESCRIPTION
Based on input from Support, SMTP heading has been removed, and relevant content added to the config section.