### PR TITLE
MM-43524 Add note about not unzipping Slack exports

### DIFF
--- a/source/onboard/migrating-to-mattermost.rst
+++ b/source/onboard/migrating-to-mattermost.rst
@@ -140,6 +140,10 @@ We recommend you create a new team in Mattermost to hold the imported Slack data
 
 The first step is to generate a `Slack export <https://slack.com/help/articles/201658943-Export-your-workspace-data>`_.
 
+.. note::
+
+  Make sure not to unzip and rezip the Slack export. Doing that can modify the directory structure of the archive which could cause issues with the import process.
+
 Next, follow these steps to create a bot token:
 
 1. Go to https://api.slack.com/apps.


### PR DESCRIPTION
Along with https://github.com/mattermost/mmetl/pull/19, this will hopefully help us not spend more time debugging issues with Slack exports because the folder structure is wrong due to being rezipped

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43524

