### PR TITLE
Move unofficial content from product documentation to User Forum

### DIFF
--- a/source/archive/administrator.rst
+++ b/source/archive/administrator.rst
@@ -263,14 +263,4 @@ Learn how to support growth within Mattermost.
 Community-Managed Documentation
 -------------------------------
 
-Documentation on early previews and unofficial functionality.
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   /install/prod-docker*
-   /install/deploy-cloudron*
-   /administration/upgrade-script*
-   /administration/light-install-hindi.rst
-   
+Documentation on unofficial functionality is available on the `Mattermost Discussion Forums <https://forum.mattermost.com/c/docs/37>`__.

--- a/source/conf.py
+++ b/source/conf.py
@@ -357,7 +357,8 @@ redirects = {
 "configure/config-ssl-http2-apache2.html": 
 	"https://forum.mattermost.org/t/configuring-apache2-with-ssl-and-http-2/11939",
 "configure/configuring-apache2.html": 
-        "https://forum.mattermost.org/c/docs/37",
+        "https://forum.mattermost.com/t/configuring-apache2-as-a-proxy-for-mattermost-server/11938",
+
 
 # Configuration settings redirects
 "configure/configuration-settings.html#channels":
@@ -816,7 +817,7 @@ redirects = {
 "install/config-cloudfront.html":
         "https://docs.mattermost.com/configure/configuring-cloudfront-to-host-mattermost-static-assets.html",
 "install/config-apache2.html": 
-        "https://docs.mattermost.com/configure/configuring-apache2.html",
+        "https://forum.mattermost.com/t/configuring-apache2-as-a-proxy-for-mattermost-server/11938",
 "install/deploy-bitnami.html": 
         "https://docs.mattermost.com/install/deploying-team-edition-on-bitnami.html",
 "install/desktop.html": 
@@ -875,6 +876,8 @@ redirects = {
         "https://docs.mattermost.com/install/proxy-to-mattermost-transport-encryption.html",
 "install/use-kubernetes-mattermost.html":
         "https://docs.mattermost.com/install/install-kubernetes.html",
+"install/deploy-cloudron.html":
+        "https://forum.mattermost.com/t/deploy-mattermost-on-cloudron/13526",
 
 # Integrations redirects.
 # The integrations directory and its contents have been archived in FY23 Q2 and all applicable content has been moved from docs.mm.com to developers.mm.com.
@@ -898,6 +901,10 @@ redirects = {
         "https://developers.mattermost.com/integrate/admin-guide/admin-zapier-integration/",
 "integrations/zoom.html": 
         "https://mattermost.gitbook.io/plugin-zoom/",
+
+# Manage redirects
+"manage/scripts.html":
+        "https://forum.mattermost.com/t/scripts-for-performing-discreet-tasks/13527",        
 
 # Messaging redirects
 "messaging/about-teams-channels-messages.html#teams":

--- a/source/configure/configuring-apache2.rst
+++ b/source/configure/configuring-apache2.rst
@@ -1,7 +1,7 @@
 Configuring Apache2 (unofficial)
 ================================
 
-.. This page is intentionally NOT accessible from the LHS. Unofficial content will be moved to the User Forum.
+.. This page is intentionally NOT accessible from the LHS, and is no longer maintained in this repository. Unofficial content has moved to the User Forum.
 
 Unofficial, community-maintained guides for configuring Apache as a proxy instead of NGINX.
 

--- a/source/getting-started/architecture-overview.rst
+++ b/source/getting-started/architecture-overview.rst
@@ -48,7 +48,7 @@ A proxy server is a server (a computer system or an application) that acts as an
 - **Performance:** In a High Availability configuration, the proxy server balances the network load across multiple Mattermost servers for optimized performance. A hardware proxy with dedicated devices for processing SSL encryption and decryption can also be used to increase performance.
 - **Monitoring**: A proxy server can monitor connection traffic and record traffic in standard audit logs that common monitoring tools like Kibana and Splunk can consume and report on. Some of the events that can be captured include file uploads and downloads, which are not tracked by the Mattermost server logging process.
 
-Mattermost provides documentation and support for the `NGINX proxy <https://www.nginx.com/>`__. For information on how to install and configure NGINX for your environment, see `our guide <https://docs.mattermost.com/guides/administrator.html#installing-mattermost>`__. Mattermost also unofficially supports other proxies including `Apache 2 <https://docs.mattermost.com/install/config-apache2.html>`__.
+Mattermost provides documentation and support for the `NGINX proxy <https://www.nginx.com/>`__. For information on how to install and configure NGINX for your environment, see `our guide <https://docs.mattermost.com/guides/administrator.html#installing-mattermost>`__. Mattermost also unofficially supports other proxies including `Apache 2 <https://forum.mattermost.com/t/configuring-apache2-as-a-proxy-for-mattermost-server/11938/3>`__.
 
 .. image:: ../images/architecture_with_proxy.png
 

--- a/source/getting-started/enterprise-roll-out-checklist.rst
+++ b/source/getting-started/enterprise-roll-out-checklist.rst
@@ -343,7 +343,7 @@ Now that you have an environment in place, we recommend working through the foll
 
  - mmctl Command Line Tool Resource: https://docs.mattermost.com/manage/mmctl-command-line-tool.html
  - Command Line Tools Resource: https://docs.mattermost.com/manage/command-line-tools.html
- - Database Scripts Resource: https://docs.mattermost.com/manage/scripts.html 
+ - Database Scripts Resource: https://forum.mattermost.com/t/scripts-for-performing-discreet-tasks/13527 
 
 Review the roll out 
 ~~~~~~~~~~~~~~~~~~~
@@ -375,7 +375,7 @@ We recommend that you review your rollout on a cadence that matches your iterati
 
 - Analyze usage by lines of business and peak usage times
 
- - Resources: https://docs.mattermost.com/manage/scripts.html
+ - Resources: https://forum.mattermost.com/t/scripts-for-performing-discreet-tasks/13527
 
 3. Analyze system performance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/guides/administration.rst
+++ b/source/guides/administration.rst
@@ -187,7 +187,6 @@ Other resources
     Migration announcement email template </onboard/migration-announcement-email>
     Advanced permissions: Backend infrastructure </onboard/advanced-permissions-backend-infrastructure>
     Command line tools </manage/command-line-tools>
-    Scripts </manage/scripts>
 
 If the information above doesn’t solve your problem, look at these other resources to find something that meets your needs. Alternatively, you can also :doc:`get help </guides/get-help>` from our community or via premium support services.
 
@@ -197,4 +196,3 @@ If the information above doesn’t solve your problem, look at these other resou
 * :doc:`Migration announcement email template </onboard/migration-announcement-email>` - Use this email template to notify your users about migrating to Mattermost.
 * :doc:`Advanced permissions: Backend infrastructure </onboard/advanced-permissions-backend-infrastructure>` - Read our technical guide on modifying self-hosted Mattermost installations to create custom permissions schemes.
 * :doc:`Command line tools </manage/command-line-tools>` - Learn how to use the command line to manage self-hosted Mattermost servers.
-* :doc:`Scripts </manage/scripts>` - Explore a selection of example scripts you can use to manage self-hosted Mattermost servers.

--- a/source/install/deploy-cloudron.rst
+++ b/source/install/deploy-cloudron.rst
@@ -1,6 +1,6 @@
-:orphan:
-
 .. _deploy-cloudron:
+
+.. This page is intentionally NOT accessible from the LHS, and is no longer maintained in this repository. Unofficial content has moved to the User Forum.
 
 Deploy Mattermost on Cloudron (unofficial)
 ==========================================

--- a/source/manage/scripts.rst
+++ b/source/manage/scripts.rst
@@ -1,3 +1,5 @@
+.. This page is intentionally NOT accessible from the LHS, and is no longer maintained in this repository. Unofficial content has moved to the User Forum.
+
 Scripts (unofficial)
 ====================
 


### PR DESCRIPTION
The last of the unofficial content remains searchable through the product documentation. Users who select these topics from search results are taken directly to the User Forum article.