### PR TITLE
Clarified standard vs advanced logging scope

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -1631,7 +1631,7 @@ Access the following configuration settings in the System Console by going to **
 
 .. note::
 
-  Standard logging in Mattermost supports the ability to output logs to the console and file targets. Mattermost Enterprise customers can specify additional log target types, such as TCP configuration options using Audit log v2. See the `Audit log v2 <https://docs.mattermost.com/comply/audit-log.html>`__ documentation and the `Advanced audit logging configuration <https://docs.mattermost.com/configure/configuration-settings.html#advanced-audit-logging-configuration>`__ documentation for additional details.
+  Standard logging in Mattermost supports the ability to output logs to the console and file targets. Mattermost Enterprise customers can specify additional log target types, such as TCP configuration options using audit log v2. See the `audit log v2 <https://docs.mattermost.com/comply/audit-log.html>`__ documentation and the `advanced audit logging configuration <https://docs.mattermost.com/configure/configuration-settings.html#advanced-audit-logging-configuration>`__ documentation for additional details.
 
 Output logs to console
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -1629,6 +1629,10 @@ Standard Logging
 
 Access the following configuration settings in the System Console by going to **Environment > Logging**.
 
+.. note::
+
+  Standard logging in Mattermost supports the ability to output logs to the console and file targets. Mattermost Enterprise customers can specify additional log target types, such as TCP configuration options using Audit log v2. See the `Audit log v2 <https://docs.mattermost.com/comply/audit-log.html>`__ documentation and the `Advanced audit logging configuration <https://docs.mattermost.com/configure/configuration-settings.html#advanced-audit-logging-configuration>`__ documentation for additional details.
+
 Output logs to console
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Added a note to the Standard logging configuration setting documentation based on community feedback that docs weren't clear about plans and logging functionality.
- clarify the scope of standard logging versus advanced logging
- provide links to the advanced logging config settings & Audit Log V2 documentation