### PR TITLE
Fix http links pointing to mm.com uploads

### DIFF
--- a/source/archive/cloud-integrations.rst
+++ b/source/archive/cloud-integrations.rst
@@ -53,7 +53,7 @@ See `developer documentation <https://developers.mattermost.com/integrate/incomi
   payload={
     "channel": "town-square",
     "username": "test-automation",
-    "icon_url": "http://mattermost.com/wp-content/uploads/2022/02/icon.png",
+    "icon_url": "https://mattermost.com/wp-content/uploads/2022/02/icon.png",
     "text": "#### Test results for July 27th, 2017\n<!channel> please review failed tests.\n
     | Component  | Tests Run   | Tests Failed                                   |
     |:-----------|:-----------:|:-----------------------------------------------|

--- a/source/samples/actiance_export.xml
+++ b/source/samples/actiance_export.xml
@@ -3524,7 +3524,7 @@
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
       <DateTimeUTC>1538657668936</DateTimeUTC>
-      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)&#xA;</Content>
+      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)&#xA;</Content>
     </Message>
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
@@ -3539,7 +3539,7 @@
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
       <DateTimeUTC>1538657731934</DateTimeUTC>
-      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
@@ -3549,7 +3549,7 @@
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
       <DateTimeUTC>1538657774930</DateTimeUTC>
-      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
@@ -3559,7 +3559,7 @@
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
       <DateTimeUTC>1538657795230</DateTimeUTC>
-      <Content> ## I *meant* to link to [this](http://example.com) ::man_facepalming: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content> ## I *meant* to link to [this](http://example.com) ::man_facepalming: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>sudheer.105@mattermost.com</LoginName>
@@ -5631,12 +5631,12 @@
     <Message>
       <LoginName>linda+8oct18@mattermost.com</LoginName>
       <DateTimeUTC>1538521172841</DateTimeUTC>
-      <Content>![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>linda+8oct18@mattermost.com</LoginName>
       <DateTimeUTC>1538521177380</DateTimeUTC>
-      <Content>![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <ParticipantLeft>
       <LoginName>linda+0000@mattermost.com</LoginName>
@@ -10657,7 +10657,7 @@
     <Message>
       <LoginName>bot@mattermost.com</LoginName>
       <DateTimeUTC>1536261689430</DateTimeUTC>
-      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content> ## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>bot@mattermost.com</LoginName>
@@ -10777,7 +10777,7 @@
     <Message>
       <LoginName>dylan+05072018-a@mattermost.com</LoginName>
       <DateTimeUTC>1536267834756</DateTimeUTC>
-      <Content>## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>dylan+05072018-a@mattermost.com</LoginName>
@@ -14372,7 +14372,7 @@
     <Message>
       <LoginName>george+43@mattermost.com</LoginName>
       <DateTimeUTC>1536248645622</DateTimeUTC>
-      <Content>## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>george+43@mattermost.com</LoginName>
@@ -23606,7 +23606,7 @@
     <Message>
       <LoginName>dylan+05072018-a@mattermost.com</LoginName>
       <DateTimeUTC>1536267983005</DateTimeUTC>
-      <Content>## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>## I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>dylan+05072018-a@mattermost.com</LoginName>
@@ -24786,27 +24786,27 @@
     <Message>
       <LoginName>lindsay+a@mattermost.com</LoginName>
       <DateTimeUTC>1536185720231</DateTimeUTC>
-      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>lindsay+a@mattermost.com</LoginName>
       <DateTimeUTC>1536185733950</DateTimeUTC>
-      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>lindsay+a@mattermost.com</LoginName>
       <DateTimeUTC>1536185760952</DateTimeUTC>
-      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>lindsay+a@mattermost.com</LoginName>
       <DateTimeUTC>1536185769403</DateTimeUTC>
-      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>lindsay+a@mattermost.com</LoginName>
       <DateTimeUTC>1536185800265</DateTimeUTC>
-      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](http://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
+      <Content>That&#39;s great! I *meant* to link to [this](http://example.com) :facepalm: ![Mattermost](https://mattermost.com/wp-content/uploads/2022/02/logoHorizontal.png)</Content>
     </Message>
     <Message>
       <LoginName>lindsay@mattermost.com</LoginName>


### PR DESCRIPTION
Replacing http links with secure https replacements. URLs point to images on mattermost.com.

cc @cwarnermm 

TY!