### PR TITLE
Redirect filename fix

### DIFF
--- a/extensions/reredirects/__init__.py
+++ b/extensions/reredirects/__init__.py
@@ -190,7 +190,9 @@ class Reredirects:
         """
         for doc, target in status_iterator(to_be_redirected, 'writing redirects...', 'darkgreen',
                                            len(to_be_redirected.items())):
-            redirect_file_abs = Path(self.app.outdir).joinpath(doc).with_suffix(".html")
+            if not str(doc).endswith(".html"):
+                doc += ".html"
+            redirect_file_abs = Path(self.app.outdir).joinpath(doc)
             self._create_redirect_file(redirect_file_abs, target)
 
     @staticmethod

--- a/source/conf.py
+++ b/source/conf.py
@@ -72,7 +72,7 @@ redirects = {
 # Ensure that all redirects end in a comma, except for the very last redirect.
 
 # About redirects
-"about/license-and-subscription.html#do-you-have-a-program-for-official-non-profits-open-source-projects-and-charities.": 
+"about/license-and-subscription.html#do-you-have-a-program-for-official-non-profits-open-source-projects-and-charities": 
     "https://docs.mattermost.com/about/subscription.html#do-you-have-a-program-for-official-non-profits-open-source-projects-and-charities",
 
 # Administration redirects resulting from the June 2021 docs reorganization project.
@@ -201,7 +201,7 @@ redirects = {
 "administration/config-settings.html#aggregate-search-indexes":
         "https://docs.mattermost.com/configure/configuration-settings.html#aggregate-search-indexes",
 "administration/config-settings.html#allow-users-to-view-archived-channels-beta":
-        "https://docs.mattermost.com/configure/config-settings.html#allow-users-to-view-archived-channels",
+        "https://docs.mattermost.com/configure/configuration-settings.html#allow-users-to-view-archived-channels",
 "administration/config-settings.html#autoclose-direct-messages-in-sidebar-experimental":
         "https://docs.mattermost.com/configure/configuration-settings.html#autoclose-direct-messages-in-sidebar-experimental",
 "administration/config-settings.html#ad-ldap": 


### PR DESCRIPTION
Replaced code that determined the redirect filename and stripped everything after the first occurrence of `.html`. This code has been replaced with a simpler version that checks whether the entire filename already ends in `.html`; if it doesn't, it appends `.html` to the end of the file. Big shoutout to @neflyte for assisting with this fix.