### PR TITLE
Clarify Browse Channels functionality

### DIFF
--- a/source/channels/find-channels.rst
+++ b/source/channels/find-channels.rst
@@ -18,10 +18,13 @@ Find channels
   :target: https://mattermost.com/deploy
   :alt: Available for Mattermost Self-Hosted deployments.
 
-To see all available public channels you can join, select the **+** icon at the top of the channel sidebar, then select **Browse Channels**. Search for channels by name or scroll through the list. Select **Join** next to any channel to become a member of that channel.
+Find channels to join
+---------------------
+
+To see all available public channels you can join that you're not already a member of, select the **+** icon at the top of the channel sidebar, then select **Browse Channels**. Search for channels by name or scroll through the list. Select **Join** next to any channel to become a member of that channel.
 
 .. tip:: 
-    Select **Find Channel** in the channel sidebar to see all of the channels you're currently a member of across all of your teams, including public and private channels, as well as all direct and group messages.
+    - Want to see all of the channels you're already a member of? Select **Find Channel** in the channel sidebar to see all of the channels you're currently a member of across all of your teams, including public and private channels, as well as all direct and group messages.
 
 Revisit recent channels
 -----------------------


### PR DESCRIPTION
Based on recent feedback from a documentation visitor, clarified that Browse Channels shows you channels you're not yet a member of.