### PR TITLE
Timestamps now enabled in the default audit config

### DIFF
--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -6730,7 +6730,7 @@ File configuration options
 
 This setting isn't available in the System Console and can only be set in ``config.json``.
 
-Enable this setting to write audit files locally, specifying size, backup interval, compression, and maximum age to manage file rotation. 
+Enable this setting to write audit files locally, specifying size, backup interval, compression, maximum age to manage file rotation, and timestamps. 
 
 **True**: File output is enabled.
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/20015
- Updated config setting description to include timestamps.