### PR TITLE
Experimental functionality cleanup

### DIFF
--- a/source/comply/audit-log.rst
+++ b/source/comply/audit-log.rst
@@ -15,7 +15,7 @@ Audit log v2 (experimental)
 
 *Available in legacy Mattermost Enterprise Edition E20*
 
-System Admins can review a comprehensive listing of events for more in-depth analysis. Additionally, the new audit log provides more control over where the logs are generated and stored. 
+Audit log v2 is an experimental feature that provides System Admins with a comprehensive listing of events for more in-depth analysis. Additionally, the new audit log provides more control over where the logs are generated and stored. 
 
 The advanced logging capabilities of the Audit Log V2 allow any combination of console, local file, syslog, and TCP socket targets, and can send log records to multiple targets. These targets have been chosen as they support the vast majority of log aggregators, and other log analysis tools, without needing additional software installed.
 

--- a/source/onboard/certificate-based-authentication.rst
+++ b/source/onboard/certificate-based-authentication.rst
@@ -1,5 +1,5 @@
-Certificate-based authentication
-================================
+Certificate-based authentication (experimental)
+===============================================
 
 |enterprise| |cloud| |self-hosted|
 
@@ -20,7 +20,7 @@ Certificate-based authentication
 
 *Available as an experimental feature in legacy Mattermost Enterprise Edition E20.*
 
-Certificate-based authentication (CBA) can be used to identify a user or a device before granting access to Mattermost, providing an additional layer of security to access the system.
+Certificate-based authentication (CBA) is available as an experimental feature to identify a user or a device before granting access to Mattermost and provide an additional layer of security to access the system.
 
 Follow these steps to configure user CBA for your browser and Mattermost Desktop Apps. Support for the Mattermost iOS and Android Apps is planned. It is expected that you can manage certificate distribution for each personal device (BYOD) and their lifecycle management with a service like `OpenSSL <https://www.openssl.org/>`__.
 

--- a/source/onboard/shared-channels.rst
+++ b/source/onboard/shared-channels.rst
@@ -18,7 +18,7 @@ Shared channels (experimental)
   :target: https://mattermost.com/deploy
   :alt: Available for Mattermost Self-Hosted deployments.
 
-Shared channels bring people together from multiple Mattermost installations, such as teams collaborating with external partners and customers using multiple Mattermost instances in a federated architecture.
+Shared channels is an experimental feature that bring people together from multiple Mattermost installations, such as teams collaborating with external partners and customers using multiple Mattermost instances in a federated architecture.
 
 Mattermost System Admins use slash commands to establish secure connections between Mattermost instances, then invite secured connections to shared channels.
 

--- a/source/onboard/shared-channels.rst
+++ b/source/onboard/shared-channels.rst
@@ -18,7 +18,7 @@ Shared channels (experimental)
   :target: https://mattermost.com/deploy
   :alt: Available for Mattermost Self-Hosted deployments.
 
-Shared channels is an experimental feature that bring people together from multiple Mattermost installations, such as teams collaborating with external partners and customers using multiple Mattermost instances in a federated architecture.
+Shared channels is an experimental feature that brings people together from multiple Mattermost installations. For example, teams collaborating with external partners and customers using multiple Mattermost instances in a federated architecture.
 
 Mattermost System Admins use slash commands to establish secure connections between Mattermost instances, then invite secured connections to shared channels.
 


### PR DESCRIPTION
The following product functionality documentation has been updated to clarify that they are experimental with the latest Mattermost subscriptions:
- Certificate-based authentication
- Shared channels
- Audit logging V2