### PR TITLE
Documented mmctl dependencies

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -6335,9 +6335,6 @@ This setting isn't available in the System Console and can only be set in ``conf
 
 **False**: The API endpoint cannot be called. Note that ``api/v4/teams/{teamid}`` can still be used to soft delete a team.
 
-.. note::
-  mmctl local mode ignores this setting and behaves as though ``EnableAPITeamDeletion`` is set to ``true``.
-
 +-------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableAPITeamDeletion": false`` with options ``true`` and ``false``. |
 +-------------------------------------------------------------------------------------------------------------------+
@@ -6356,9 +6353,6 @@ This setting isn't available in the System Console and can only be set in ``conf
 +-------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableAPIUserDeletion": false`` with options ``true`` and ``false``. |
 +-------------------------------------------------------------------------------------------------------------------+
-
-.. note::
-  mmctl local mode ignores this setting and behaves as though ``EnableAPIUserDeletion`` is set to ``true``.
 
 Enable API Channel Deletion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -5009,6 +5009,9 @@ mmctl team delete
 
 Permanently delete a team along with all related information including posts from the database.
 
+.. note::
+   Requires the `Enable API Team Deletion <https://docs.mattermost.com/configure/configuration-settings.html#enable-api-team-deletion>`__ configuration setting to be enabled. If this configuration setting is disabled, attempting to delete the team using mmctl fails.
+
 **Format**
 
 .. code-block:: sh
@@ -5764,7 +5767,10 @@ mmctl user delete
 
 **Description**
 
-Permanently delete users along with all related information including posts from the database.
+Permanently delete users along with all related information including posts from the database. 
+
+.. note::
+   Requires the `Enable API User Deletion <https://docs.mattermost.com/configure/configuration-settings.html#enable-api-user-deletion>`__ configuration setting to be enabled. If this configuration setting is disabled, attempting to delete the user using mmctl fails.
 
 **Format**
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/docs/issues/5466
- Updated mmctl user delete documentation to clarify that Enable API User Deletion config setting must be enabled. Removed note in configuration setting documentation about local mode ignoring this setting.
- Updated mmctl team delete documentation to clarify that Enable API Team Deletion config setting must be enabled. Removed note in configuration setting documentation about local mode ignoring this setting. 