### PR TITLE
Fix links in changelog table of contents

### DIFF
--- a/source/install/self-managed-changelog.md
+++ b/source/install/self-managed-changelog.md
@@ -4,9 +4,9 @@
 Also see [changelog in progress](https://bit.ly/2nK3cVf) for the next release.
 
 Latest Mattermost Releases:
-- [Release v6.2 - Feature Release](#release-v6.2-feature-release)
-- [Release v6.1 - Feature Release](#release-v6.1-feature-release)
-- [Release v6.0 - Feature Release](#release-v6.0-feature-release)
+- [Release v6.2 - Feature Release](#release-v6-2-feature-release)
+- [Release v6.1 - Feature Release](#release-v6-1-feature-release)
+- [Release v6.0 - Feature Release](#release-v6-0-feature-release)
 - [Release v5.39 - Quality Release](#release-v5-39-quality-release)
 - [Release v5.37 - Extended Support Release](#release-v5-37-extended-support-release)
 


### PR DESCRIPTION
The format of the anchors for the latest few releases are incorrect, so clicking on them doesn't do anything