### PR TITLE
Clarify Cloud uptime guarantees in documentation

### DIFF
--- a/source/about/editions-and-offerings.rst
+++ b/source/about/editions-and-offerings.rst
@@ -91,7 +91,6 @@ This offering includes all the features of Mattermost Starter, plus:
 - `Read-only announcement channels <https://docs.mattermost.com/manage/team-channel-members.html#channel-moderation-e20>`__.
 - `System-wide announcement banners <https://docs.mattermost.com/manage/announcement-banner.html>`__.
 - O365 integration with `Microsoft Teams Calling <https://mattermost.com/marketplace/microsoft-teams-meetings/>`_ and `Jira multi-server <https://mattermost.com/marketplace/jira-plugin/>`_.
-- 99.9% uptime SLA guarantee (Cloud only).
 - `Next business day support via online ticketing system <https://mattermost.com/support/>`__.
 
 See a complete list of features `here <https://mattermost.com/pricing>`__.
@@ -121,6 +120,7 @@ This offering includes all the features of Mattermost Professional, plus:
 - `Horizontal scaling through cluster-based deployment <https://docs.mattermost.com/scale/scaling-for-enterprise.html#cluster-based-deployment>`__.
 - `Advanced performance monitoring <https://docs.mattermost.com/scale/performance-monitoring.html>`__.
 - `Eligibility for Premier Support add-on <https://mattermost.com/support/>`__.
+- 99% uptime SLA guarantee (Cloud only, via dedicated virtual secure Cloud add-on option).
 
 Limits
 ------

--- a/source/archive/mattermost-cloud-overview.rst
+++ b/source/archive/mattermost-cloud-overview.rst
@@ -22,7 +22,7 @@ To get started with Mattermost Cloud Professional, visit https://mattermost.com/
 Mattermost Cloud Enterprise
 ---------------------------
 
-Mattermost Cloud Enterprise offers the isolation, security, and control of self-hosted editions but without the burden of managing deployment, maintaining uptime, or applying upgrades. Mattermost Cloud Enterprise offers all chat and administration features, integrated DevOps workflows, provides a 99.0% financially-backed guaranteed uptime, and enterprise-grade support.
+Mattermost Cloud Enterprise offers the isolation, security, and control of self-hosted editions but without the burden of managing deployment, maintaining uptime, or applying upgrades. Mattermost Cloud Enterprise offers all chat and administration features, integrated DevOps workflows, and enterprise-grade support.
   
 Every Mattermost Cloud Enterprise instance is deployed in a private environment within an AWS VPC dedicated to a single customer. Within that VPC, all the required resources to run, monitor, and administer Mattermost are deployed in isolation. These resources include a dedicated RDS Aurora database cluster and a dedicated Kubernetes cluster, deployed across multiple Availability Zones and managed by Kubernetes experts.
 


### PR DESCRIPTION
We have old uptime guarantees for the legacy Cloud Enterprise offering that was discontinued in April/2021. Updating documentation to reflect uptime guarantees for the current offering.