### PR TITLE
Docs Listening: Improved user's documentation journey

### DIFF
--- a/source/channels/manage-channel-members.rst
+++ b/source/channels/manage-channel-members.rst
@@ -21,11 +21,11 @@ Manage channel members
 Add members to a channel
 ------------------------
 
-Any member of a channel can add new members to a channel. Select the channel name at the top of the center pane to access the drop-down menu, then select **Add Members**. Choose **Add** next to a user's name. Users already added to the channel will not appear in this list.
+Any member of a channel can add new members to a channel. Select the channel name at the top of the center pane to access the drop-down menu, then select **Add Members**. Search for users, select users, then select **Add** to add them to the current channel. Mattermost notifies you when a user is already a member of the channel.
 
 .. image:: ../images/add-member-to-channel.png
 
-You can also add users to channels within their profile pop-over by choosing **Add to a Channel** and selecting the channel you want them to join.
+You can also add users to channels within their profile pop-over by choosing **Add to a Channel**, specifying the channel you want them to join, then selecting **Add**.
 
 .. image:: ../images/add-member-pop.png
     :alt: Add a member to a channel.
@@ -33,7 +33,7 @@ You can also add users to channels within their profile pop-over by choosing **A
 Remove members from a channel
 -----------------------------
 
-Any member of a channel can remove other members to a channel. Select the channel name at the top of the center pane to access the drop-down menu, then select **Manage Members**. Select the member's channel role, then select **Remove from Channel**.
+Any member of a channel can remove other members to a channel. Select the channel name at the top of the center pane to access the drop-down menu, then select **Manage Members**. Select the member's `user role <https://docs.mattermost.com/welcome/about-user-roles.html>`__, then select **Remove from Channel**.
 
 .. image:: ../images/remove-member-from-channel.png
     :alt: Remove a member from a channel.


### PR DESCRIPTION
This PR addresses the following Channels product documentation feedback provided through the feedback widget at docs.mm.com: "Looking to see what rights assigning the role of channel manager gives that user." 
- Updated the channel management page to reflect current product workflows in v7.0, and to add a link to the user roles documentation where the privileges of each role are described in more detail.