### PR TITLE
Correct socked based db creation

### DIFF
--- a/source/install/setting-up-socket-based-mattermost-database.rst
+++ b/source/install/setting-up-socket-based-mattermost-database.rst
@@ -84,7 +84,7 @@ With Unix socket
 
   .. code-block:: bash
 
-     sudo -u postgres createuser mattermost
+     sudo -u postgres createdb -O mattermost mattermostdb
 
 - Setup the Unix socket by adding the following line to ``/var/lib/postgres/data/pg_hba.conf``:
 
@@ -98,7 +98,7 @@ With Unix socket
 
   .. code-block:: bash
 
-     sudo -u mattermost psql --dbname=mattermostdb --username=mattermost
+     sudo -u mattermost psql --dbname=mattermostdb
 
 
 Configuring Mattermost


### PR DESCRIPTION
Code labeled "create the database" was actually just a copy/paste of the
"create a user" blob. This is the actual createdb command including
setting the owner of the database to the right user.

Additionally the test code to connect to it does not need (and even
should not have) the username. The example uses peer authentication and
if it is going to work from the mattermost daemon it needs to work
without specifying the user based on the system user ID.
