### PR TITLE
Added product UI for clarity

### DIFF
--- a/source/channels/mark-messages-unread.rst
+++ b/source/channels/mark-messages-unread.rst
@@ -17,7 +17,12 @@ Mark messages as unread
   :scale: 30
   :target: https://mattermost.com/deploy
   :alt: Available for Mattermost Self-Hosted deployments.
+  
+.. |more-actions-icon| image:: ../images/dots-horizontal_F01D8.svg
+  :height: 24px
+  :width: 24px
+  :alt: Access additional message actions using the More actions icon.
 
 If you read a message but don't have time to address it right away, you can mark that message as unread. Marking a message as unread bolds the channel in your sidebar, and adds the new messages line above the marked message. 
 
-To mark a message as unread, select the **More Actions** link next to a message, then select **Mark as Unread**.
+To mark a message as unread, select the **More Actions** |more-actions-icon| icon visible when you hover over a message, then select **Mark as Unread**.


### PR DESCRIPTION
Based on customer feedback received through the docs feedback widget, incorporating the product icon to clarify how to mark a message as unread.