### PR TITLE
Update download links to deploy

### DIFF
--- a/source/archive/branding.rst
+++ b/source/archive/branding.rst
@@ -69,7 +69,7 @@ Mattermost Team Edition Description
 
 When redistributing the open source Mattermost Team Edition binary, the following description may be used:
 
-  Mattermost Team Edition is an open source, self-hosted alternative to proprietary SaaS messaging. Mattermost brings all your team communication into one place, making it searchable and accessible anywhere. Deploys as single Linux binary on MySQL or PostgreSQL under an MIT license from `mattermost.com/download <https://mattermost.com/download/>`__.
+  Mattermost Team Edition is an open source, self-hosted alternative to proprietary SaaS messaging. Mattermost brings all your team communication into one place, making it searchable and accessible anywhere. Deploys as single Linux binary on MySQL or PostgreSQL under an MIT license from `mattermost.com/download <https://mattermost.com/deploy/>`__.
 
 Mattermost Enterprise Edition Description
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/archive/legacy-upgrade.md
+++ b/source/archive/legacy-upgrade.md
@@ -31,7 +31,7 @@ If you're upgrading a server that's already running a supported version, See [Up
 
 1. Download the latest version of Team Edition server and note any compatibility procedures:
       1. Review past and upcoming deprecation notices [listed on our website](https://about.mattermost.com/deprecated-features/).
-      2. Download [the latest version of the Mattermost Server](https://mattermost.com/download/). In the following command, replace `X.X.X` with the version that you want to download:
+      2. Download [the latest version of the Mattermost Server](https://mattermost.com/deploy/). In the following command, replace `X.X.X` with the version that you want to download:
           - **Team Edition**: `wget https://releases.mattermost.com/X.X.X/mattermost-team-X.X.X-linux-amd64.tar.gz`
 2. Stop the Mattermost server
       1. Consider posting an announcement to active teams about stopping the Mattermost server for an upgrade.

--- a/source/developer/slash-commands.rst
+++ b/source/developer/slash-commands.rst
@@ -21,7 +21,7 @@ Messages that begin with ``/`` are interpreted as slash commands. The commands w
 Built-in Commands
 -----------------
 
-Each Mattermost installation comes with some built-in slash commands that are ready to use. These commands are available in the `latest Mattermost release <https://mattermost.com/download>`__:
+Each Mattermost installation comes with some built-in slash commands that are ready to use. These commands are available in the `latest Mattermost release <https://mattermost.com/deploy>`__:
 
 .. csv-table::
     :header: "Command", "Description", "Example"

--- a/source/install/install-rhel-6-mattermost.rst
+++ b/source/install/install-rhel-6-mattermost.rst
@@ -11,7 +11,7 @@ Assume that the IP address of this server is 10.10.10.2
 
 1. Log in to the server that will host Mattermost Server and open a terminal window.
 
-2. Download `the latest version of the Mattermost Server <https://mattermost.com/download/>`__. In the following command, replace ``X.X.X`` with the version that you want to download:
+2. Download `the latest version of the Mattermost Server <https://mattermost.com/deploy/>`__. In the following command, replace ``X.X.X`` with the version that you want to download:
 
   ``wget https://releases.mattermost.com/X.X.X/mattermost-X.X.X-linux-amd64.tar.gz``
 

--- a/source/upgrade/upgrading-mattermost-server.rst
+++ b/source/upgrade/upgrading-mattermost-server.rst
@@ -157,7 +157,7 @@ Upgrading Mattermost Server
 
      cd /tmp
 
-2. Download `the latest version of Mattermost Server <https://mattermost.com/download/>`__. In the following command, replace ``X.X.X`` with the version that you want to download:
+2. Download `the latest version of Mattermost Server <https://mattermost.com/deploy/>`__. In the following command, replace ``X.X.X`` with the version that you want to download:
 
    .. code-block:: sh
 


### PR DESCRIPTION
#### Summary
The mattermost.com/download page no longer has links to deploy the server. They have moved to /deploy


#### Ticket Link
N/a

