### PR TITLE
Move Enable Reliable Websockets config setting to GA

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -6906,19 +6906,6 @@ Audit settings
 
 The audit settings output audit records to syslog (local or remote server via TLS) and/or to a local file. Both are disabled by default. They can be enabled simultaneously.
 
-Enable Reliable Websockets
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-|all-plans| |self-hosted|
-
-This setting isn't available in the System Console and can only be set in ``config.json``.
-
-Enable this setting to make websocket messages more reliable by buffering messages during a connection loss and then re-transmitting all unsent messages when the connection is revived. This setting can only be changed from ``config.json`` file, it cannot be changed from the System Console user interface.
-
-+---------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableReliableWebsockets": true`` with options ``true`` and ``false``. |
-+---------------------------------------------------------------------------------------------------------------------+
-
 Remote Clusters
 ^^^^^^^^^^^^^^^
 

--- a/source/configure/deprecated-configuration-settings.rst
+++ b/source/configure/deprecated-configuration-settings.rst
@@ -4,6 +4,19 @@ Deprecated Configuration Settings
 Service Settings
 ----------------
 
+Enable Reliable Websockets
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*This configuration setting has been deprecated, and the ability to buffer messages during a connection loss has been promoted to general availability from Mattermost v6.3. This setting is enabled for older clients to maintain backwards compatibility.*
+
+This setting isn't available in the System Console and can only be set in ``config.json``.
+
+Enable this setting to make websocket messages more reliable by buffering messages during a connection loss and then re-transmitting all unsent messages when the connection is revived. 
+
++---------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"EnableReliableWebsockets": true`` with options ``true`` and ``false``. |
++---------------------------------------------------------------------------------------------------------------------+
+
 Data Prefetch
 ^^^^^^^^^^^^^^
 
@@ -136,6 +149,7 @@ Allow Team Administrators to edit others' posts
 **False**: Only System Admins can edit other users' posts.
 
 .. note::
+
    System Admins and Team Admins can always delete other users' posts. This setting is only available for Team Edition servers. Enterprise Edition servers can use `Advanced Permissions <https://docs.mattermost.com/onboard/advanced-permissions.html>`__ to configure this permission.
 
 Enable Team Creation


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/19040

Moved **Enable Reliable Websockets** config setting to deprecated config settings page with a note that it's now generally available (and set to true for backwards compatibility with older clients).