### PR TITLE
Add guests and active to user filters

### DIFF
--- a/source/welcome/about-user-roles.rst
+++ b/source/welcome/about-user-roles.rst
@@ -34,7 +34,7 @@ The System Admin is typically a member of the IT staff and has all the privilege
 - Ability to deactivate user accounts and to reactivate them.
 - Access to private channels, but only if given the link to the private channel.
 
-A System Admin can view and manage users in **System Console > Users**. They can search users by name, filter users by teams, and filter to view other System Admins, guests, as well as active and inactive users.
+A System Admin can view and manage users in **System Console > User Management > Users**. They can search users by name, filter users by teams, and filter to view other System Admins, guests, as well as active and inactive users.
 
 Team Admin
 ----------


### PR DESCRIPTION
Updated User Roles documentation to note that System Admins can filter the list of users by additional attributes including guests and active users.