### PR TITLE
Fix the path for Desktop App logs for Linux users

### DIFF
--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -113,7 +113,7 @@ Mattermost Desktop App logs
 The desktop app log file can be found in the user directory:
 
 - **Windows:** ``%userprofile%\AppData\Roaming\Mattermost\logs``
-- **Linux:** ``~/.local/share/Mattermost/logs``
+- **Linux:** ``~/.local/share/Mattermost/logs`` OR ``~/.config/Mattermost/logs``
 - **MacOS:** ``~/Library/Logs/Mattermost``
 
 Mattermost Browser App logs


### PR DESCRIPTION
#### Summary
There's a new directory that logs can be stored. I'm just adding it to the docs :)


