### PR TITLE
Add Team Sidebar BG as customizable theme element

### DIFF
--- a/source/welcome/customize-your-theme.rst
+++ b/source/welcome/customize-your-theme.rst
@@ -64,6 +64,8 @@ Sidebar Text
   	Text color of read channels in the Channels pane, and tabs in the Account and Team settings navigation sidebar.
 Sidebar Header BG
  	Background color of the header above the Channels pane and all dialog window headers.
+Team Sidebar BG
+	Background color of the Global Header (available from Mattermost v6.0).
 Sidebar Header Text
  	Text color of the header above the Channels pane and all dialog window headers.
 Sidebar Unread Text


### PR DESCRIPTION
The Global Header was introduced in Mattermost v6.0, and users can customize its background color in Mattermost via **Settings > Display**.
- Updated Mattermost theme customization documentation to expose this element as a customizable element.
- Standard theme code examples include this customizable element already.
- In the product documentation, go to **Welcome to Mattermost > Customize your Mattermost experience > Customize your Mattermost theme > Standard themes > Sidebar styles** to see the **Team Sidebar BG** option added to docs.
