### PR TITLE
Update mmctl-command-line-tool.rst

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -937,14 +937,14 @@ Create a channel.
 
 .. code-block:: sh
 
-   channel create --team myteam --name mynewchannel --display_name "My New Channel"
-   channel create --team myteam --name mynewprivatechannel --display_name "My New Private Channel" --private
+   channel create --team myteam --name mynewchannel --display-name "My New Channel"
+   channel create --team myteam --name mynewprivatechannel --display-name "My New Private Channel" --private
 
 **Options**
 
 .. code-block:: sh
    
-   --display_name string   Channel Display Name
+   --display-name string   Channel Display Name
    --header string         Channel header
    -h, --help              help for create
    --name string           Channel Name
@@ -5160,7 +5160,7 @@ Add specified users to a team.
 
 .. code-block:: sh
 
-   team add myteam user@example.com username
+   team users add myteam user@example.com username
 
 **Options**
 


### PR DESCRIPTION
1. I think I found a small error in the mmctl documentation here: https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-team-users-add
The example reads
team add myteam user@example.com username
but should read
team users add myteam user@example.com username
2. Another small error in the mmctl documentation here: https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-channel-create
The option is listed as
--display_name
both in the option list as well as in the example.
But when using mmctl with this option, the command returns that this option is deprecated and the following should be used instead
--display-name

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

