### PR TITLE
Update software-hardware-requirements for new migration system with the mysql permission scope

### DIFF
--- a/source/install/software-hardware-requirements.rst
+++ b/source/install/software-hardware-requirements.rst
@@ -127,7 +127,7 @@ Search limitations on MySQL:
 
 - Hashtags or recent mentions of usernames containing a dot do not return search results.
 
-For Mattermost v6.4+:
+From Mattermost v6.4:
 
 The new migration system requires the MySQL database user to have additional `EXECUTE`, `CREATE ROUTINE`, `ALTER ROUTINE` and `REFERENCES` privileges to run schema migrations.
 


### PR DESCRIPTION

#### Summary
The new schema migration system (Introduced after `v6.4.0`) requires MySQL user to have additional privileges in addition to existing one.

