### PR TITLE
Update search-for-messages.rst

### DIFF
--- a/source/channels/search-for-messages.rst
+++ b/source/channels/search-for-messages.rst
@@ -183,6 +183,7 @@ Other database-specific differences include:
 PostgreSQL:
 
 - Email addresses don't return results.
+- URLs don't return results.
 - Hashtags or recent mentions of usernames containing a dash don't return results.
 - Terms containing a dash return incorrect results since dashes are ignored in the search engine.
 


### PR DESCRIPTION
User reached out about not seeing any results when searching for URLs on postgres database, and I discovered [this forum post](https://forum.mattermost.com/t/solved-search-messages-with-url-keyword-returns-no-results-found/3068) during investigations. Confirmed with Eric that we won't fix this issue unless we do a backend search rewrite from [MM-1082](https://mattermost.atlassian.net/browse/MM-1082). Updating the docs to reflect this issue.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

