### PR TITLE
[GH-5449] Add Step to see 'import process' status

### DIFF
--- a/source/onboard/migrating-to-mattermost.rst
+++ b/source/onboard/migrating-to-mattermost.rst
@@ -202,16 +202,22 @@ Run this command to list the available imports:
 
     mmctl import list available
 
-Finally, run this command to process the import. Replace ``<IMPORT FILE NAME>`` with the name you got from the ``mmctl import list available`` command:
+Run this command to process the import. Replace ``<IMPORT FILE NAME>`` with the name you got from the ``mmctl import list available`` command:
 
 .. code:: bash
 
-    mmctl import process <IMPORT FILE NAME>    
+    mmctl import process <IMPORT FILE NAME>
+    
+Finally, run this command to view the status of the import process job. If the job status shows as ``pending``, then wait before running the command again. The ``--json`` flag is required to view the possible error message. Replace ``<JOB ID>`` with the id you got from the ``mmctl import list process`` command:
+
+.. code:: bash
+
+    mmctl import job show <JOB ID> --json
 
 Debugging Imports
 -----------------
 
-If you run into problems your best bet is to use the ``mattermost bulk import`` command, since the ``mmctl`` import process does not give you any debugging information, even in the Mattermost server logs.
+The ``mmctl import job show`` shows a detailed error message. If you run into problems which the error message does not help to resolve, your best bet is to use the ``mattermost bulk import`` command. The ``mmctl`` import process does not give you any additional debugging information, even in the Mattermost server logs.
 
 Migrating from Slack using the Mattermost Web App
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
The **Migrating from Slack** section is improved with one new step to view the status `mmctl import process` job. This extra step allows the user to determine success/error of the slack migration import before returning to the webapp. If there was an error message, it is shown to assist debugging.

Tested with:
1) Ubuntu 20.04 developer environment. release-6.4 
2) Ubuntu 20.04 self hosted. release-6.4

#### Ticket Link
Fixes #5449

