### PR TITLE
Updated mmctl channel delete requirements

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -6375,9 +6375,6 @@ This setting isn't available in the System Console and can only be set in ``conf
 | This feature's ``config.json`` setting is ``"EnableAPIChannelDeletion": false`` with options ``true`` and ``false``. |
 +----------------------------------------------------------------------------------------------------------------------+
 
-.. note::
-  mmctl local mode ignores this setting and behaves as though ``EnableAPIChannelDeletion`` is set to ``true``.
-
 Enable OpenTracing
 ^^^^^^^^^^^^^^^^^^^
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -992,6 +992,9 @@ mmctl channel delete
 
 Permanently delete channels along with all related information including posts from the database.
 
+.. note::
+   Requires the `Enable API Channel Deletion <https://docs.mattermost.com/configure/configuration-settings.html#enable-api-channel-deletion>`__ configuration setting to be enabled. If this configuration setting is disabled, attempting to delete the channel using mmctl fails.
+
 **Format**
 
 .. code-block:: sh


### PR DESCRIPTION
Updated mmctl channel delete documentation to clarify that Enable API Channel Deletion config setting must be enabled. Removed note in configuration setting documentation about local mode ignoring this setting.

Update for issue https://github.com/mattermost/docs/issues/5466

