### PR TITLE
Incorporated payload descriptions

### DIFF
--- a/source/deploy/mobile-faq.rst
+++ b/source/deploy/mobile-faq.rst
@@ -117,6 +117,14 @@ The following payload shows an example of the json that is transmitted to the pu
         "is_id_loaded": true
     }
 
+where the following definitions are applied:
+
+- ``ack_id``: An ephemeral identifier generated per notification that determines whether the notification sent was received by the device (using same method that generates identifiers to the rest of the models in the server). This information is available in the ``notifications.log`` file on the Mattermost server. The ``ack_id`` is only used for receipt delivery from the mobile app to the Mattermost server to confirm whether the notification sent was received. 
+- ``server_id``: A server identifier created on the server, called ``DiagnosticId``. In the future, this value will be used in the mobile app (for multi-server support) to identify which server the notification belongs to.
+- ``device_id``: The token that APNs and FCM return when you allow the device to receive notifications. So when the user logs into Mattermost, Mattermost sends this ``device_id`` to attach it to the session. If the session is terminated, the ``device_id`` is no longer present in the server database because the session record is removed. When the user logs back in, the ``device_id`` is registered again with the same value because the identifier is specific to the device. This value won't be the same across apps or devices owned by the same person, but will be the same for each session the user creates from the same app on the same device.
+- ``version``: Tells the mobile app how data is structured so it can parse it properly. Current value is ``v2``.
+- ``is_id_loaded``: (Mattermost Enterprise only) When true, the mobile app look for the contents of the notification on the server because those details are not part of the payload. 
+
 What are my options for securing the mobile apps?
 -------------------------------------------------
 

--- a/source/deploy/mobile-hpns.rst
+++ b/source/deploy/mobile-hpns.rst
@@ -49,7 +49,7 @@ To use the Mattermost TPNS, go to **System Console > Environment > Push Notifica
 See our `Testing Push Notifications <https://docs.mattermost.com/deploy/mobile-testing-notifications.html>`__ documentation to learn more about testing mobile push notifications.
 
 .. note::
-  - The TPNS only works with the pre-built mobile apps Mattermost deploys through the Apple App Store and Google Play Store. If you have built your own mobile apps, you must also `host your own Mattermost push proxy service <#host-your-own-push-proxy-service>`_.  
+  - The TPNS only works with the pre-built mobile apps that Mattermost deploys through the Apple App Store and Google Play Store. If you have built your own mobile apps, you must also `host your own Mattermost push proxy service <#host-your-own-push-proxy-service>`_.  
   - You must ensure that the push proxy can be reached on the correct port. For TPNS, it's port 80 from the Mattermost server.
 
 Hosted Push Notifications Service (HPNS)
@@ -72,6 +72,7 @@ Mattermost Enterprise, Professional, and Cloud customers can use Mattermost's Ho
 .. note:: 
   - The HPNS only works with pre-built apps Mattermost deploys through the Apple App Store and Google Play Store. If you build your own mobile apps, you must also `host your own Mattermost push proxy server <#id4>`_.
   - You must ensure that the push proxy can be reached on the correct port. For HPNS, it's port 443 from the Mattermost server.
+  - Mattermost doesn't store any notification data. Any data being stored is at the server level only, such as the ``device_id``, since the HPNS needs to know which device the notification must be sent to.
 
 Enable HPNS for existing deployments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Based on recent community led requests for documentation:
- Clarified key payload definitions in the Mobile apps FAQ documentation for data transmitted to the push notification service when using the ID-Only setting.
- Clarified that no notification data is stored by Mattermost, and that any data stored is at the server level, such as ``device_id``.