### PR TITLE
Moved Elasticsearch config settings to new page

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -459,6 +459,48 @@ redirects = {
         "https://docs.mattermost.com/configure/web-server-configuration-settings.html#webserver-mode",
 "configure/configuration-settings.html#write-timeout":
         "https://docs.mattermost.com/configure/web-server-configuration-settings.html#write-timeout",
+"configure/configuration-settings.html#elasticsearch":
+        "https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html",
+"configure/configuration-settings.html#elasticsearch-settings":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html",
+"configure/configuration-settings.html#enable-elasticsearch-indexing":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-elasticsearch-indexing.html",
+"configure/configuration-settings.html#server-connection-address":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#server-connection-address.html",
+"configure/configuration-settings.html#skip-tls-verification":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#skip-tls-verification.html",
+"configure/configuration-settings.html#server-username":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#server-username.html",
+"configure/configuration-settings.html#server-password":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#server-password.html",
+"configure/configuration-settings.html#enable-cluster-sniffing":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-cluster-sniffing.html",
+"configure/configuration-settings.html#bulk-indexing":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#bulk-indexing.html",
+"configure/configuration-settings.html#purge-indexes":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#purge-indexes.html",
+"configure/configuration-settings.html#enable-elasticsearch-for-search-queries":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-elasticsearch-for-search-queries.html",
+"configure/configuration-settings.html#enable-elasticsearch-for-autocomplete-queries":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-elasticsearch-for-autocomplete-queries.html",
+"configure/configuration-settings.html#post-index-replicas":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#post-index-replicas.html",
+"configure/configuration-settings.html#post-index-shards":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#post-index-shards.html",
+"configure/configuration-settings.html#aggregate-search-indexes":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#aggregate-search-indexes.html",
+"configure/configuration-settings.html#post-aggregator-start-time":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#post-aggregator-start-time.html",
+"configure/configuration-settings.html#index-prefix":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#index-prefix.html",
+"configure/configuration-settings.html#live-indexing-batch-size":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#live-indexing-batch-size.html",
+"configure/configuration-settings.html#request-timeout":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#request-timeout.html",
+"configure/configuration-settings.html#bulk-indexing-time-window":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#bulk-indexing-time-window.html",
+"configure/configuration-settings.html#trace":
+	"https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#trace.html",
 
 # Deploy redirects
 "deploy/mobile-apps-faq.html":

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -132,7 +132,7 @@ Upload or remove license files. For more information on Mattermost Licensing, pl
 Reporting
 ---------
 
-See the :doc:`reporting configuration settings </configure/reporting-configuration-settings>` documentation for details on:
+See the :doc:`reporting configuration settings </configure/reporting-configuration-settings>` documentation for details on the following configuration settings:
 
 - `Site statistics <https://docs.mattermost.com/configure/reporting-configuration-settings.html#site-statistics>`__
 - `Team statistics <https://docs.mattermost.com/configure/reporting-configuration-settings.html#team-statistics>`__
@@ -141,7 +141,7 @@ See the :doc:`reporting configuration settings </configure/reporting-configurati
 User Management
 ---------------
 
-See the :doc:`user management configuration settings </configure/user-management-configuration-settings>` documentation for details on:
+See the :doc:`user management configuration settings </configure/user-management-configuration-settings>` documentation for details on the following configuration settings:
 
 - `Users <https://docs.mattermost.com/configure/user-management-configuration-settings.html#users>`__
 - `Groups <https://docs.mattermost.com/configure/user-management-configuration-settings.html#groups>`__
@@ -156,7 +156,7 @@ Environment
 Web server
 ~~~~~~~~~~
 
-See the :doc:`web server configuration settings </configure/web-server-configuration-settings>` documentation for details on:
+See the :doc:`web server configuration settings </configure/web-server-configuration-settings>` documentation for details on the following configuration settingsn:
 
 - `Site URL <https://docs.mattermost.com/configure/web-server-configuration-settings.html#site-url>`__
 - `Listen address <https://docs.mattermost.com/configure/web-server-configuration-settings.html#listen-address>`__
@@ -178,7 +178,7 @@ See the :doc:`web server configuration settings </configure/web-server-configura
 Database
 ~~~~~~~~
 
-See the :doc:`database configuration settings </configure/database-configuration-settings>` documentation for details on:
+See the :doc:`database configuration settings </configure/database-configuration-settings>` documentation for details on the following configuration settings:
 
 - `Driver name <https://docs.mattermost.com/configure/database-configuration-settings.html#driver-name>`__
 - `Data source <https://docs.mattermost.com/configure/database-configuration-settings.html#data-source>`__
@@ -194,23 +194,34 @@ See the :doc:`database configuration settings </configure/database-configuration
 - `Disable database search <https://docs.mattermost.com/configure/database-configuration-settings.html#disable-database-search>`__
 - `Applied schema migrations <https://docs.mattermost.com/configure/database-configuration-settings.html#applied-schema-migrations>`__
 
-At Rest Encrypt Key
-^^^^^^^^^^^^^^^^^^^
-
-|all-plans| |self-hosted|
-
-A 32-character key for encrypting and decrypting sensitive fields in the database. You can generate your own cryptographically random alphanumeric string, or you can go to **System Console > Environment > Database** and select **Regenerate**, which displays the value until you select **Save**.
-
-When using High Availability, the salt must be identical in each instance of Mattermost.
-
-No fields are encrypted using ``AtRestEncryptKey``. It's a legacy setting used to encrypt data stored at rest in the database.
-
-+------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"AtRestEncryptKey": ""`` with string input.  |
-+------------------------------------------------------------------------------------------+
-
 Elasticsearch
 ~~~~~~~~~~~~~~
+
+See the :doc:`Elasticsearch configuration settings </configure/elasticsearch-configuration-settings>` documentation for details on the following configuration settings:
+
+- `Enable Elasticsearch indexing <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-elasticsearch-indexing>`__
+- `Server connection address <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#server-connection-address>`__
+- `Skip TLS verification <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#skip-TLS-verification>`__
+- `Server username <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#server-username>`__
+- `Server password <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#server-password>`__
+- `Enable cluster sniffing <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-cluster-sniffing>`__
+- `Bulk indexing <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#bulk-indexing>`__
+- `Purge indexes <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#purge-indexes>`__
+- `Enable Elasticsearch for search queries <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-elasticsearch-for-search-queries>`__
+- `Enable Elasticsearch for autocomplete queries <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#enable-elasticsearch-for-autocomplete-queries>`__
+- `Post index replicas <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#post-index-replicas>`__
+- `Post index shards <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#post-index-shards>`__
+- `Channel index replicas <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#channel-index-replicas>`__
+- `Channel index shards <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#channel-index-shards>`__
+- `User index replicas <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#user-index-replicas>`__
+- `User index shards <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#user-idex-shards>`__
+- `Aggregate search indexes <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#aggregate-search-indexes>`__
+- `Post aggregator start time <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#post-aggregator-start-time>`__
+- `Index prefix <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#index-prefix>`__
+- `Live indexing batch size <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#live-indexing-batch-size>`__
+- `Bulk indexing time window <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#bulk-indexing-time-window>`__
+- `Request timeout <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#request-timeout>`__
+- `Trace <https://docs.mattermost.com/configure/elasticsearch-configuration-settings.html#trace>`__
 
 Changes to properties in this section require a server restart before taking effect. Access the following configuration settings in the System Console by going to **Environment > Elasticsearch**.
 
@@ -6239,6 +6250,19 @@ This setting isn't available in the System Console and can only be set in ``conf
 
 Database Settings
 ~~~~~~~~~~~~~~~~~
+
+At Rest Encrypt Key
+^^^^^^^^^^^^^^^^^^^
+
+|all-plans| |self-hosted|
+
+This setting isn't available in the System Console and can only be set in ``config.json``. It's a legacy setting used to encrypt data stored at rest in the database, and no fields are encrypted using ``AtRestEncryptKey``. 
+
+A 32-character key for encrypting and decrypting sensitive fields in the database. When using High Availability, this value must be identical in each instance of Mattermost.
+
++------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"AtRestEncryptKey": ""`` with string input.  |
++------------------------------------------------------------------------------------------+
 
 Clean Up Old Database Jobs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/configure/elasticsearch-configuration-settings.rst
+++ b/source/configure/elasticsearch-configuration-settings.rst
@@ -105,7 +105,7 @@ Server password
 *Available in legacy Enterprise Edition E10/E20*
 
 +---------------------------------------------------------------+--------------------------------------------------------------------------+
-| (Optional) The PASSWORD to authenticate to the                | - System Config path: **Environment > Elasticsearch**                    |
+| (Optional) The password to authenticate to the                | - System Config path: **Environment > Elasticsearch**                    |
 | Elasticsearch server.                                         | - ``config.json`` setting: ``".Elasticsearchsettings.Password",``        |
 |                                                               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_PASSWORD``            |
 | String input.                                                 |                                                                          |
@@ -121,8 +121,8 @@ Enable cluster sniffing
 +----------------------------------------------------------------+--------------------------------------------------------------------------+
 | Automatically find and connect to all data nodes in a cluster. | - System Config path: **Environment > Elasticsearch**                    |
 |                                                                | - ``config.json`` setting: ``".Elasticsearchsettings.Sniff: false",``    |
-| - **true**: **(Default)** Sniffing finds and connects to       | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_SNIFF``               |
-|   all data nodes in your cluster automatically.                |                                                                          |
+| - **true**: Sniffing finds and connects to all data nodes      | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_SNIFF``               |
+|   in your cluster automatically.                               |                                                                          |
 | - **false**: **(Default)** Cluster sniffing is disabled .      |                                                                          |
 +----------------------------------------------------------------+--------------------------------------------------------------------------+
 | Select the **Test Connection** button in the System Console to validate the connection between Mattermost and the Elasticsearch server.   |

--- a/source/configure/elasticsearch-configuration-settings.rst
+++ b/source/configure/elasticsearch-configuration-settings.rst
@@ -1,0 +1,401 @@
+Elasticsearch configuration settings
+====================================
+
+.. |all-plans| image:: ../images/all-plans-badge.png
+  :scale: 25
+  :target: https://mattermost.com/pricing
+  :alt: Available in Mattermost Free and Starter subscription plans.
+
+.. |enterprise| image:: ../images/enterprise-badge.png
+  :scale: 25
+  :target: https://mattermost.com/pricing
+  :alt: Available in the Mattermost Enterprise subscription plan.
+
+.. |professional| image:: ../images/professional-badge.png
+  :scale: 25
+  :target: https://mattermost.com/pricing
+  :alt: Available in the Mattermost Professional subscription plan.
+
+.. |cloud| image:: ../images/cloud-badge.png
+  :scale: 25
+  :target: https://mattermost.com/download
+  :alt: Available for Mattermost Cloud deployments.
+
+.. |self-hosted| image:: ../images/self-hosted-badge.png
+  :scale: 25
+  :target: https://mattermost.com/deploy
+  :alt: Available for Mattermost Self-Hosted deployments.
+
+Elasticsearch provides enterprise-scale deployments with optimized search performance and prevents performance degradation and timeouts. Learn more about `Elasticsearch <https://docs.mattermost.com/scale/elasticsearch.html>`__ in our product documentation. 
+
+Configure the Elasticsearch environment in which Mattermost is deployed by going to **System Console > Environment > Elasticsearch**, or by editing the ``config.json`` file as described in the following table. Changes to configuration settings in this section require a server restart before taking effect.
+
+.. include:: common-config-settings-notation.rst
+    :start-after: :nosearch:
+
+Enable Elasticsearch indexing
+-----------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------------+
+| New posts can be automatically indexed.                       | - System Config path: **Environment > Elasticsearch**                          |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.EnableIndexing: false",`` |
+| - **true**: Indexing of new posts occurs automatically.       | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_ENABLEINDEXING``            |
+| - **false**: **(Default)** Elasticsearch indexing is disabled |                                                                                |
+|   and new posts are not indexed.                              |                                                                                |
++---------------------------------------------------------------+--------------------------------------------------------------------------------+
+| **Note**:                                                                                                                                      |
+|                                                                                                                                                |
+| - If indexing is disabled and re-enabled after an index is created, we recommend you purge and rebuild the index to ensure complete            |
+|   search results.                                                                                                                              |
+| - Search queries will use database search until Elasticsearch for search queries is enabled.                                                   |
++----------------------------------------------------------------------+-------------------------------------------------------------------------+
+
+Server connection address
+--------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| The address of the Elasticsearch server.                      | - System Config path: **Environment > Elasticsearch**                    |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.ConnectionUrl",``   |
+|                                                               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_CONNECTIONURL``       |
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+
+Skip TLS verification
+----------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+-------------------------------------------------------------------------------------+
+| The certificate step for TLS connections can be skipped.      | - System Config path: **Environment > Elasticsearch**                               |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.SkipTLSVerification: false",`` |
+| - **true**: Skips the certificate verification step for       | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_SKIPTLSVERIFICATION``            |
+|   TLS connections.                                            |                                                                                     |
+| - **false**: **(Default)** Mattermost does not skip           |                                                                                     |
+|   certificate verification.                                   |                                                                                     |
++---------------------------------------------------------------+-------------------------------------------------------------------------------------+
+
+Server username
+---------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| (Optional) The username to authenticate to the                | - System Config path: **Environment > Elasticsearch**                    |
+| Elasticsearch server.                                         | - ``config.json`` setting: ``".Elasticsearchsettings.UserName",``        |
+|                                                               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_USERNAME``            |
+| String input.                                                 |                                                                          |
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+
+Server password
+---------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| (Optional) The PASSWORD to authenticate to the                | - System Config path: **Environment > Elasticsearch**                    |
+| Elasticsearch server.                                         | - ``config.json`` setting: ``".Elasticsearchsettings.Password",``        |
+|                                                               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_PASSWORD``            |
+| String input.                                                 |                                                                          |
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+
+Enable cluster sniffing
+------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++----------------------------------------------------------------+--------------------------------------------------------------------------+
+| Automatically find and connect to all data nodes in a cluster. | - System Config path: **Environment > Elasticsearch**                    |
+|                                                                | - ``config.json`` setting: ``".Elasticsearchsettings.Sniff: false",``    |
+| - **true**: **(Default)** Sniffing finds and connects to       | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_SNIFF``               |
+|   all data nodes in your cluster automatically.                |                                                                          |
+| - **false**: **(Default)** Cluster sniffing is disabled .      |                                                                          |
++----------------------------------------------------------------+--------------------------------------------------------------------------+
+| Select the **Test Connection** button in the System Console to validate the connection between Mattermost and the Elasticsearch server.   |
++----------------------------------------------------------------+--------------------------------------------------------------------------+
+
+Bulk indexing
+-------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| Start a bulk index of all existing posts in the database.     | - System Config path: **Environment > Elasticsearch**                    |
+|                                                               | - ``config.json`` setting: N/A                                           |
+| Select the **Index Now** button in the System Console to      | - Environment variable: N/A                                              |
+| start a bulk index of all posts. If the indexing process is   |                                                                          |
+| canceled, the index and search results will be incomplete.    |                                                                          |
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+
+Purge indexes
+-------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+-------------------------------------------------------------+
+| Purge the entire Elasticsearch index.                         | - System Config path: **Environment > Elasticsearch**       |        
+| Typically only used if the index has corrupted and search     | - ``config.json`` setting: N/A                              |
+| isn't behaving as expected.                                   | - Environment variable: N/A                                 |          
+|                                                               |                                                             |
+| Select the **Purge Indexes** button in the System Console to  |                                                             |
+| purge the index. After purging the index, create a new        |                                                             |
+| index with the **Index Now** button.                          |                                                             |
++---------------------------------------------------------------+-------------------------------------------------------------+
+
+Enable Elasticsearch for search queries
+---------------------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------------+
+| Use the latest index for all search queries.                  | - System Config path: **Environment > Elasticsearch**                          |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.EnableSearching:false",`` |
+| - **true**: Elasticsearch will be used for all search         | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_ENABLESEARCHING``           | 
+|   queries using the latest index. Search results may be       |                                                                                |
+|   incomplete until a bulk index of the existing post database |                                                                                |
+|   is finished.                                                |                                                                                |
+| - **false**: **(Default)** Database search is used for        |                                                                                |
+|   search queries.                                             |                                                                                |
++---------------------------------------------------------------+--------------------------------------------------------------------------------+
+
+Enable Elasticsearch for autocomplete queries
+---------------------------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+------------------------------------------------------------------------------------+
+| Elasticsearch can use the latest index for all autocompletion | - System Config path: **Environment > Elasticsearch**                              |
+| queries on users and channels.                                | - ``config.json`` setting: ``".Elasticsearchsettings.EnableAutocomplete: false",`` |
+|                                                               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_ENABLEAUTOCOMPLETE``            |
+| - **true**: Elasticsearch will be used for all autocompletion |                                                                                    |
+|   queries on users and channels using the latest index.       |                                                                                    |
+| - **false**: **(Default)** Database autocomplete is used.     |                                                                                    |
++---------------------------------------------------------------+------------------------------------------------------------------------------------+
+| **Note**: Autocompletion results may be incomplete until a bulk index of the existing users and channels database is finished.                     |
++---------------------------------------------------------------+------------------------------------------------------------------------------------+
+
+Post index replicas
+-------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+| The number of replicas to use for each post index.            | - System Config path: N/A                                                     |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.PostIndexReplicas: 1",`` |
+| Numerical input. Default is 1.                                | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_POSTINDEXREPLICAS``        |
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+| **Important**: If this setting is changed, the changed configuration only applies to newly-created indexes. To apply the change to            | 
+| existing indexes, purge and rebuild the index after changing this setting.                                                                    |
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+
+Post index shards
+-----------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+| The number of shards to use for each post index.              | - System Config path: N/A                                                     |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.PostIndexShards: 1",``   |
+| Numerical input. Default is 1.                                | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_POSTINDEXSHARDS``          |
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+| **Important**: If this setting is changed, the changed configuration only applies to newly-created indexes. To apply the change to            | 
+| existing indexes, purge and rebuild the index after changing this setting.                                                                    |
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+
+Channel index replicas
+-----------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+----------------------------------------------------------------------------------+
+| The number of replicas to use for each channel index.         | - System Config path: N/A                                                        |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.ChannelIndexReplicas: 1",`` |
+| Numerical input. Default is 1.                                | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_CHANNELINDEXREPLICAS``        |
++---------------------------------------------------------------+----------------------------------------------------------------------------------+
+
+Channel index shards
+--------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+----------------------------------------------------------------------------------+
+| The number of shards to use for each channel index.           | - System Config path: N/A                                                        |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.ChannelIndexShards: 1",``   |
+| Numerical input. Default is 1.                                | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_CHANNELINDEXSHARDS``          |
++---------------------------------------------------------------+----------------------------------------------------------------------------------+
+
+User index replicas
+-------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+| The number of replicas to use for each user index.            | - System Config path: N/A                                                     |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.UserIndexReplicas: 1",`` |
+| Numerical input. Default is 1.                                | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_USERINDEXREPLICAS``        |
++---------------------------------------------------------------+-------------------------------------------------------------------------------+
+
+User index shards
+-----------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+----------------------------------------------------------------------------------+
+| The number of shards to use for each user index.              | - System Config path: N/A                                                        |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.UserIndexShards: 1",``      |
+| Numerical input. Default is 1.                                | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_USERINDEXSHARDS``             |
++---------------------------------------------------------------+----------------------------------------------------------------------------------+
+
+Aggregate search indexes
+-------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+----------------------------------------------------------------------------------------+
+| Elasticsearch indexes older than the age specified by this    | - System Config path: N/A                                                              |
+| setting, in days, will be aggregated during the daily         | - ``config.json`` setting: ``".Elasticsearchsettings.AggregatePostsAfterDays: 365",``  |
+| scheduled job.                                                | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_AGGREGATEPOSTSAFTERDAYS``           |
+|                                                               |                                                                                        |
+| Numerical input. Default is 365 days.                         |                                                                                        |
++---------------------------------------------------------------+----------------------------------------------------------------------------------------+
+| **Note**: If you’re using `data retention <https://docs.mattermost.com/comply/data-retention-policy.html>`__ and                                       |
+| `Elasticsearch <https://docs.mattermost.com/scale/elasticsearch.html>`__, configure this with a value greater than your data retention policy.         |
++---------------------------------------------------------------+----------------------------------------------------------------------------------------+
+
+Post aggregator start time
+--------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+---------------------------------------------------------------------------------------------+
+| The start time of the daily scheduled aggregator job.         | - System Config path: N/A                                                                   |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.PostsAggregatorJobStartTime: "03:00"`` | | Must be a 24-hour time stamp in the form ``HH:MM`` based  on  | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_POSTSAGGREGATORJOBSTARTTIME``            |
+| the local time of the server.                                 |                                                                                             |
+|                                                               |                                                                                             |
+| Default is 03:00 (3 a.m.).                                    |                                                                                             |
++---------------------------------------------------------------+---------------------------------------------------------------------------------------------+
+
+Index prefix
+------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| Prefix added to the Elasticsearch index name.                 | - System Config path: N/A                                                |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.IndexPrefix",``     |
+|                                                               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_INDEXPREFIX``         |
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| **Note**: When this setting is used, all Elasticsearch indexes created by Mattermost are given this prefix. You can set different        |
+| prefixes so that multiple Mattermost deployments can share an Elasticsearch cluster without the index names colliding.                   |
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+
+Live indexing batch size
+------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+-----------------------------------------------------------------------------------+
+| Determines how many new posts are batched together before     | - System Config path: N/a                                                         |
+| they are added to the Elasticsearch index.                    | - ``config.json`` setting: ``".Elasticsearchsettings.LiveIndexingBatchSize: 1",`` |
+|                                                               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_LIVEINDEXINGBATCHSIZE``        |
+| Numerical input. Default is 1.                                |                                                                                   |
++---------------------------------------------------------------+-----------------------------------------------------------------------------------+
+| **Note**: It may be necessary to increase this value to avoid hitting the rate limit of your Elasticsearch cluster on installs handling           | 
+| multiple messages per second.                                                                                                                     |    
++---------------------------------------------------------------+-----------------------------------------------------------------------------------+
+
+Bulk indexing time window
+-------------------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+----------------------------------------------------------------------------------------------+
+| Determines the maximum time window for a batch of posts       | - System Config path: **Environment > Elasticsearch**                                        |
+| being indexed by the Bulk Indexer. This setting serves as a   | - ``config.json`` setting: ``".Elasticsearchsettings.BulkIndexingTimeWindowSeconds: 3600",`` |
+| performance optimization for installs with over ~10 million   | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_BULKINDEXINGTIMEWINDOWSECONDS``           |
+| posts in the database.                                        |                                                                                              |
+|                                                               |                                                                                              |
+| Numerical input in seconds. Default is 3600 seconds (1 hour). |                                                                                              |
+| Approximate this value based on the average number of seconds |                                                                                              |
+| for 2,000 posts to be added to the database on a typical      |                                                                                              |
+| day in production.                                            |                                                                                              |
++---------------------------------------------------------------+----------------------------------------------------------------------------------------------+
+| **Note**: Setting this value too low will cause Bulk Indexing jobs to run slowly.                                                                            |
++---------------------------------------------------------------+----------------------------------------------------------------------------------------------+
+
+Request timeout
+---------------
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+------------------------------------------------------------------------------------+
+| Timeout in seconds for Elasticsearch calls.                   | - System Config path: N/A                                                          |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.RequestTimeoutSeconds:30",``  |
+| Numerical input in seconds. Default is 30 seconds.            | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_REQUESTTIMEOUTSECONDS``         |
++---------------------------------------------------------------+------------------------------------------------------------------------------------+
+
+Trace
+-----
+
+|enterprise| |self-hosted|
+
+*Available in legacy Enterprise Edition E10/E20*
+
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| Options for printing Elasticsearch trace errors.              | - System Config path: N/A                                                |
+|                                                               | - ``config.json`` setting: ``".Elasticsearchsettings.Trace",``           |
+| - **error**: Creates the error trace when initializing        | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_TRACE``               |
+|   the Elasticsearch client and prints any template creation   |                                                                          |
+|   or search query that returns an error as part of the        |                                                                          |
+|   error message.                                              |                                                                          |
+| - **all**: Creates the three traces (error, trace and info)   |                                                                          |
+|   for the driver and doesn’t print the queries because they   |                                                                          |
+|   will be part of the trace log level of the driver.          |                                                                          |
+| - **not specified**: **(Default)** No error trace is created. |                                                                          |
++---------------------------------------------------------------+--------------------------------------------------------------------------+

--- a/source/guides/administration.rst
+++ b/source/guides/administration.rst
@@ -21,6 +21,7 @@ The basics
     User management configuration settings </configure/user-management-configuration-settings>
     Web server configuration settings </configure/web-server-configuration-settings>
     Database configuration settings </configure/database-configuration-settings>
+    Elasticsearch configuraiton settings </configure/elasticsearch-configuration-settings>
     Mattermost deprecated configuration settings </configure/deprecated-configuration-settings>
     Advanced permissions </onboard/advanced-permissions>
     Guest accounts </onboard/guest-accounts>

--- a/source/guides/administration.rst
+++ b/source/guides/administration.rst
@@ -21,7 +21,7 @@ The basics
     User management configuration settings </configure/user-management-configuration-settings>
     Web server configuration settings </configure/web-server-configuration-settings>
     Database configuration settings </configure/database-configuration-settings>
-    Elasticsearch configuraiton settings </configure/elasticsearch-configuration-settings>
+    Elasticsearch configuration settings </configure/elasticsearch-configuration-settings>
     Mattermost deprecated configuration settings </configure/deprecated-configuration-settings>
     Advanced permissions </onboard/advanced-permissions>
     Guest accounts </onboard/guest-accounts>


### PR DESCRIPTION
Part of a larger effort to organize Mattermost configuration settings based on the System Console.