### PR TITLE
Redirects Cleanup

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -61,770 +61,749 @@ source_suffix = [".rst", ".md"]
 
 # Redirects using: https://pypi.org/project/sphinx-reredirects/
 redirects = {
-    "integrations/jira": 
-        "https://mattermost.gitbook.io/plugin-jira/",
-    "integrations/zoom": 
-        "https://mattermost.gitbook.io/plugin-zoom/",
-    "integrations/net-promoter-score": 
-        "https://docs.mattermost.com/manage/user-satisfaction-surveys.html",
-    "developer/interactive-dialogs": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-interactive-dialogs/",
-    "developer/interactive-message-buttons": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-interactive-messages/",
-    "developer/message-attachments": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-message-attachments/",
-    "developer/oauth-2-0-applications": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-oauth2/",
-    "developer/personal-access-token": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-personal-access-token/",
-    "developer/slash-commands": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-slash-commands/",
-    "developer/webhook-outgoing": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-outgoing/",
-    "developer/webhook-incoming":
-        "https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-incoming/",
-    "developer/bot-accounts": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
-    "developer/localization":
-        "https://handbook.mattermost.com/contributors/contributors/localization",
-    "overview/security": 
-        "https://docs.mattermost.com/about/security.html",
-    "overview/integrations": 
-        "https://docs.mattermost.com/about/integrations.html",
-    "overview/license-and-subscription": 
-        "https://docs.mattermost.com/about/subscription.html",
-    "overview/auth": 
-        "https://docs.mattermost.com/about/corporate-directory-integration.html",
-    "overview/compliance": 
-        "https://docs.mattermost.com/about/certifications-and-compliance.html",
-    "overview/faq": 
-        "https://docs.mattermost.com/about/frequently-asked-questions.html",
-    "overview/architecture": 
-        "https://docs.mattermost.com/getting-started/architecture-overview.html",
-    "integrations/jira": "https://mattermost.gitbook.io/plugin-jira/",
-    "integrations/zoom": "https://mattermost.gitbook.io/plugin-zoom/",
-    "integrations/net-promoter-score": "https://docs.mattermost.com/manage/user-satisfaction-surveys.html",
-    "developer/interactive-dialogs": "https://developers.mattermost.com/integrate/admin-guide/admin-interactive-dialogs/",
-    "developer/interactive-message-buttons": "https://developers.mattermost.com/integrate/admin-guide/admin-interactive-messages/",
-    "developer/message-attachments": "https://developers.mattermost.com/integrate/admin-guide/admin-message-attachments/",
-    "developer/oauth-2-0-applications": "https://developers.mattermost.com/integrate/admin-guide/admin-oauth2/",
-    "developer/personal-access-token": "https://developers.mattermost.com/integrate/admin-guide/admin-personal-access-token/",
-    "developer/slash-commands": "https://developers.mattermost.com/integrate/admin-guide/admin-slash-commands/",
-    "developer/webhook-outgoing": "https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-outgoing/",
-    "developer/webhook-incoming": "https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-incoming/",
-    "developer/bot-accounts": "https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
-    "developer/localization": "https://handbook.mattermost.com/contributors/contributors/localization",
-    "overview/product": "https://docs.mattermost.com/about/product.html",
-    "overview/security": "https://docs.mattermost.com/about/security.html",
-    "overview/integrations": "https://docs.mattermost.com/about/integrations.html",
-    "overview/auth": "https://docs.mattermost.com/about/corporate-directory-integration.html",
-    "overview/compliance": "https://docs.mattermost.com/about/certifications-and-compliance.html",
-    "overview/faq": "https://docs.mattermost.com/about/frequently-asked-questions.html",
-    "overview/architecture": "https://docs.mattermost.com/getting-started/architecture-overview.html",
-    "overview/license-and-subscription#frequently-asked-questions": 
-        "https://docs.mattermost.com/about/subscription.html#frequently-asked-questions",
-    "overview/product#mattermost-enterprise-edition-e10": 
-        "https://docs.mattermost.com/about/product.html#mattermost-enterprise-edition-e10",
-    "getting-started/implementation_plan": 
-        "https://docs.mattermost.com/getting-started/implementation-plan.html",
-    "getting-started/welcome_email": 
-        "https://docs.mattermost.com/getting-started/welcome-email-to-end-users.html",
-    "guides/orchestration": 
-        "https://docs.mattermost.com/about/orchestration.html",
-    "guides/administrator": 
-        "https://docs.mattermost.com/guides/deployment.html",
-    "guides/administrator": 
-        "https://docs.mattermost.com/guides/deployment.html",
-    "guides/developer": 
-        "https://developers.mattermost.com/integrate/admin-guide/",
-    "guides/integration": 
-        "https://developers.mattermost.com/integrate/getting-started/",
-    "guides/user": 
-        "https://docs.mattermost.com/guides/channels.html",
-    "guides/cloud-admin-guide": 
-        "https://docs.mattermost.com/guides/deployment.html",
-    "install/requirements": 
-        "https://docs.mattermost.com/install/software-hardware-requirements.html",
-    "install/install-ubuntu-2004": 
-        "https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html",
-    "install/install-ubuntu-1804": 
-        "https://docs.mattermost.com/install/installing-ubuntu-1804-LTS.html",
-    "install/mattermost-omnibus": 
-        "https://docs.mattermost.com/install/installing-mattermost-omnibus.html",
-    "install/sockets-db": 
-        "https://docs.mattermost.com/install/setting-up-socket-based-mattermost-database.html",
-    "install/ee-install": 
-        "https://docs.mattermost.com/install/enterprise-install-upgrade.html",
-    "install/transport-encryption/config": 
-        "https://docs.mattermost.com/install/transport-encryption.html",
-    "install/transport-encryption/config-mattermost":
-        "https://docs.mattermost.com/install/proxy-to-mattermost-transport-encryption.html",
-    "install/transport-encryption/config-database":
-        "https://docs.mattermost.com/install/database-transport-encryption.html",
-    "install/transport-encryption/config-cluster":
-        "https://docs.mattermost.com/install/cluster-transport-encryption.html",
-    "install/deploy-bitnami": 
-        "https://docs.mattermost.com/install/deploying-team-edition-on-bitnami.html",
-    "install/docker-local-machine": 
-        "https://docs.mattermost.com/install/setting-up-local-machine-using-docker.html",
-    "install/docker-ebs": 
-        "https://docs.mattermost.com/install/setting-up-aws-elastic-beanstalk-docker.html",
-    "install/install-mmte-helm-gitlab-helm":
-        "https://docs.mattermost.com/install/installing-team-edition-helm-chart.html",
-    "install/desktop": 
-        "https://docs.mattermost.com/install/desktop-app-install.html",
-    "install/desktop-managed-resources": 
-        "https://docs.mattermost.com/install/desktop-app-managed-resources.html",
-    "install/desktop-msi-gpo":
-        "https://docs.mattermost.com/install/desktop-msi-installer-and-group-policy-install.html",
-    "install/smtp-email-setup": 
-        "https://docs.mattermost.com/configure/smtp-email.html",
-    "install/config-cloudfront":
-        "https://docs.mattermost.com/configure/configuring-cloudfront-to-host-mattermost-static-assets.html",
-    "install/outbound-proxy": 
-        "https://docs.mattermost.com/configure/using-outbound-proxy.html",
-    "install/i18n": 
-        "https://docs.mattermost.com/configure/enabling-chinese-japanese-korean-search.html",
-    "install/config-apache2": 
-        "https://docs.mattermost.com/configure/configuring-apache2.html",
-    "administration/telemetry": 
-        "https://docs.mattermost.com/manage/telemetry.html",
-    "administration/changelog": 
-        "https://docs.mattermost.com/install/self-managed-changelog.html",
-    "administration/command-line-tools": 
-        "https://docs.mattermost.com/manage/command-line-tools.html",
-    "administration/compliance-export": 
-        "https://docs.mattermost.com/comply/compliance-export.html",
-    "install/outbound-proxy": "https://docs.mattermost.com/configure/using-outbound-proxy.html",
-    "install/i18n": "https://docs.mattermost.com/configure/enabling-chinese-japanese-korean-search.html",
-    "install/config-apache2": "https://docs.mattermost.com/configure/configuring-apache2.html",
-    "install/prod-windows-2012": "https://forum.mattermost.org/t/production-install-on-windows-server/12232",
-    "administration/telemetry": "https://docs.mattermost.com/manage/telemetry.html",
-    "administration/changelog": "https://docs.mattermost.com/install/self-managed-changelog.html",
-    "administration/command-line-tools": "https://docs.mattermost.com/manage/command-line-tools.html",
-    "administration/compliance-export": "https://docs.mattermost.com/comply/compliance-export.html",
-    "administration/config-settings#allow-users-to-view-archived-channels-beta":
-        "https://docs.mattermost.com/configure/configuration-settings.html#allow-users-to-view-archived-channels-beta",
-    "administration/config-settings#timezone": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#timezone",
-    "administration/config-settings#enable-legacy-sidebar":
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
-    "administration/config-settings#town-square-is-read-only-experimental":
-        "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-read-only-experimental",
-    "administration/config-settings#town-square-is-hidden-in-left-hand-sidebar-experimental":
-        "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-hidden-in-left-hand-sidebar-experimental",
-    "administration/config-settings#enable-x-to-leave-channels-from-left-hand-sidebar-experimental":
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-x-to-leave-channels-from-left-hand-sidebar-experimental",
-    "administration/config-settings#autoclose-direct-messages-in-sidebar-experimental":
-        "https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental",
-    "administration/config-settings#sidebar-organization":
-        "https://docs.mattermost.com/configure/configuration-settings.html#sidebar-organization",
-    "administration/config-settings#experimental-sidebar-features":
-        "https://docs.mattermost.com/configure/configuration-settings.html#experimental-sidebar-features",
-    "administration/config-settings#deprecated-configuration-settings":
-        "https://docs.mattermost.com/configure/configuration-settings.html#deprecated-configuration-settings",
-    "administration/custom-terms-of-service": 
-        "https://docs.mattermost.com/comply/custom-terms-of-service.html",
-    "administration/image-proxy": 
-        "https://docs.mattermost.com/deploy/image-proxy.html",
-    "administration/encryption": 
-        "https://docs.mattermost.com/deploy/encryption-options.html",
-    "administration/extended-support-release": 
-        "https://docs.mattermost.com/upgrade/extended-support-release.html",
-    "administration/backup": 
-        "https://docs.mattermost.com/deploy/backup-disaster-recovery.html",
-    "administration/upgrade": 
-        "https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html",
-    "administration/important-upgrade-notes": 
-        "https://docs.mattermost.com/upgrade/important-upgrade-notes.html",
-    "administration/version-archive": 
-        "https://docs.mattermost.com/upgrade/version-archive.html",
-    "administration/extended-support-release": 
-        "https://docs.mattermost.com/upgrade/extended-support-release.html",
-    "administration/release-lifecycle": 
-        "https://docs.mattermost.com/upgrade/release-lifecycle.html",
-    "administration/downgrade": 
-        "https://docs.mattermost.com/upgrade/downgrading-mattermost-server.html",
-    "administration/open-source-components": 
-        "https://docs.mattermost.com/upgrade/open-source-components.html",
-    "administration/mmctl-cli-tool": 
-        "https://docs.mattermost.com/manage/mmctl-cli-tool.html",
-    "administration/migrating#migrating-from-slack-using-the-mattermost-web-app":
-        "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-web-app",
-    "administration/migrating#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import":
-        "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
-    "administration/release-definitions": 
-        "https://docs.mattermost.com/upgrade/release-definitions.html",
-    "administration/performance-alerting-guide": 
-        "https://docs.mattermost.com/scale/peformance-alerting.html",
-    "administration/config-settings": 
-        "https://docs.mattermost.com/configure/configuration-settings.html",
-    "administration/config-in-database":
-        "https://docs.mattermost.com/configure/configuation-in-mattermost-database.html",
-    "administration/branding": 
-        "https://docs.mattermost.com/configure/custom-branding-tools.html",
-    "administration/config-settings#rate-limiting": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#rate-limiting",
-    "administration/config-settings#customization": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#customization",
-    "administration/config-settings#terms-of-service-link": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#terms-of-service-link",
-    "administration/config-settings#ad-ldap": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#ad-ldap",
-    "administration/config-settings#user-filter": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#user-filter",
-    "administration/command-line-tools#mattermost-ldap-idmigrate": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-ldap-idmigrate",
-    "administration/config-settings#id-attribute": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#id-attribute",
-    "administration/config-settings#login-id-attribute": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#login-id-attribute",
-    "administration/config-settings#maximum-page-size": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#maximum-page-size",
-    "administration/config-settings#enable-local-mode": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-local-mode",
-    "administration/config-settings#enable-local-mode-socket-location": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-local-mode-socket-location",
-    "administration/config-in-database#create-an-environment-file": 
-        "https://docs.mattermost.com/configure/configuation-in-mattermost-database.html#create-an-environment-file",
-    "administration/config-settings#enable-public-channel-creation-for": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-public-channel-creation-for",
-    "administration/config-settings#enable-public-channel-renaming-for": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-public-channel-renaming-for",
-    "administration/config-settings#data-retention-policy": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#data-retention-policy",
-    "administration/command-line-tools#mattermost-channel-restore": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-channel-restore",
-    "administration/mmctl-cli-tool#mmctl-channel-modify": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-channel-modify",
-    "administration/config-settings#post-edit-time-limit": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#post-edit-time-limit",
-    "administration/command-line-tools#mattermost-permissions-reset": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-permissions-reset",
-    "administration/command-line-tools#mattermost-permissions-export": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-permissions-export",
-    "administration/command-line-tools#mattermost-permissions-import": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-permissions-import",
-    "configure/configuration-settings#compliance-export-beta": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#compliance-export",
-    "configure/configuration-settings#custom-terms-of-service-beta": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#custom-terms-of-service",
-    "configure/configuration-settings#guest-access-beta": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#guest-access",
-    "configure/configuration-settings#plugins-beta": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#plugins",
-    "administration/upgrade#upgrade-team-edition-to-enterprise-edition": 
-        "https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html#upgrading-team-edition-to-enterprise-edition",
-    "administration/migrating#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import": 
-        "https://docs.mattermost.com/onboard/migrating-to-mattermost.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
-    "administration/config-settings#enable-legacy-sidebar": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
-    "administration/config-settings#post-edit-time-limit": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#post-edit-time-limit",
-    "administration/config-settings#default-channels-experimental": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#default-channels-experimental",
-    "administration/config-settings#ad-ldap": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#ad-ldap",
-    "administration/command-line-tools#mattermost-group-team-list": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-team-list",
-    "administration/command-line-tools#mattermost-group-team-enable": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-team-enable",
-    "administration/command-line-tools#mattermost-group-channel-enable": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-channel-enable",
-    "administration/command-line-tools#mattermost-group-team-disable": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-team-disable",
-    "administration/command-line-tools#mattermost-group-channel-disable": 
-        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-channel-disable",
-    "administration/config-settings#logging": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#standard-logging",
-    "administration/ediscovery#mattermost-restful-api": 
-        "https://docs.mattermost.com/comply/electronic-discovery.html#mattermost-restful-api",
-    "administration/ediscovery#mattermost-database": 
-        "https://docs.mattermost.com/comply/electronic-discovery.html#mattermost-database",
-    "deployment/deployment": 
-        "https://docs.mattermost.com/deploy/deployment-overview.html",
-    "administration/config-settings#enable-automatic-replies-experimental": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-automatic-replies-experimental",
-    "administration/config-settings#teammate-name-display": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#teammate-name-display",
-    "administration/config-settings#group-unread-channels-experimental": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#group-unread-channels-experimental",
-    "administration/config-settings#enable-legacy-sidebar": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
-    "administration/config-settings#autoclose-direct-messages-in-sidebar-experimental": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental",
-    "administration/config-settings#timezone": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#timezone",
-    "administration/config-settings#link-previews": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-link-previews",
-    "deployment/deployment": "https://docs.mattermost.com/deploy/deployment-overview.html",
-    "deployment/advanced-permissions#read-only-channels": 
-        "https://docs.mattermost.com/onboard/advanced-permissions.html#read-only-channels-e20",
-    "deployment/bots": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
-    "deployment/on-boarding": "https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html",
-    "deployment/ha": "https://docs.mattermost.com/deployment/cluster.html",
-    "deployment/webrtc": "https://docs.mattermost.com/deployment/video-and-audio-calling.html",
-    "deployment/desktop-app-deployment": "https://docs.mattermost.com/deploy/desktop-app.html",
-    "deployment/scaling": "https://docs.mattermost.com/scale/scaling-for-enterprise.html",
-    "deployment/cluster": "https://docs.mattermost.com/scale/high-availability-cluster.html",
-    "deployment/elasticsearch": "https://docs.mattermost.com/scale/elasticsearch.html",
-    "deployment/metrics": "https://docs.mattermost.com/scale/performance-monitoring.html",
-    "deployment/customize-mattermost": "https://docs.mattermost.com/configure/customizing-mattermost.html",
-    "deployment/customize-email": "https://docs.mattermost.com/configure/email-templates.html",
-    "deployment/advanced-permissions": "https://docs.mattermost.com/onboard/advanced-permissions.html",
-    "deployment/permissions-backend":
-        "https://docs.mattermost.com/onboard/advanced-permissions-backend-infrastructure.html",
-    "deployment/admin-roles": "https://docs.mattermost.com/onboard/system-admin-roles.html",
-    "deployment/guest-accounts": "https://docs.mattermost.com/onboard/guest-accounts.html",
-    "deployment/sso-ldap": "https://docs.mattermost.com/onboard/ad-ldap.html",
-    "deployment/auth": "https://docs.mattermost.com/onboard/multi-factor-authentication.html",
-    "deployment/sso-openidconnect": "https://docs.mattermost.com/onboard/sso-openidconnect.html",
-    "deployment/sso-gitlab": "https://docs.mattermost.com/onboard/sso-gitlab.html",
-    "deployment/sso-google": "https://docs.mattermost.com/onboard/sso-google.html",
-    "deployment/sso-office": "https://docs.mattermost.com/onboard/sso-office.html",
-    "deployment/converting-oauth20-service-providers-to-openidconnect":
-        "https://docs.mattermost.com/onboard/convert-oauth20-service-providers-to-openidconnect.html",
-    "deployment/bulk-loading": "https://docs.mattermost.com/onboard/bulk-loading-data.html",
-    "deployment/ldap-group-sync": "https://docs.mattermost.com/onboard/ad-ldap-groups-synchronization.html",
-    "deployment/ldap-group-constrained-team-channel":
-        "https://docs.mattermost.com/onboard/manage-team-channel-membership-using-ad-ldap-sync-groups.html",
-    "deployment/sso-saml": "https://docs.mattermost.com/onboard/sso-saml.html",
-    "deployment/sso-saml-okta": "https://docs.mattermost.com/onboard/sso-saml-okta.html",
-    "deployment/sso-saml-technical": "https://docs.mattermost.com/onboard/sso-saml-technical.html",
-    "deployment/sso-saml-adfs-msws2016": "https://docs.mattermost.com/onboard/sso-saml-adfs-msws2016.html",
-    "deployment/ssl-client-certificate": "https://docs.mattermost.com/onboard/ssl-client-certificate.html",
-    "deployment/team-channel-management": "https://docs.mattermost.com/manage/team-channel-members.html",
-    "deployment/certificate-based-authentication":
-        "https://docs.mattermost.com/onboard/certificate-based-authentication.html",
-    "deployment/push": "https://docs.mattermost.com/deploy/mobile-hpns.html",
-    "deployment/on-boarding#common-tasks": 
-        "https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html",
-    "deployment/ldap-group-sync#add-default-teams-or-channels-for-the-group": 
-        "https://docs.mattermost.com/onboard/ad-ldap-groups-synchronization.html#adding-default-teams-or-channels-for-the-group",
-    "deployment/team-channel-management#profile": "https://docs.mattermost.com/manage/team-channel-members.html#profile",
-    "deployment/ldap-group-sync#add-default-teams-or-channels-for-the-group": 
-        "https://docs.mattermost.com/onboard/ad-ldap-groups-synchronization.html#adding-default-teams-or-channels-for-the-group",
-    "deployment/ldap-group-sync#add-default-teams-or-channels-for-the-group": 
-        "https://docs.mattermost.com/onboard/ad-ldap-groups-synchronization.html#adding-default-teams-or-channels-for-the-group",
-    "deployment/sso-saml-okta#configure-saml-synchronization-with-ad-ldap": 
-        "https://docs.mattermost.com/onboard/sso-saml-okta.html#configure-saml-synchronization-with-ad-ldap",
-    "administration/config-settings#files": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#file-storage",
-    "administration/config-settings#maximum-file-size":
-        "https://docs.mattermost.com/configure/configuration-settings.html#maximum-file-size",
-    "administration/config-settings#aggregate-search-indexes":
-        "https://docs.mattermost.com/configure/configuration-settings.html#aggregate-search-indexes",
-    "administration/changelog#database-changes-from-v3-4-to-v3-5":
-        "https://docs.mattermost.com/install/self-managed-changelog.html#id41",
-    "administration/config-settings#environment":
-        "https://docs.mattermost.com/configure/configuration-settings.html#environment-variables",
-    "administration/config-settings#site-configuration":
-        "https://docs.mattermost.com/configure/configuration-settings.html#site-configuration",
-    "administration/performance-alerting-guide": 
-        "https://docs.mattermost.com/scale/performance-monitoring.html",
-    "administration/config-settings#policy": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#policy",
-    "administration/devops-command-center": 
-        "https://docs.mattermost.com/guides/incident-collaboration.html",
-    "administration/plugins": 
-        "https://developers.mattermost.com/integrate/admin-guide/admin-plugins-beta/",
-    "administration/migrating": 
-        "https://docs.mattermost.com/onboard/migrating-to-mattermost.html",
-    "administration/user-provisioning":
-        "https://docs.mattermost.com/onboard/user-provisioning-workflows.html",
-    "administration/hipchat-migration-guidelines":
-        "https://docs.mattermost.com/onboard/migrating-from-hipchat-to-mattermost.html",
-    "administration/migration-announcement-email-template":
-        "https://docs.mattermost.com/onboard/migration-announcement-email.html",
-    "administration/generating-support-packet": 
-        "https://docs.mattermost.com/manage/generating-support-packet.html",
-    "administration/mmctl-cli-tool": 
-        "https://docs.mattermost.com/manage/mmctl-command-line-tool.html",
-    "administration/command-line-tools": 
-        "https://docs.mattermost.com/manage/command-line-tools.html",
-    "administration/scripts": 
-        "https://docs.mattermost.com/manage/scripts.html",
-    "administration/statistics": 
-        "https://docs.mattermost.com/manage/statistics.html",
-    "administration/notices": 
-        "https://docs.mattermost.com/manage/in-product-notices.html",
-    "administration/health-check": 
-        "https://docs.mattermost.com/manage/health-checks.html",
-    "administration/announcement-banner": 
-        "https://docs.mattermost.com/manage/announcement-banner.html",
-    "administration/bulk-export": 
-        "https://docs.mattermost.com/manage/bulk-export-tool.html",
-    "administration/ediscovery": 
-        "https://docs.mattermost.com/comply/electronic-discovery.html",
-    "administration/compliance": 
-        "https://docs.mattermost.com/comply/compliance-reporting-oversight.html",
-    "administration/compliance-export": 
-        "https://docs.mattermost.com/comply/compliance-export.html",
-    "administration/audit-log": 
+
+# How to add redirects for docs.mattermost.com:
+# A redirect is required when an existing product documentation page is moved to a new sub-directory OR to another information site altogether. Redirects defined here ensure that existing links in the wild to these changed pages take the user to the correct destination page. Many of the links below are the result of the information architecture overhaul completed in FY22 Q2.
+# All redirects in the following are organized alphabetically for easy scanning and management based on the origin URL (the URL to the left of the colon). Please take care to ensure that alphabetical order is maintained as new redirects are added. See a mistake? Please feel free to fix it!
+# Before adding a new redirect, please search to confirm that the redirect you want isn't already specified below. 
+# Add the new redirect in the appropriate section, based on its path. 
+# For page heading redirects, use the format "directory/filename.html": "full-URL-path-to-new-destination.html",
+# For mid-page redirects (also known as section title redirects), use the format "directory/filename.html#section-title": "full-URL-path-to-new-destination.html",
+# Ensure that all redirects end in a comma, except for the very last redirect.
+
+# About redirects
+"about/license-and-subscription.html#do-you-have-a-program-for-official-non-profits-open-source-projects-and-charities.": 
+    "https://docs.mattermost.com/about/subscription.html#do-you-have-a-program-for-official-non-profits-open-source-projects-and-charities",
+
+# Administration redirects resulting from the June 2021 docs reorganization project.
+"administration/announcement-banner.html": 
+    "https://docs.mattermost.com/manage/announcement-banner.html",
+"administration/audit-log.html": 
         "https://docs.mattermost.com/comply/audit-log.html",
-    "administration/data-retention": 
-        "https://docs.mattermost.com/comply/data-retention-policy.html",
-    "administration/custom-terms-of-service": 
+"administration/backup.html": 
+        "https://docs.mattermost.com/deploy/backup-disaster-recovery.html",
+"administration/branding.html": 
+        "https://docs.mattermost.com/configure/custom-branding-tools.html",
+"administration/bulk-export.html": 
+        "https://docs.mattermost.com/manage/bulk-export-tool.html",
+"administration/changelog.html": 
+        "https://docs.mattermost.com/install/self-managed-changelog.html",
+"administration/changelog.html": 
+	"https://docs.mattermost.com/install/self-managed-changelog.html",
+"administration/changelog.html#database-changes-from-v3-4-to-v3-5":
+        "https://docs.mattermost.com/install/self-managed-changelog.html#id41",
+"administration/command-line-tools.html": 
+        "https://docs.mattermost.com/manage/command-line-tools.html",
+"administration/command-line-tools.html#mattermost-channel-restore": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-channel-restore",
+"administration/command-line-tools.html#mattermost-permissions-reset": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-permissions-reset",
+"administration/command-line-tools.html#mattermost-permissions-export": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-permissions-export",
+"administration/command-line-tools.html#mattermost-permissions-import": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-permissions-import",
+"administration/command-line-tools.html#mattermost-group-team-list": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-team-list",
+"administration/command-line-tools.html#mattermost-group-team-enable": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-team-enable",
+"administration/command-line-tools.html#mattermost-group-channel-enable": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-channel-enable",
+"administration/command-line-tools.html#mattermost-group-team-disable": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-team-disable",
+"administration/command-line-tools.html#mattermost-group-channel-disable": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-group-channel-disable",
+"administration/command-line-tools.html#mattermost-ldap-idmigrate": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-ldap-idmigrate",
+"administration/compliance.html": 
+        "https://docs.mattermost.com/comply/compliance-reporting-oversight.html",
+"administration/compliance-export.html": 
+        "https://docs.mattermost.com/comply/compliance-export.html",
+"administration/config-in-database.html":
+        "https://docs.mattermost.com/configure/configuation-in-mattermost-database.html",
+"administration/custom-terms-of-service.html": 
         "https://docs.mattermost.com/comply/custom-terms-of-service.html",
-    "administration/mobile-changelog": 
+"administration/custom-terms-of-service.html": 
+        "https://docs.mattermost.com/comply/custom-terms-of-service.html",
+"administration/data-retention.html": 
+        "https://docs.mattermost.com/comply/data-retention-policy.html",
+"administration/devops-command-center.html": 
+        "https://docs.mattermost.com/guides/incident-collaboration.html",
+"administration/downgrade.html": 
+        "https://docs.mattermost.com/upgrade/downgrading-mattermost-server.html",
+"administration/ediscovery.html#mattermost-restful-api": 
+        "https://docs.mattermost.com/comply/electronic-discovery.html#mattermost-restful-api",
+"administration/ediscovery.html#mattermost-database": 
+        "https://docs.mattermost.com/comply/electronic-discovery.html#mattermost-database",
+"administration/ediscovery.html": 
+        "https://docs.mattermost.com/comply/electronic-discovery.html",
+"administration/encryption.html": 
+        "https://docs.mattermost.com/deploy/encryption-options.html",
+"administration/extended-support-release.html": 
+        "https://docs.mattermost.com/upgrade/extended-support-release.html",
+"administration/extended-support-release.html": 
+        "https://docs.mattermost.com/upgrade/extended-support-release.html",
+"administration/generating-support-packet.html": 
+        "https://docs.mattermost.com/manage/generating-support-packet.html",
+"administration/health-check.html": 
+        "https://docs.mattermost.com/manage/health-checks.html",
+"administration/hipchat-migration-guidelines.html":
+        "https://docs.mattermost.com/onboard/migrating-from-hipchat-to-mattermost.html",
+"administration/image-proxy.html": 
+        "https://docs.mattermost.com/deploy/image-proxy.html",
+"administration/important-upgrade-notes.html": 
+        "https://docs.mattermost.com/upgrade/important-upgrade-notes.html",
+"administration/migrating.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import":
+        "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
+"administration/migrating.html#migrating-from-slack-using-the-mattermost-web-app.":
+        "https://docs.mattermost.com/onboard/migrating.html#migrating-from-slack-using-the-mattermost-web-app",
+"administration/migrating.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import": 
+        "https://docs.mattermost.com/onboard/migrating-to-mattermost.html#migrating-from-slack-using-the-mattermost-mmetl-tool-and-bulk-import",
+"administration/migrating.html": 
+        "https://docs.mattermost.com/onboard/migrating-to-mattermost.html",
+"administration/migration-announcement-email-template.html":
+        "https://docs.mattermost.com/onboard/migration-announcement-email.html",
+"administration/mmctl-cli-tool.html": 
+        "https://docs.mattermost.com/manage/mmctl-cli-tool.html",
+"administration/mmctl-cli-tool.html#mmctl-channel-modify": 
+        "https://docs.mattermost.com/manage/command-line-tools.html#mattermost-channel-modify",
+"administration/mmctl-cli-tool.html": 
+        "https://docs.mattermost.com/manage/mmctl-command-line-tool.html",
+"administration/mobile-changelog.html": 
         "https://docs.mattermost.com/deploy/mobile-app-changelog.html",
-    "administration/config-settings#allow-users-to-view-archived-channels-beta": 
-        "https://docs.mattermost.com/configure/config-settings.html#allow-users-to-view-archived-channels",
-    "administration/config-settings#push-notification-contents": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#push-notification-contents",
-    "administration/config-settings#gitlab-settings": "https://docs.mattermost.com/configure/configuration-settings.html#gitlab-settings",
-    "administration/config-settings": "https://docs.mattermost.com/configure/configuration-settings.html",
-    "administration/config-settings#google-settings":
-        "https://docs.mattermost.com/configure/configuration-settings.html#google-settings",
-    "administration/config-settings#office-365-settings":
-        "https://docs.mattermost.com/configure/configuration-settings.html#office-365-settings",
-    "administration/config-settings#openid-connect-other-settings":
-        "https://docs.mattermost.com/configure/configuration-settings.html#openid-connect-other-settings",
-    "administration/config-settings#storage":
-        "https://docs.mattermost.com/configure/configuration-settings.html#local-storage-directory",
-    "administration/config-settings#aggregate-search-indexes":
+"administration/notices.html": 
+        "https://docs.mattermost.com/manage/in-product-notices.html",
+"administration/open-source-components.html": 
+        "https://docs.mattermost.com/upgrade/open-source-components.html",
+"administration/performance-alerting-guide.html": 
+        "https://docs.mattermost.com/scale/peformance-alerting.html",
+"administration/performance-alerting-guide": 
+        "https://docs.mattermost.com/scale/performance-monitoring.html",
+"administration/plugins.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-plugins-beta/",
+"administration/release-definitions.html": 
+        "https://docs.mattermost.com/upgrade/release-definitions.html",
+"administration/release-lifecycle.html": 
+        "https://docs.mattermost.com/upgrade/release-lifecycle.html",
+"administration/scripts.html": 
+        "https://docs.mattermost.com/manage/scripts.html",
+"administration/statistics.html": 
+        "https://docs.mattermost.com/manage/statistics.html",
+"administration/telemetry.html": 
+        "https://docs.mattermost.com/manage/telemetry.html",
+"administration/telemetry.html": 
+	"https://docs.mattermost.com/manage/telemetry.html",     
+"administration/upgrade.html": 
+        "https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html",
+"administration/upgrade.html#upgrade-team-edition-to-enterprise-edition": 
+        "https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html#upgrading-team-edition-to-enterprise-edition",
+"administration/user-provisioning.html":
+        "https://docs.mattermost.com/onboard/user-provisioning-workflows.html",
+"administration/config-in-database.html#create-an-environment-file": 
+       "https://docs.mattermost.com/configure/configuration-settings.html#enable-public-channel-creation-for",
+"administration/config-settings.html": 
+        "https://docs.mattermost.com/configure/configuration-settings.html",  
+"administration/config-settings.html#aggregate-search-indexes":
         "https://docs.mattermost.com/configure/configuration-settings.html#aggregate-search-indexes",
-    "administration/config-settings#enable-document-search-by-content":
+"administration/config-settings.html#allow-users-to-view-archived-channels-beta":
+        "https://docs.mattermost.com/configure/config-settings.html#allow-users-to-view-archived-channels",
+"administration/config-settings.html#autoclose-direct-messages-in-sidebar-experimental":
+        "https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental",
+"administration/config-settings.html#ad-ldap": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#ad-ldap",
+"administration/config-in-database.html":   
+	"https://docs.mattermost.com/configure/configuation-in-mattermost-database.html#create-an-environment-file",
+"administration/config-settings.html#customization": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#customization",
+"administration/config-settings.html#default-channels-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#default-channels-experimental",
+"administration/config-settings.html#deprecated-configuration-settings":
+        "https://docs.mattermost.com/configure/configuration-settings.html#deprecated-configuration-settings",
+"administration/config-settings.html#data-retention-policy": 
+ 	"https://docs.mattermost.com/configure/configuration-settings.html#data-retention-policy",  
+"administration/config-settings.html#enable-automatic-replies-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-automatic-replies-experimental",
+"administration/config-settings.html#enable-document-search-by-content":
         "https://docs.mattermost.com/configure/configuration-settings.html#enable-document-search-by-content",
-    "administration/config-settings#site-url":
-        "https://docs.mattermost.com/configure/configuration-settings.html#site-url",
-    "administration/config-settings#enable-link-previews":
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-link-previews",
-    "administration/config-settings#enable-high-availability-mode":
+"administration/config-settings.html#enable-high-availability-mode":
         "https://docs.mattermost.com/configure/configuration-settings.html#enable-high-availability-mode",
-    "administration/config-settings#forward-port-80-to-443":
+"administration/config-settings.html#enable-legacy-sidebar":
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-legacy-sidebar",
+"administration/config-settings.html#enable-link-previews":
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-link-previews",
+"administration/config-settings.html#enable-local-mode": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-local-mode",
+"administration/config-settings.html#enable-local-mode-socket-location": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-local-mode-socket-location",   
+"administration/config-settings.html#enable-public-channel-renaming-for": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-public-channel-renaming-for",
+"administration/config-settings.html#enable-public-channel-creation-for": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-public-channel-creation-for",
+"administration/config-settings.html#enable-x-to-leave-channels-from-left-hand-sidebar-experimental":
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-x-to-leave-channels-from-left-hand-sidebar-experimental",
+"administration/config-settings.html#environment":
+        "https://docs.mattermost.com/configure/configuration-settings.html#environment-variables",
+"administration/config-settings.html#experimental-sidebar-features":
+        "https://docs.mattermost.com/configure/configuration-settings.html#experimental-sidebar-features",
+"administration/config-settings.html#files": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#file-storage", 
+"administration/config-settings.html#forward-port-80-to-443":
         "https://docs.mattermost.com/configure/configuration-settings.html#forward-port-80-to-443",
-    "administration/config-settings#smtp-email-server": 
+"administration/config-settings.html#gitlab-settings": 
+	"https://docs.mattermost.com/configure/configuration-settings.html#gitlab-settings",
+"administration/config-settings.html#google-settings":
+        "https://docs.mattermost.com/configure/configuration-settings.html#google-settings",
+"administration/config-settings.html#group-unread-channels-experimental": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#group-unread-channels-experimental",
+"administration/config-settings.html#id-attribute": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#id-attribute",               
+"administration/config-settings.html#link-previews": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-link-previews",
+"administration/config-settings.html#logging": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#standard-logging",
+"administration/config-settings.html#login-id-attribute": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#login-id-attribute",
+"administration/config-settings.html#maximum-file-size":
+        "https://docs.mattermost.com/configure/configuration-settings.html#maximum-file-size",       
+"administration/config-settings.html#maximum-page-size": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#maximum-page-size",
+"administration/config-settings.html#office-365-settings":
+        "https://docs.mattermost.com/configure/configuration-settings.html#office-365-settings",
+"administration/config-settings.html#openid-connect-other-settings":
+        "https://docs.mattermost.com/configure/configuration-settings.html#openid-connect-other-settings",
+"administration/config-settings.html#policy": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#policy",
+"administration/config-settings#post-edit-time-limit.html": 
+    "https://docs.mattermost.com/configure/configuration-settings.html#post-edit-time-limit",
+"administration/config-settings.html#push-notification-contents": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#push-notification-contents",  
+"administration/config-settings.html#rate-limiting": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#rate-limiting",
+"administration/config-settings.html#session-lengths": 
+	"https://docs.mattermost.com/configure/configuration-settings.html#session-lengths",
+"administration/config-settings.html#sidebar-organization":
+        "https://docs.mattermost.com/configure/configuration-settings.html#sidebar-organization",
+"administration/config-settings#site-configuration.html":
+        "https://docs.mattermost.com/configure/configuration-settings.html#site-configuration",
+"administration/config-settings.html#site-url":
+        "https://docs.mattermost.com/configure/configuration-settings.html#site-url",
+"administration/config-settings.html#smtp-email-server": 
         "https://docs.mattermost.com/configure/configuration-settings.html#smtp-email-server",
-    "administration/config-settings.html#session-lengths": "https://docs.mattermost.com/configure/configuration-settings.html#session-lengths",
-    "configure/config-ssl-http2-apache2": "https://forum.mattermost.org/t/configuring-apache2-with-ssl-and-http-2/11939",
-    "configure/configuration-settings#enable-latex-rendering": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#enable-latex-code-block-rendering",
-    "configure/configuration-settings#terms-of-service-link": 
-        "https://docs.mattermost.com/configure/configuration-settings.html#terms-of-use-link",
-    "cloud/cloud-administration/cloud-changelog": "https://docs.mattermost.com/install/cloud-changelog.html",
-    "cloud/cloud-administration/cloud-compliance":
+"administration/config-settings#storage.html":
+        "https://docs.mattermost.com/configure/configuration-settings.html#local-storage-directory",
+"administration/config-settings.html#teammate-name-display": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#teammate-name-display",
+"administration/config-settings.html#timezone": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#timezone",
+"administration/config-settings.html#town-square-is-hidden-in-left-hand-sidebar-experimental":
+        "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-hidden-in-left-hand-sidebar-experimental",
+"administration/config-settings.html#town-square-is-read-only-experimental":
+        "https://docs.mattermost.com/configure/configuration-settings.html#town-square-is-read-only-experimental",
+"administration/config-settings.html#user-filter": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#user-filter",
+
+# Cloud redirects. Additional redirects will be added in FY23 Q1/Q2.
+"cloud/cloud-mobile/cloud-app-config.html": 
+	"https://docs.mattermost.com/deploy/mobile-appconfig.html",
+"cloud/cloud-billing/cloud-billing.html": 
+	"https://docs.mattermost.com/manage/cloud-billing.html",
+"cloud/cloud-administration/cloud-changelog.html": 
+	"https://docs.mattermost.com/install/cloud-changelog.html",
+"cloud/cloud-administration/cloud-compliance.html":
         "https://docs.mattermost.com/comply/cloud-compliance-and-oversight.html",
-    "cloud/cloud-administration/compliance-export": "https://docs.mattermost.com/comply/cloud-compliance-export.html",
-    "cloud/cloud-administration/data-retention-policy":
-        "https://docs.mattermost.com/comply/cloud-data-retention-policy.html",
-    "cloud/cloud-administration/custom-terms-of-service":
+"cloud/cloud-integrations/cloud-slash-commands.html": 
+	"https://docs.mattermost.com/messaging/executing-slash-commands.html",
+"cloud/cloud-administration/compliance-export.html": 
+	"https://docs.mattermost.com/comply/cloud-compliance-export.html",
+"cloud/cloud-administration/custom-terms-of-service.html":
         "https://docs.mattermost.com/comply/cloud-custom-terms-of-service.html",
-    "cloud/cloud-billing/cloud-billing": "https://docs.mattermost.com/manage/cloud-billing.html",
-    "cloud/cloud-administration/sso-saml": "https://docs.mattermost.com/onboard/cloud-sso-saml.html",
-    "cloud/cloud-administration/saml-technical": "https://docs.mattermost.com/onboard/cloud-sso-saml-technical.html",
-    "cloud/cloud-reporting": "https://docs.mattermost.com/manage/cloud-reporting.html",
-    "cloud/cloud-administration/site-configuration":
+"cloud/cloud-reporting.html": 
+	"https://docs.mattermost.com/manage/cloud-reporting.html",
+"cloud/cloud-administration/data-retention-policy.html":
+        "https://docs.mattermost.com/comply/cloud-data-retention-policy.html",
+"cloud/cloud-administration/site-configuration.html":
         "https://docs.mattermost.com/configure/cloud-site-configuration.html",
-    "cloud/cloud-mobile/cloud-app-config": "https://docs.mattermost.com/deploy/mobile-appconfig.html",
-    "cloud/cloud-integrations/cloud-slash-commands": "https://docs.mattermost.com/messaging/executing-slash-commands.html",
-    "deployment/atlassian-integrations":
+"cloud/cloud-administration/saml-technical.html": 
+	"https://docs.mattermost.com/onboard/cloud-sso-saml-technical.html",
+"cloud/cloud-administration/sso-saml.html": 
+	"https://docs.mattermost.com/onboard/cloud-sso-saml.html",
+
+# Configure redirects
+"configure/config-ssl-http2-apache2.html": 
+	"https://forum.mattermost.org/t/configuring-apache2-with-ssl-and-http-2/11939",
+"configure/configuring-apache2.html": "https://forum.mattermost.org/c/docs/37",
+"configure/configuration-settings.html#compliance-export-beta": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#compliance-export",
+"configure/configuration-settings.html#custom-terms-of-service-beta": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#custom-terms-of-service",
+"configure/configuration-settings.html#enable-latex-rendering": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#enable-latex-code-block-rendering",
+ "configure/configuration-settings.html#guest-access-beta": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#guest-access",
+"configure/configuration-settings.html#plugins-beta": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#plugins",
+"configure/configuration-settings.html#terms-of-service-link": 
+        "https://docs.mattermost.com/configure/configuration-settings.html#terms-of-use-link",
+
+# Deployment redirects
+"deployment/advanced-permissions.html": 
+	"https://docs.mattermost.com/onboard/advanced-permissions.html",
+"deployment/auth.html": 
+	"https://docs.mattermost.com/onboard/multi-factor-authentication.html",
+"deployment/admin-roles.html": 
+	"https://docs.mattermost.com/onboard/system-admin-roles.html",
+ "deployment/atlassian-integrations.html":
         "https://docs.mattermost.com/messaging/extending-messaging-with-integrations.html#atlassian-integrations",
-    "deployment/bot-integrations":
+"deployment/advanced-permissions.html#read-only-channels": 
+        "https://docs.mattermost.com/onboard/advanced-permissions.html#read-only-channels",
+"deployment/bot-integrations.html":
         "https://docs.mattermost.com/messaging/extending-messaging-with-integrations.html#bot-integrations",
-    "deployment/admin-roles": "https://docs.mattermost.com/deploy/admin-roles.html",
-    "deployment/deployment": "https://docs.mattermost.com/deploy/deployment-overview.html",
-    "deployment/bots": "https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
-    "deployment/guest-accounts": "https://docs.mattermost.com/deploy/guest-accounts.html",
-    "deployment/on-boarding": "https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html",
-    "deployment/ha": "https://docs.mattermost.com/deployment/cluster.html",
-    "deployment/webrtc": "https://docs.mattermost.com/deployment/video-and-audio-calling.html",
-    "deployment/desktop-app-deployment": "https://docs.mattermost.com/deploy/desktop-app.html",
-    "deployment/scaling": "https://docs.mattermost.com/scale/scaling-for-enterprise.html",
-    "deployment/cluster": "https://docs.mattermost.com/scale/high-availability-cluster.html",
-    "deployment/elasticsearch": "https://docs.mattermost.com/scale/elasticsearch.html",
-    "deployment/metrics": "https://docs.mattermost.com/scale/performance-monitoring.html",
-    "deployment/customize-mattermost": "https://docs.mattermost.com/configure/customizing-mattermost.html",
-    "deployment/customize-email": "https://docs.mattermost.com/configure/email-templates.html",
-    "deployment/advanced-permissions": "https://docs.mattermost.com/onboard/advanced-permissions.html",
-    "deployment/permissions-backend":
-        "https://docs.mattermost.com/onboard/advanced-permissions-backend-infrastructure.html",
-    "deployment/admin-roles": "https://docs.mattermost.com/onboard/system-admin-roles.html",
-    "deployment/guest-accounts": "https://docs.mattermost.com/onboard/guest-accounts.html",
-    "deployment/sso-ldap": "https://docs.mattermost.com/onboard/ad-ldap.html",
-    "deployment/auth": "https://docs.mattermost.com/onboard/multi-factor-authentication.html",
-    "deployment/sso-openidconnect": "https://docs.mattermost.com/onboard/sso-openidconnect.html",
-    "deployment/sso-gitlab": "https://docs.mattermost.com/onboard/sso-gitlab.html",
-    "deployment/sso-google": "https://docs.mattermost.com/onboard/sso-google.html",
-    "deployment/sso-office": "https://docs.mattermost.com/onboard/sso-office.html",
-    "deployment/converting-oauth20-service-providers-to-openidconnect":
+"deployment/bots.html": 
+	"https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
+"deployment/bulk-loading.html": 
+	"https://docs.mattermost.com/onboard/bulk-loading-data.html",
+"deployment/cluster.html": 
+	"https://docs.mattermost.com/scale/high-availability-cluster.html",
+"deployment/cluster#upgrade-guide.html": 
+	"https://docs.mattermost.com/scale/high-availability-cluster.html#upgrade-guide",
+"deployment/customize-mattermost.html": 
+	"https://docs.mattermost.com/configure/customizing-mattermost.html",
+"deployment/customize-email.html": 
+	"https://docs.mattermost.com/configure/email-templates.html.html",
+"deployment/converting-oauth20-service-providers-to-openidconnect.html":
         "https://docs.mattermost.com/onboard/convert-oauth20-service-providers-to-openidconnect.html",
-    "deployment/bulk-loading": "https://docs.mattermost.com/onboard/bulk-loading-data.html",
-    "deployment/ldap-group-sync": "https://docs.mattermost.com/onboard/ad-ldap-groups-synchronization.html",
-    "deployment/ldap-group-constrained-team-channel":
-        "https://docs.mattermost.com/onboard/manage-team-channel-membership-using-ad-ldap-sync-groups.html",
-    "deployment/sso-saml": "https://docs.mattermost.com/onboard/sso-saml.html",
-    "deployment/sso-saml-okta": "https://docs.mattermost.com/onboard/sso-saml-okta.html",
-    "deployment/sso-saml-technical": "https://docs.mattermost.com/onboard/sso-saml-technical.html",
-    "deployment/sso-saml-adfs-msws2016": "https://docs.mattermost.com/onboard/sso-saml-adfs-msws2016.html",
-    "deployment/ssl-client-certificate": "https://docs.mattermost.com/onboard/ssl-client-certificate.html",
-    "deployment/team-channel-management": "https://docs.mattermost.com/manage/team-channel-members.html",
-    "deployment/certificate-based-authentication":
+"deployment/certificate-based-authentication.html":
         "https://docs.mattermost.com/onboard/certificate-based-authentication.html",
-    "deployment/mobile-app-deployment": "https://docs.mattermost.com/deploy/mobile-overview.html",
-    "deployment/deployment#file-store": "https://docs.mattermost.com/deploy/deployment-overview.html#file-store",
-    "deployment/cluster#proxy-server-configuration": 
+"deployment/cluster#proxy-server-configuration.html": 
         "https://docs.mattermost.com/scale/high-availability-cluster.html#proxy-server-configuration",
-    "deployment/cluster#upgrade-guide": "https://docs.mattermost.com/scale/high-availability-cluster.html#upgrade-guide",
-    "deployment/mobile-app-deployment": "https://docs.mattermost.com/deploy/mobile-overview.html",
-    "deployment/push.html": "https://docs.mattermost.com/deploy/mobile-hpns.html#mobile-push-notifications",
-    "deployment/ldap-group-constrained-team-channel": "https://docs.mattermost.com/onboard/cloud-groups.html",
-    "developer/personal-access-tokens": "https://developers.mattermost.com/integrate/admin-guide/admin-personal-access-token/",
-    "developer/localization": "https://handbook.mattermost.com/contributors/contributors/localization",
-    "getting-started/implementation_plan": "https://docs.mattermost.com/getting-started/implementation-plan.html",
-    "getting-started/welcome_email": "https://docs.mattermost.com/getting-started/welcome-email-to-end-users.html",
-    "guides/orchestration": "https://docs.mattermost.com/about/orchestration.html",
-    "guides/administrator": "https://docs.mattermost.com/guides/install-deploy-upgrade-scale.html",
-    "guides/administrator": "https://docs.mattermost.com/guides/install-deploy-upgrade-scale.html",
-    "guides/developer": "https://developers.mattermost.com/integrate/admin-guide/",
-    "guides/integration": "https://developers.mattermost.com/integrate/getting-started/",
-    "guides/user": "https://docs.mattermost.com/guides/channels.html",
-    "guides/cloud-admin-guide": "https://docs.mattermost.com/guides/install-deploy-upgrade-scale.html",
-    "guides/administrator#mattermost-integrations": "https://developers.mattermost.com/integrate/getting-started/",
-    "guides/integration": "https://developers.mattermost.com/integrate/other-integrations/",
-    "guides/install-deploy-upgrade-scale#install-mattermost":
+"deployment/team-channel-management.html": 
+	"https://docs.mattermost.com/manage/team-channel-members.html",
+"deployment/deployment.html": 
+        "https://docs.mattermost.com/deploy/deployment-overview.html",
+"deployment/deployment#file-store.html": 
+	"https://docs.mattermost.com/deploy/deployment-overview.html#file-store",
+"deployment/desktop-app-deployment.html": 
+	"https://docs.mattermost.com/deploy/desktop-app.html",
+"deployment/elasticsearch.html": 
+	"https://docs.mattermost.com/scale/elasticsearch.html",
+"deployment/guest-accounts.html":
+	"https://docs.mattermost.com/onboard/guest-accounts.html",
+"deployment/ha.html": 
+	"https://docs.mattermost.com/deployment/cluster.html",
+"deployment/ldap-group-sync.html": 
+	"https://docs.mattermost.com/onboard/ad-ldap-groups-synchronization.html",
+"deployment/ldap-group-constrained-team-channel.html": 
+	"https://docs.mattermost.com/onboard/cloud-groups.html",
+"deployment/ldap-group-sync.html#add-default-teams-or-channels-for-the-group": 
+        "https://docs.mattermost.com/onboard/ad-ldap-groups-synchronization.html#adding-default-teams-or-channels-for-the-group",
+"deployment/team-channel-management.html#profile": 
+	"https://docs.mattermost.com/manage/team-channel-members.html#profile",
+"deployment/metrics.html": 
+	"https://docs.mattermost.com/scale/performance-monitoring.html",
+"deployment/mobile-app-deployment.html": 
+	"https://docs.mattermost.com/deploy/mobile-overview.html",
+"deployment/on-boarding.html": 
+	"https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html",
+"deployment/on-boarding.html#common-tasks": 
+        "https://docs.mattermost.com/getting-started/admin-onboarding-tasks.html",
+"deployment/permissions-backend.html":
+        "https://docs.mattermost.com/onboard/advanced-permissions-backend-infrastructure.html",
+"deployment/push.html": 
+	"https://docs.mattermost.com/deploy/mobile-hpns.html",
+"deployment/scaling.html": 
+	"https://docs.mattermost.com/scale/scaling-for-enterprise.html",
+"deployment/sso-ldap.html": 
+	"https://docs.mattermost.com/onboard/ad-ldap.html",
+"deployment/sso-openidconnect.html": 
+	"https://docs.mattermost.com/onboard/sso-openidconnect.html",
+"deployment/sso-gitlab.html": 
+	"https://docs.mattermost.com/onboard/sso-gitlab.html",
+"deployment/sso-google.html": 
+	"https://docs.mattermost.com/onboard/sso-google.html",
+"deployment/sso-office.html": 
+	"https://docs.mattermost.com/onboard/sso-office.html",
+"deployment/sso-saml.html": 
+	"https://docs.mattermost.com/onboard/sso-saml.html",
+"deployment/sso-saml-technical.html": 
+	"https://docs.mattermost.com/onboard/sso-saml-technical.html",
+"deployment/ssl-client-certificate.html": 
+	"https://docs.mattermost.com/onboard/ssl-client-certificate.html",
+"deployment/sso-saml-okta.html": 
+	"https://docs.mattermost.com/onboard/sso-saml-okta.html",
+"deployment/sso-saml-okta.html#configure-saml-synchronization-with-ad-ldap": 
+        "https://docs.mattermost.com/onboard/sso-saml-okta.html#configure-saml-synchronization-with-ad-ldap",
+"deployment/sso-saml-adfs-msws2016.html": 
+	"https://docs.mattermost.com/onboard/sso-saml-adfs-msws2016.html",
+"deployment/team-channel-management.html": 
+	"https://docs.mattermost.com/manage/team-channel-members.html",
+"deployment/webrtc.html": 
+	"https://docs.mattermost.com/deployment/video-and-audio-calling.html",
+
+
+# Developer redirects. 
+# Important Note: The developer directory and its contents are scheduled to be archived by FY23 Q2 since all applicable content has been moved from docs.mm.com to developers.mm.com.
+"developer/bot-accounts.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/",
+"developer/interactive-dialogs.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-interactive-dialogs/",
+"developer/interactive-message-buttons.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-interactive-messages/",
+"developer/localization.html":
+        "https://handbook.mattermost.com/contributors/contributors/localization",
+"developer/message-attachments.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-message-attachments/",
+"developer/oauth-2-0-applications.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-oauth2/",
+"developer/personal-access-token.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-personal-access-token/",
+"developer/slash-commands.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-slash-commands/",
+"developer/webhook-outgoing.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-outgoing/",
+"developer/webhook-incoming.html":
+        "https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-incoming/",
+
+
+# Focalboard redirects
+"focalboard/installing-boards": 
+	"https://docs.mattermost.com/guides/boards.html",
+
+
+# Getting Started redirects
+"getting-started/implementation_plan.html": 
+        "https://docs.mattermost.com/getting-started/implementation-plan.html",
+"getting-started/welcome_email.html": 
+        "https://docs.mattermost.com/getting-started/welcome-email-to-end-users.html",
+
+
+# Guides redirects
+"guides/administrator.html": 
+        "https://docs.mattermost.com/guides/deployment.html",
+"guides/administrator.html#mattermost-integrations": 
+	"https://developers.mattermost.com/integrate/getting-started/",
+"guides/administrator.html#installing-mattermost": 
+	"https://docs.mattermost.com/guides/deployment.html#install-guides",
+"guides/messaging.html": 
+	"https://docs.mattermost.com/guides/channels.html",
+"guides/orchestration.html": 
+        "https://docs.mattermost.com/about/orchestration.html",
+
+# Important Note: The following guide files are scheduled to be archived by FY23 Q2 since they're no longer used in production.
+"guides/cloud-admin-guide.html": 
+	"https://docs.mattermost.com/guides/deployment.html",
+"guides/developer.html": 
+        "https://developers.mattermost.com/integrate/admin-guide/",
+"guides/install-deploy-upgrade-scale.html":
+	 "https://docs.mattermost.com/guides/deployment.html",
+"guides/install-deploy-upgrade-scale.html#install-mattermost":
         "https://docs.mattermost.com/guides/deployment.html#install-guides",
-    "guides/administrator#installing-mattermost": "https://docs.mattermost.com/guides/deployment.html#install-guides",
-    "help/apps/desktop-guide": "https://docs.mattermost.com/messaging/managing-desktop-app-servers.html",
-    "help/apps/desktop-changelog": "https://docs.mattermost.com/install/desktop-app-changelog.html",
-    "help/getting-started/welcome-to-mattermost": "https://docs.mattermost.com/guides/channels.html",
-    "messaging/welcome-to-mattermost-messaging": "https://docs.mattermost.com/guides/channels.html",
-    "help/getting-started/access-your-workspace": "https://docs.mattermost.com/messaging/accessing-your-workspace.html",
-    "help/getting-started/signing-in": "https://docs.mattermost.com/messaging/signing-in.html",
-    "help/getting-started/switch-between-teams": "https://docs.mattermost.com/messaging/switching-between-teams.html",
-    "help/getting-started/about-teams-channels-messages":
+"guides/integration.html": 
+        "https://developers.mattermost.com/integrate/getting-started/",
+"guides/setup-onboard-manage-comply.html": 
+	"https://docs.mattermost.com/guides/administration.html",
+"guides/user.html": 
+        "https://docs.mattermost.com/guides/channels.html",
+
+
+# Help redirects resulting from the June 2021 docs reorganization project.
+"help/apps/desktop-changelog.html": 
+	"https://docs.mattermost.com/install/desktop-app-changelog.html",
+"help/apps/desktop-guide.html": 
+	"https://docs.mattermost.com/messaging/managing-desktop-app-servers.html",
+"help/getting-started/about-teams-channels-messages.html":
         "https://docs.mattermost.com/messaging/about-teams-channels-messages.html",
-    "help/getting-started/log-out": "https://docs.mattermost.com/messaging/logging-out.html",
-    "help/getting-started/searching": "https://docs.mattermost.com/messaging/searching-in-mattermost.html",
-    "help/getting-started/creating-teams": "https://docs.mattermost.com/messaging/creating-teams.html",
-    "help/settings/team-settings": "https://docs.mattermost.com/messaging/team-settings.html",
-    "help/getting-started/organizing-conversations": "https://docs.mattermost.com/messaging/managing-channels.html",
-    "help/getting-started/organizing": "https://docs.mattermost.com/messaging/organizing-channels.html",
-    "help/settings/channel-settings": "https://docs.mattermost.com/messaging/channel-settings.html",
-    "help/getting-started/managing-members": "https://docs.mattermost.com/messaging/managing-members.html",
-    "help/getting-started/setting-your-status-availability":
-        "https://docs.mattermost.com/messaging/setting-your-status-availability.html",
-    "help/getting-started/configuring-notifications":
-        "https://docs.mattermost.com/messaging/configuring-notifications.html",
-    "help/getting-started/organizing-your-sidebar":
-        "https://docs.mattermost.com/messaging/organizing-your-sidebar.html",
-    "help/messaging/sending-messages": "https://docs.mattermost.com/messaging/sending-receiving-messages.html",
-    "help/messaging/organizing-conversations": "https://docs.mattermost.com/messaging/organizing-conversations.html",
-    "help/messaging/organizing-conversations#known-issues":
-        "https://docs.mattermost.com/messaging/organizing-conversations.html#known-issues",
-    "help/messaging/formatting-text": "https://docs.mattermost.com/messaging/formatting-text.html",
-    "help/messaging/emoji": 
-        "https://docs.mattermost.com/messaging/using-emoji.html",
-    "help/messaging/mentioning-teammates": 
-        "https://docs.mattermost.com/messaging/mentioning-teammates.html",
-    "help/messaging/attaching-files": 
-        "https://docs.mattermost.com/messaging/sharing-files.html",
-    "help/messaging/executing-commands": 
-        "https://docs.mattermost.com/messaging/executing-slash-commands.html",
-    "help/messaging/flagging-messages": 
-        "https://docs.mattermost.com/messaging/saving-messages.html",
-    "help/messaging/pinning-messages": 
-        "https://docs.mattermost.com/messaging/pinning-messages.html",
-    "help/messaging/keyboard-shortcuts": 
-        "https://docs.mattermost.com/messaging/keyboard-shortcuts.html",
-    "help/settings/custom-emoji": 
-        "https://docs.mattermost.com/messaging/using-custom-emoji.html",
-    "help/settings/account-settings": 
-        "https://docs.mattermost.com/messaging/manage-channels-settings.html",
-    "help/settings/theme-colors": 
-        "https://docs.mattermost.com/messaging/customizing-theme-colors.html",
-    "help/settings/desktop-app-options": 
-        "https://docs.mattermost.com/messaging/managing-desktop-app-options.html",
-    "help/settings/manage-servers": 
-        "https://docs.mattermost.com/messaging/managing-desktop-app-servers.html",
-    "help/getting-started/accessibility": 
+"help/getting-started/access-your-workspace.html": 
+	"https://docs.mattermost.com/messaging/accessing-your-workspace.html",
+"help/getting-started/accessibility.html": 
         "https://docs.mattermost.com/messaging/keyboard-accessibility.html",
-    "help/settings/integration-settings":
-        "https://docs.mattermost.com/messaging/extending-messaging-with-integrations.html",
-    "help/getting-started/install-desktop-app":
+"help/messaging/attaching-files.html": 
+        "https://docs.mattermost.com/messaging/sharing-files.html",
+"help/getting-started/configuring-notifications.html":
+        "https://docs.mattermost.com/messaging/configuring-notifications.html",
+"help/getting-started/creating-teams.html": 
+	"https://docs.mattermost.com/messaging/creating-teams.html",
+"help/getting-started/install-desktop-app.html":
         "https://docs.mattermost.com/install/installing-mattermost-desktop-app.html",
-    "help/getting-started/light-install": 
+"help/messaging/emoji.html": 
+        "https://docs.mattermost.com/messaging/using-emoji.html",
+"help/messaging/executing-commands.html": 
+        "https://docs.mattermost.com/messaging/executing-slash-commands.html",
+"help/messaging/flagging-messages.html": 
+        "https://docs.mattermost.com/messaging/saving-messages.html",
+"help/messaging/formatting-text.html": 
+	"https://docs.mattermost.com/messaging/formatting-text.html",
+"help/messaging/formatting-text.html#in-line-images": 
+	"https://docs.mattermost.com/messaging/formatting-text.html#in-line-images",
+"help/getting-started/light-install.html": 
         "https://docs.mattermost.com/getting-started/light-install.html",
-    "help/settings/account-settings#link-preview": 
+"help/getting-started/log-out.html": 
+	"https://docs.mattermost.com/messaging/logging-out.html",
+"help/messaging/keyboard-shortcuts.html": 
+        "https://docs.mattermost.com/messaging/keyboard-shortcuts.html",
+"help/getting-started/managing-members.html": 
+	"https://docs.mattermost.com/messaging/managing-members.html",
+"help/messaging/mentioning-teammates.html": 
+        "https://docs.mattermost.com/messaging/mentioning-teammates.html",
+"help/getting-started/messaging-basics.html#messaging-basics": 
+	"https://docs.mattermost.com/messaging/messaging-basics.html",
+"help/getting-started/organizing.html": 
+	"https://docs.mattermost.com/messaging/organizing-channels.html",
+"help/getting-started/organizing-conversations.html": 
+	"https://docs.mattermost.com/messaging/managing-channels.html",
+"help/messaging/organizing-conversations.html": 
+	"https://docs.mattermost.com/messaging/organizing-conversations.html",
+"help/messaging/organizing-conversations.html#known-issues":
+        "https://docs.mattermost.com/messaging/organizing-conversations.html#known-issues",
+"help/getting-started/organizing-your-sidebar.html": 
+	"https://docs.mattermost.com/messaging/organizing-your-sidebar.html",
+"help/messaging/pinning-messages.html": 
+        "https://docs.mattermost.com/messaging/pinning-messages.html",
+"help/getting-started/signing-in.html": 
+	"https://docs.mattermost.com/messaging/signing-in.html",
+"help/getting-started/searching.html": 
+	"https://docs.mattermost.com/messaging/searching-in-mattermost.html",
+"help/messaging/sending-messages.html": 
+	"https://docs.mattermost.com/messaging/sending-receiving-messages.html",
+"help/getting-started/setting-your-status-availability.html":
+        "https://docs.mattermost.com/messaging/setting-your-status-availability.html",
+"help/getting-started/switch-between-teams.html": 
+	"https://docs.mattermost.com/messaging/switching-between-teams.html",
+"help/getting-started/welcome-to-mattermost.html": 
+	"https://docs.mattermost.com/guides/channels.html",
+"help/settings/account-settings.html": 
+        "https://docs.mattermost.com/messaging/manage-channels-settings.html",
+"help/settings/account-settings.html#link-preview": 
         "https://docs.mattermost.com/messaging/manage-channels-settings.html#website-link-previews",
-    "incident-collaboration/playbook-planning": 
-        "https://docs.mattermost.com/incident-collaboration/setting-up-playbooks.html",
-    "help/settings/custom-emoji": 
-        "https://docs.mattermost.com/messaging/using-emoji.html#creating-custom-emojis",
-    "help/settings/custom-emoji": "https://docs.mattermost.com/messaging/using-emoji.html#creating-custom-emojis",
-    "help/getting-started/messaging-basics#messaging-basics": "https://docs.mattermost.com/messaging/messaging-basics.html",
-    "help/messaging/formatting-text#in-line-images": "https://docs.mattermost.com/messaging/formatting-text.html#in-line-images",
-    "help/getting-started/organizing-your-sidebar": "https://docs.mattermost.com/messaging/organizing-your-sidebar.html",
-    "incident-collaboration/launching-playbooks": 
-        "https://docs.mattermost.com/incident-collaboration/running-playbooks.html",
-    "incident-collaboration/playbook-planning":
-        "https://docs.mattermost.com/incident-collaboration/setting-up-playbooks.html",
-    "incident-collaboration/launching-playbooks":
-        "https://docs.mattermost.com/incident-collaboration/running-playbooks.html",
-    "incident-collaboration/review-and-refine":
-        "https://docs.mattermost.com/incident-collaboration/refining-and-improving.html",
-    "incident-collaboration/overview": 
-        "https://docs.mattermost.com/playbooks/refining-and-improving.html",
-    "incident-collaboration/getting-started": 
+"help/settings/channel-settings.html": 
+	"https://docs.mattermost.com/messaging/channel-settings.html",
+"help/settings/custom-emoji.html": 
+        "https://docs.mattermost.com/messaging/using-custom-emoji.html",
+"help/settings/desktop-app-options.html": 
+        "https://docs.mattermost.com/messaging/managing-desktop-app-options.html",
+"help/settings/integration-settings.html":
+        "https://docs.mattermost.com/messaging/extending-messaging-with-integrations.html",
+"help/settings/manage-servers.html": 
+        "https://docs.mattermost.com/messaging/managing-desktop-app-servers.html",
+"help/settings/team-settings.html": 
+	"https://docs.mattermost.com/messaging/team-settings.html",
+"help/settings/theme-colors.html": 
+        "https://docs.mattermost.com/messaging/customizing-theme-colors.html",
+
+
+# Incident Collaboration redirects resulting from organization's branding shift from Incident Collaboration to Playbooks.
+"incident-collaboration/getting-started.html": 
         "https://docs.mattermost.com/playbooks/getting-started.html",
-    "incident-collaboration/setting-up-playbooks": 
-        "https://docs.mattermost.com/playbooks/setting-up-playbooks.html",
-    "incident-collaboration/running-playbooks": 
+"incident-collaboration/launching-playbooks.html": 
+        "https://docs.mattermost.com/incident-collaboration/running-playbooks.html",
+"incident-collaboration/overview.html": 
+        "https://docs.mattermost.com/playbooks/refining-and-improving.html",
+"incident-collaboration/playbook-planning.html": 
+        "https://docs.mattermost.com/incident-collaboration/setting-up-playbooks.html",
+"incident-collaboration/review-and-refine.html":
+        "https://docs.mattermost.com/incident-collaboration/refining-and-improving.html",
+"incident-collaboration/running-playbooks.html": 
         "https://docs.mattermost.com/playbooks/running-playbooks.html",
-    "incident-collaboration/refining-and-improving": 
+"incident-collaboration/refining-and-improving.html": 
          "https://docs.mattermost.com/playbooks/refining-and-improving.html",
-    "messaging/welcome-to-mattermost-messaging": 
-        "https://docs.mattermost.com/messaging/welcome-to-mattermost-channels.html",
-    "messaging/messaging-basics": 
-        "https://docs.mattermost.com/messaging/channels-basics.html",
-    "messaging/organizing-mattermost": 
-        "https://docs.mattermost.com/messaging/organizing-channels.html",
-    "messaging/extending-messaging-with-integrations": 
-        "https://docs.mattermost.com/messaging/extending-channels-with-integrations.html",
-    "messaging/switching-between-teams": "https://docs.mattermost.com/messaging/navigating-between-teams.html",
-    "incident-collaboration/refining-and-improving":
-         "https://docs.mattermost.com/playbooks/refining-and-improving.html",
-    "install/requirements": 
-        "https://docs.mattermost.com/install/software-hardware-requirements.html",
-    "install/install-ubuntu-2004": 
-        "https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html",
-    "install/install-ubuntu-1804": 
-        "https://docs.mattermost.com/install/installing-ubuntu-1804-LTS.html",
-    "install/mattermost-omnibus": 
-        "https://docs.mattermost.com/install/installing-mattermost-omnibus.html",
-    "install/sockets-db": 
-        "https://docs.mattermost.com/install/setting-up-socket-based-mattermost-database.html",
-    "install/ee-install":
-        "https://docs.mattermost.com/install/enterprise-install-upgrade.html",
-    "install/transport-encryption/config": "https://docs.mattermost.com/install/transport-encryption.html",
-    "install/transport-encryption/config-mattermost":
-        "https://docs.mattermost.com/install/proxy-to-mattermost-transport-encryption.html",
-    "install/transport-encryption/config-database":
-        "https://docs.mattermost.com/install/database-transport-encryption.html",
-    "install/transport-encryption/config-cluster":
-        "https://docs.mattermost.com/install/cluster-transport-encryption.html",
-    "install/deploy-bitnami": "https://docs.mattermost.com/install/deploying-team-edition-on-bitnami.html",
-    "install/docker-local-machine": "https://docs.mattermost.com/install/setting-up-local-machine-using-docker.html",
-    "install/docker-ebs": "https://docs.mattermost.com/install/setting-up-aws-elastic-beanstalk-docker.html",
-    "install/install-mmte-helm-gitlab-helm":
-        "https://docs.mattermost.com/install/installing-team-edition-helm-chart.html",
-    "install/desktop": "https://docs.mattermost.com/install/desktop-app-install.html",
-    "install/desktop-managed-resources": 
-        "https://docs.mattermost.com/install/desktop-app-managed-resources.html",
-    "install/desktop-msi-gpo":
-        "https://docs.mattermost.com/install/desktop-msi-installer-and-group-policy-install.html",
-    "install/smtp-email-setup": 
-        "https://docs.mattermost.com/configure/smtp-email.html",
-    "install/config-cloudfront":
+"incident-collaboration/setting-up-playbooks.html": 
+        "https://docs.mattermost.com/playbooks/setting-up-playbooks.html",
+
+
+# Install redirects
+"install/config-cloudfront.html":
         "https://docs.mattermost.com/configure/configuring-cloudfront-to-host-mattermost-static-assets.html",
-    "install/outbound-proxy": 
-        "https://docs.mattermost.com/configure/using-outbound-proxy.html",
-    "install/i18n": 
-        "https://docs.mattermost.com/configure/enabling-chinese-japanese-korean-search.html",
-    "install/config-apache2": 
+"install/config-apache2.html": 
         "https://docs.mattermost.com/configure/configuring-apache2.html",
-    "integrations/jira": 
+"install/deploy-bitnami.html": 
+        "https://docs.mattermost.com/install/deploying-team-edition-on-bitnami.html",
+"install/desktop.html": 
+        "https://docs.mattermost.com/install/desktop-app-install.html",
+"install/desktop-managed-resources.html": 
+        "https://docs.mattermost.com/install/desktop-app-managed-resources.html",
+"install/desktop-msi-gpo.html":
+        "https://docs.mattermost.com/install/desktop-msi-installer-and-group-policy-install.html",
+"install/docker-ebs.html": 
+        "https://docs.mattermost.com/install/setting-up-aws-elastic-beanstalk-docker.html",
+"install/docker-local-machine.html": 
+        "https://docs.mattermost.com/install/setting-up-local-machine-using-docker.html",
+"install/ee-install.html": 
+        "https://docs.mattermost.com/install/enterprise-install-upgrade.html",
+"install/enterprise-install-upgrade.html#changing-a-license-key": 
+	"https://docs.mattermost.com/upgrade/installing-license-key.html",
+"install/i18n.html": 
+	"https://docs.mattermost.com/configure/enabling-chinese-japanese-korean-search.html",
+"install/install-ubuntu-1804.html": 
+        "https://docs.mattermost.com/install/installing-ubuntu-1804-LTS.html",
+"install/install-ubuntu-2004.html": 
+        "https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html",
+"install/install-mmte-helm-gitlab-helm.html":
+        "https://docs.mattermost.com/install/installing-team-edition-helm-chart.html",
+"install/mattermost-omnibus.html": 
+        "https://docs.mattermost.com/install/installing-mattermost-omnibus.html",
+"install/outbound-proxy.html": 
+        "https://docs.mattermost.com/configure/using-outbound-proxy.html",
+"install/prod-docker.html": 
+	"https://forum.mattermost.org/t/deploy-mattermost-on-docker/12231",
+"install/prod-windows-2012.html": 
+	"https://forum.mattermost.org/t/production-install-on-windows-server/12232",
+"install/requirements.html": 
+        "https://docs.mattermost.com/install/software-hardware-requirements.html",
+"install/sockets-db.html": 
+        "https://docs.mattermost.com/install/setting-up-socket-based-mattermost-database.html",
+"install/smtp-email-setup.html": 
+        "https://docs.mattermost.com/configure/smtp-email.html",
+"install/transport-encryption/config.html": 
+        "https://docs.mattermost.com/install/transport-encryption.html",
+"install/transport-encryption/config-cluster.html":
+        "https://docs.mattermost.com/install/cluster-transport-encryption.html",
+"install/transport-encryption/config-database.html":
+        "https://docs.mattermost.com/install/database-transport-encryption.html",
+"install/transport-encryption/config-mattermost.html":
+        "https://docs.mattermost.com/install/proxy-to-mattermost-transport-encryption.html",
+
+
+# Integrations redirects.
+# Important Note: The integrations directory and its contents are scheduled to be archived by FY23 Q2 since all applicable content has been moved from docs.mm.com to developers.mm.com.
+"integrations/jira.html": 
         "https://mattermost.gitbook.io/plugin-jira/",
-    "integrations/zoom":
+"integrations/net-promoter-score.html": 
+        "https://docs.mattermost.com/manage/user-satisfaction-surveys.html",
+"integrations/zoom.html": 
         "https://mattermost.gitbook.io/plugin-zoom/",
-    "install/outbound-proxy": "https://docs.mattermost.com/configure/using-outbound-proxy.html",
-    "install/i18n": "https://docs.mattermost.com/configure/enabling-chinese-japanese-korean-search.html",
-    "install/config-apache2": "https://docs.mattermost.com/configure/configuring-apache2.html",
-    "install/prod-docker": "https://forum.mattermost.org/t/deploy-mattermost-on-docker/12231",
-    "install/enterprise-install-upgrade#changing-a-license-key": "https://docs.mattermost.com/upgrade/installing-license-key.html",
-    "integrations/jira": "https://mattermost.gitbook.io/plugin-jira/",
-    "integrations/zoom": "https://mattermost.gitbook.io/plugin-zoom/",
-    "integrations/net-promoter-score": "https://docs.mattermost.com/manage/user-satisfaction-surveys.html",
-    "mobile/mobile-overview#use-an-emm-provider-with-managed-app-configuration":
-        "https://docs.mattermost.com/deploy/deploy-mobile-apps-using-emm-provider.html",
-    "mobile/mobile-hpns": "https://docs.mattermost.com/deploy/mobile-hpns.html",
-    "mobile/mobile-faq#how-do-push-notifications-work":
+
+
+
+# Messaging redirects
+# Important Note: More redirects will be added in FY23 Q1/Q2 when the messages directory is migrated to channels to align with branding.
+"messaging/accessing-your-workspace.html": 
+	"https://docs.mattermost.com/messaging/signing-in.html",
+"messaging/channel-settings.html": 
+	"https://docs.mattermost.com/messaging/channel-preferences.html",
+"messaging/extending-messaging-with-integrations.html": 
+        "https://docs.mattermost.com/messaging/extending-channels-with-integrations.html",
+"messaging/managing-account-settings.html": 
+	"https://docs.mattermost.com/messaging/manage-channels-settings.html",
+"messaging/messaging-basics.html": 
+        "https://docs.mattermost.com/messaging/channels-basics.html",
+"messaging/organizing-mattermost.html": 
+        "https://docs.mattermost.com/messaging/organizing-channels.html",
+"messaging/switching-between-teams.html": 
+	"https://docs.mattermost.com/messaging/navigating-between-teams.html",
+"messaging/welcome-to-mattermost-messaging.html": 
+	"https://docs.mattermost.com/guides/channels.html",
+
+
+# Mobile redirects resulting from the June 2021 docs reorganization project.
+"mobile/deploy-mobile-apps-using-emm-provider.html": 
+	"https://docs.mattermost.com/deploy/deploy-mobile-apps-using-emm-provider.html",
+"mobile/mobile-faq#how-do-push-notifications-work.html":
         "https://docs.mattermost.com/deploy/mobile-faq.html#how-do-push-notifications-work",
-    "mobile/mobile-testing-notifications": "https://docs.mattermost.com/deploy/mobile-testing-notifications.html",
-    "mobile/deploy-mobile-apps-using-emm-provider": "https://docs.mattermost.com/deploy/deploy-mobile-apps-using-emm-provider.html",
-    "mobile/mobile-overview": "https://docs.mattermost.com/deploy/mobile-overview.html",
-    "onboard/ad-ldap#active-directory-ldap-setup-e10-e20": 
+"mobile/mobile-hpns.html": 
+	"https://docs.mattermost.com/deploy/mobile-hpns.html",
+"mobile/mobile-overview.html": 
+	"https://docs.mattermost.com/deploy/mobile-overview.html",
+"mobile/mobile-overview.html#use-an-emm-provider-with-managed-app-configuration":
+        "https://docs.mattermost.com/deploy/deploy-mobile-apps-using-emm-provider.html",
+"mobile/mobile-testing-notifications.html": 
+	"https://docs.mattermost.com/deploy/mobile-testing-notifications.html",
+
+
+# Onboard redirects
+"onboard/ad-ldap.html#active-directory-ldap-setup-e10-e20": 
         "https://docs.mattermost.com/onboard/ad-ldap.html#active-directory-ldap-setup",
-    "overview/security": "https://docs.mattermost.com/about/security.html",
-    "overview/integrations": "https://docs.mattermost.com/about/integrations.html",
-    "overview/auth": "https://docs.mattermost.com/about/corporate-directory-integration.html",
-    "overview/compliance": "https://docs.mattermost.com/about/certifications-and-compliance.html",
-    "overview/faq": "https://docs.mattermost.com/about/frequently-asked-questions.html",
-    "overview/architecture": "https://docs.mattermost.com/getting-started/architecture-overview.html",
-    "overview/architecture#database-with-vips":
+
+
+# Overview redirects
+"overview/architecture.html": 
+        "https://docs.mattermost.com/getting-started/architecture-overview.html",
+"overview/architecture#database-with-vips.html":
         "https://docs.mattermost.com/getting-started/architecture-overview.html#database-with-vips",
-    "overview/architecture#reference-architectures":
+"overview/architecture#reference-architectures.html":
         "https://docs.mattermost.com/getting-started/architecture-overview.html#reference-architectures",
-    "process/help-wanted": "https://handbook.mattermost.com/contributors/contributors/help-wanted",
-    "process/help-wanted": "https://handbook.mattermost.com/contributors/contributors/ways-to-contribute/help-wanted",
-    "process/sg_rest_markup":
-        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
-    "process/security-release":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/security-release",
-    "process/community-overview": "https://handbook.mattermost.com/contributors/contributors/community",
-    "process/handbook": "https://handbook.mattermost.com/company/about-mattermost",
-    "process/release-faq":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-overview",
-    "process/release-tips":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-tips",
-    "process/sg_general-guidelines":
-        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
-    "process/community-guidelines":
-        "https://handbook.mattermost.com/contributors/contributors/community-playbook/",
-    "process/feature-release":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/feature-release",
-    "process/security": "https://handbook.mattermost.com/operations/operations/company-policies/security-policies",
-    "process/engineer-expectations":
-        "https://handbook.mattermost.com/operations/workplace/people/working-at-mattermost/onboarding/engineer-onboarding",
-    "process/product-manager-hiring":
-        "https://handbook.mattermost.com/contributors/join-us/recruiting-cadences/product-manager-hiring",
-    "process/new-bug-tickets":
-        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/new-bug-tickets",
-    "process/sg_grammar-spelling-mechanics":
-        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
-    "process/sg_document-structure":
-        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
-    "process/release-scorecard-definitions":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-scorecard-definitions",
-    "process/software-requirements":
-        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/software-requirements",
-    "process/mobile-release-process":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/mobile-release",
-    "process/documentation-UItext-guidelines":
-        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/user-interface-text-guidelines",
-    "process/bug-fix-release":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/bug-fix-release",
-    "process/deprecated-features":
-        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/deprecated-features",
-    "process/dot-release":
-        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/dot-release",
-    "process/end-user-documentation":
-        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
-    "process/bug-severity-guidelines":
-        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/new-bug-tickets/bug-severity-guidelines",
-    "process/accepting-pull-request":
+"overview/auth.html": 
+        "https://docs.mattermost.com/about/corporate-directory-integration.html",
+"overview/compliance.html": 
+        "https://docs.mattermost.com/about/certifications-and-compliance.html",
+"overview/faq.html": 
+        "https://docs.mattermost.com/about/frequently-asked-questions.html",
+"overview/integrations.html": 
+        "https://docs.mattermost.com/about/integrations.html",
+"overview/license-and-subscription.html": 
+        "https://docs.mattermost.com/about/subscription.html",
+"overview/license-and-subscription.html#frequently-asked-questions": 
+        "https://docs.mattermost.com/about/subscription.html#frequently-asked-questions",
+"overview/product.html": 
+	"https://docs.mattermost.com/about/product.html",
+"overview/product#mattermost-enterprise-edition-e10.html": 
+        "https://docs.mattermost.com/about/product.html#mattermost-enterprise-edition",
+"overview/security.html": 
+        "https://docs.mattermost.com/about/security.html",
+
+
+# Process redirects
+# Important Note: The process directory and its contents are scheduled to be archived by FY23 Q2 since all applicable content has been moved from docs.mm.com to handbook.mm.com.
+"process/accepting-pull-request.html":
         "https://handbook.mattermost.com/contributors/contributors/help-wanted",
-    "process/pm-faq":
-        "https://handbook.mattermost.com/operations/research-and-development/product/product-management-team-handbook#frequently-asked-questions-faq",
-    "process/product-manager":
-        "https://handbook.mattermost.com/contributors/join-us/staff-recruiting/product-manager-hiring",
-    "process/partner-programs":
-        "https://handbook.mattermost.com/operations/sales/partner-programs",
-    "process/overview":
+"process/bug-fix-release.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/bug-fix-release",
+"process/bug-severity-guidelines.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/new-bug-tickets/bug-severity-guidelines",
+"process/community-guidelines.html":
+        "https://handbook.mattermost.com/contributors/contributors/community-playbook/",
+"process/community-overview.html": 
+	"https://handbook.mattermost.com/contributors/contributors/community",
+"process/deprecated-features.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/deprecated-features",
+"process/documentation-UItext-guidelines.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/user-interface-text-guidelines",
+"process/dot-release.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/dot-release",
+"process/engineer-expectations.html":
+        "https://handbook.mattermost.com/operations/workplace/people/working-at-mattermost/onboarding/engineer-onboarding",
+"process/end-user-documentation.html":
+        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
+"process/feature-release.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/feature-release",
+"process/handbook.html": 
+	"https://handbook.mattermost.com/company/about-mattermost",
+"process/help-wanted.html": 
+	"https://handbook.mattermost.com/contributors/contributors/ways-to-contribute/help-wanted",
+"process/mobile-release-process.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/mobile-release",
+"process/new-bug-tickets.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/new-bug-tickets",
+"process/overview.html":
         "https://handbook.mattermost.com/operations/research-and-development/product/development-process",
-    "mobile/mobile-hpns": "https://docs.mattermost.com/deploy/mobile-hpns.html",
-    "guides/install-deploy-upgrade-scale": "https://docs.mattermost.com/guides/deployment.html",
-    "guides/setup-onboard-manage-comply": "https://docs.mattermost.com/guides/administration.html",
-    "messaging/welcome-to-mattermost-messaging": "https://docs.mattermost.com/overview/index.html",
-    "messaging/accessing-your-workspace": "https://docs.mattermost.com/messaging/signing-in.html",
-    "messaging/managing-account-settings": "https://docs.mattermost.com/messaging/manage-channels-settings.html",
-    "messaging/channel-settings": "https://docs.mattermost.com/messaging/channel-preferences.html",
-    "guides/messaging": "https://docs.mattermost.com/guides/channels.html",
-    "focalboard/installing-boards": "https://docs.mattermost.com/guides/boards.html",
-    "about/license-and-subscription#do-you-have-a-program-for-official-non-profits-open-source-projects-and-charities": 
-        "https://docs.mattermost.com/about/subscription.html#do-you-have-a-program-for-official-non-profits-open-source-projects-and-charities",
-    "configure/configuring-apache2.html": "https://forum.mattermost.org/c/docs/37"
+"process/partner-programs.html":
+        "https://handbook.mattermost.com/operations/sales/partner-programs",
+"process/pm-faq.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/product-management-team-handbook#frequently-asked-questions-faq",
+"process/product-manager.html":
+        "https://handbook.mattermost.com/contributors/join-us/staff-recruiting/product-manager-hiring",
+"process/product-manager-hiring.html":
+        "https://handbook.mattermost.com/contributors/join-us/recruiting-cadences/product-manager-hiring",
+"process/release-faq.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-overview",
+"process/release-scorecard-definitions.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-scorecard-definitions",
+"process/release-tips.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-tips",
+"process/security.html": 
+	"https://handbook.mattermost.com/operations/operations/company-policies/security-policies",
+"process/security-release.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/release-process/security-release",
+"process/sg_document-structure.html":
+        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
+"process/sg_general-guidelines.html":
+        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
+"process/sg_grammar-spelling-mechanics.html":
+        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
+"process/sg_rest_markup.html":
+        "https://handbook.mattermost.com/operations/operations/company-processes/publishing/publishing-guidelines/voice-tone-and-writing-style-guidelines/documentation-style-guide#document-structure",
+"process/software-requirements.html":
+        "https://handbook.mattermost.com/operations/research-and-development/product/development-process/software-requirements"
+
+# End of redirects. The last redirect above should NOT end in a comma.
+
 }
 
 # The master toctree document.


### PR DESCRIPTION
The list of redirects for docs.mattermost.com were becoming difficult to manage and maintain, contained duplicate entires causing issues, and entries were no longer in a format the web server could interpret and return correctly. Any redirect missing the file extension HTML in the origin path was taking users to the home page rather than the expected destination page.

This PR:
- cleans up the redirects list
- removes duplicate entries
- adds the missing file extension for all origin URLs required by the web server
- organizes all redirects alphabetically based on the origin URL path
- introduces inline code comments to provide guidance for future contributors looking to add new redirects or manage existing redirects

Existing redirects have been randomly tested locally to ensure they continue to redirect as expected.