### PR TITLE
MMCTL updates

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -74,7 +74,8 @@ mmctl usage notes
 - ``mmctl`` comes bundled with the Mattermost distribution, and is located in the ``bin`` folder of the installation, next to the ``CLI``.
 
   - We recommend you add the path to the Mattermost ``bin`` folder into your ``$PATH`` environment variable. This ensures that you can run mmctl commands locally regardless of your current directory location.
-  - If the ``bin`` folder is missing from your ``$PATH``, you must specify the full path to mmctl when running mmctl commands. Otherwise, you must be in the ``bin`` directory to run mmctl commands, and the commands must be prefixed with ``./``.
+  - The most convenient way to use mmctl is to add the path to the Mattermost ``bin`` directory to your ``$PATH`` environment variable. This ensures that you can run mmctl commands locally regardless of your current directory location.
+  - If the ``bin`` directory is not added to the ``$PATH`` environment variable, each time you use mmctl you must be in the ``bin`` directory to run mmctl commands, and the commands must be prefixed with ``./``. If you're working from a different directory, make sure you specify the full path to mmctl when running mmctl commands.
 - Parameters in CLI commands are order-specific.
 - If special characters (``!``, ``|``, ``(``, ``)``, ``\``, ``'``, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``password mypassword\!``).
 - Team name and channel name refer to the handles, not the display names. So in the URL ``https://community.mattermost.com/core/channels/town-square`` team name would be ``core`` and channel name would be ``town-square``.

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -72,6 +72,9 @@ mmctl usage notes
 
 - System Admins have two ways to run ``mmctl`` commands: by downloading ``mmctl`` from the repository, or by building it directly. See the `mmctl readme <https://github.com/mattermost/mmctl#install>`__ for details.
 - ``mmctl`` comes bundled with the Mattermost distribution, and is located in the ``bin`` folder of the installation, next to the ``CLI``.
+
+  - We recommend you add the path to the Mattermost ``bin`` folder into your ``$PATH`` environment variable. This ensures that you can run mmctl commands locally regardless of your current directory location.
+  - If the ``bin`` folder is missing from your ``$PATH``, you must specify the full path to mmctl when running mmctl commands. Otherwise, you must be in the ``bin`` directory to run mmctl commands, and the commands must be prefixed with ``./``.
 - Parameters in CLI commands are order-specific.
 - If special characters (``!``, ``|``, ``(``, ``)``, ``\``, ``'``, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``password mypassword\!``).
 - Team name and channel name refer to the handles, not the display names. So in the URL ``https://community.mattermost.com/core/channels/town-square`` team name would be ``core`` and channel name would be ``town-square``.


### PR DESCRIPTION
Incorporated community feedback to clarify mmctl usage (particularly for those customers familiar with running CLI commands). 
- Updated Mattermost Administration > Other Resources > mmctl Command Line Tool > Usage Notes to clarify when prefixing commands with `./` is necessary.