### PR TITLE
Make Boards known issue more visible in the changelog

### DIFF
--- a/source/install/self-managed-changelog.md
+++ b/source/install/self-managed-changelog.md
@@ -12,7 +12,10 @@ Latest Mattermost Releases:
 
 ## Release v6.3 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
 
-**Release Day: 2022-01-16**
+- **v6.3.1, release day TBD**
+  - Investigating an issue where Mattermost Boards may fail to start in v6.3.0. Please see this [GitHub Issue](https://github.com/mattermost/focalboard/issues/2119) for a workaround and discussions.
+- **v6.3.0, released 2022-01-16**
+  - Original 6.3.0 release
 
 ### Highlights
 


### PR DESCRIPTION
The v6.3 Boards issue is mentioned in the Known Issues section, but I'm also moving it to the top of the changelog for more visibility.
This PR just needs one approval to be able to merge :)