### PR TITLE
Update link to deploy page

### DIFF
--- a/source/upgrade/upgrading-mattermost-server.rst
+++ b/source/upgrade/upgrading-mattermost-server.rst
@@ -157,7 +157,7 @@ Upgrading Mattermost Server
 
      cd /tmp
 
-2. Download `the latest version of Mattermost Server <https://mattermost.com/download/>`__. In the following command, replace ``X.X.X`` with the version that you want to download:
+2. Download `the latest version of Mattermost Server <https://mattermost.com/deploy/>`__. In the following command, replace ``X.X.X`` with the version that you want to download:
 
    .. code-block:: sh
 


### PR DESCRIPTION

#### Summary
Mattermost.com/download no longer has server deployment instructions. They have moved to mattermost.com/deploy


#### Ticket Link
N/a

