### PR TITLE
Add mattermost db migrate command documentation

### DIFF
--- a/source/manage/command-line-tools.rst
+++ b/source/manage/command-line-tools.rst
@@ -789,6 +789,23 @@ mattermost db init
     .. code-block:: none
     
        MM_CUSTOM_DEFAULTS_PATH=custom.json MM_CONFIG=postgres://localhost/mattermost mattermost db init
+       
+mattermost db migrate
+------------------
+
+  Description
+    Migrates the database schema if there are any unapplied migrations.
+
+  Format
+    .. code-block:: none
+
+      mattermost db migrate
+
+  Examples
+    
+    .. code-block:: none
+
+       mattermost db migrate
 
 mattermost export
 -----------------


### PR DESCRIPTION


#### Summary
Adds the new `mattermost db migrate` command documentation.