### PR TITLE
Removed invite tip

### DIFF
--- a/source/welcome/manage-custom-groups.rst
+++ b/source/welcome/manage-custom-groups.rst
@@ -27,10 +27,6 @@ Custom Groups (Beta) enables Mattermost users to create and manage custom user g
 
 When you mention a custom group, you’ll notify everyone in the group without having to mention members individually. You can mention a group's unique name the same way you @mention another Mattermost member. See the `Mention People in Messages <https://docs.mattermost.com/channels/mention-people.html>`__ documentation for details.
 
-.. tip::
-
-  Custom groups can also be used with the ``/invite`` slash command to quickly invite a group of users to a channel. 
-
 Custom groups reduce noise and improve focus by notifying the right people in a channel at the right time, while maintaining transparency for all members in that channel. For example, perhaps you want to @mention a cross-functional team about a bug fixes needed for an upcoming feature release, without notifying everyone else in the channel. Using a custom group notifies the cross-functional team immediately, while keeping important stakeholders in the loop on the status of the feature release.
 
 .. note:: 


### PR DESCRIPTION
The ability to invite members of a custom user group via the ``/invite`` slash command is not supported. Removed the tip featuring this use case.