### PR TITLE
Clarifying the Cloud VPC add-on refers to infrastructure, not to a dedicated AWS account, part 2

### DIFF
--- a/source/archive/mattermost-cloud-overview.rst
+++ b/source/archive/mattermost-cloud-overview.rst
@@ -71,7 +71,7 @@ Mattermost Cloud Enterprise is deployed in a private environment within an AWS V
 Is Mattermost Cloud Enterprise a dedicated instance run on AWS systems?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Yes, Mattermost Cloud Enterprise is a dedicated Mattermost environment running in a dedicated AWS account with separate infrastructure for that customer specifically, i.e. separate database, separate VMs, separate Kubernetes cluster.
+Mattermost Cloud Enterprise can be deployed as a dedicated Mattermost environment running with separate infrastructure for your requirements (e.g., separate database, separate VMs, separate Kubernetes cluster). Please contact Mattermost Sales for more information on this option.
 
 How is customer data in Mattermost Cloud Enterprise encrypted?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is a follow-up to https://github.com/mattermost/docs/pull/5641, clarifying the Cloud VPC add-on refers to infrastructure, not to a dedicated AWS account