### PR TITLE
Replace Desktop App Event banner

### DIFF
--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -4,7 +4,7 @@
             <span aria-hidden="true">×</span>
         </a>
 	    <div>
-		    <div><a href="https://mattermost.com/blog/mattermost-desktop-app-contributor-event">Join us for the Mattermost Desktop App Contributor Event!</a></div>
+		    <div>We want to hear from you! Share your product documentation feedback with us using the feedback option at the bottom of every page.</div>
 		</div>
     </div>
 </div>


### PR DESCRIPTION
Replacing the Desktop Event Banner with our standard CTA for product docs feedback.