### PR TITLE
PostgreSQL default_text_search_config update

### DIFF
--- a/source/channels/search-for-messages.rst
+++ b/source/channels/search-for-messages.rst
@@ -21,7 +21,7 @@ Search for messages
 .. |product-list| image:: ../images/products_E82F.svg
   :height: 24px
   :width: 24px
-  :alt: Navigate between Channels, Playbooks, and Boards using the Product menu icon.
+  :alt: Navigate between Channels, Playbooks, and Boards using the product menu icon.
 
 Use the Mattermost Search field to find messages, replies, and the contents of files shared across all channels you're a member of in your team's conversation history. File content search is available in Mattermost Server from v5.35 and in Mattermost Cloud, with mobile support coming soon.
 

--- a/source/channels/search-for-messages.rst
+++ b/source/channels/search-for-messages.rst
@@ -191,7 +191,7 @@ PostgreSQL:
 - URLs don’t return results.
 - Hashtags or recent mentions of usernames containing a dash don't return results.
 - Terms containing a dash return incorrect results since dashes are ignored in the search engine.
-- From Mattermost v7.1, search results respect the ``default_text_search_config`` value instead of being hardcoded to English. We recommend that system admins review this value to ensure it's set correctly.
+- From Mattermost v7.1, search results respect the ``default_text_search_config`` value instead of being hardcoded to English. We recommend that Mattermost system admins review this value to ensure it's set correctly.
 
 MySQL:
 

--- a/source/channels/search-for-messages.rst
+++ b/source/channels/search-for-messages.rst
@@ -179,7 +179,7 @@ Searching Chinese, Korean, and Japanese
 Differences between PostgreSQL and MySQL search
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Mattermost uses full text search support included in MySQL and PostgreSQL. These databases have slightly different search behavior. Select the **Product menu** |product-list| then select **About Mattermost** to see which database you’re using.
+By default, Mattermost uses full text search support included in MySQL and PostgreSQL. These databases have slightly different search behavior. Select the **product menu** |product-list| then select **About Mattermost** to see which database you’re using.
 
 For example, different databases have different “stop words” filtered out of search results. See `MySQL <https://dev.mysql.com/doc/refman/5.7/en/fulltext-stopwords.html>`__ or `PostgreSQL <https://www.postgresql.org/docs/10/textsearch-dictionaries.html#TEXTSEARCH-STOPWORDS>`__ database documentation for a full list.
 

--- a/source/channels/search-for-messages.rst
+++ b/source/channels/search-for-messages.rst
@@ -23,7 +23,7 @@ Search for messages
   :width: 24px
   :alt: Navigate between Channels, Playbooks, and Boards using the product menu icon.
 
-Use the Mattermost Search field to find messages, replies, and the contents of files shared across all channels you're a member of in your team's conversation history. File content search is available in Mattermost Server from v5.35 and in Mattermost Cloud, with mobile support coming soon.
+Use the Mattermost search field to find messages, replies, and the contents of files shared across all channels you're a member of in your team's conversation history. File content search is available in Mattermost Server from v5.35 and in Mattermost Cloud, with mobile support coming soon.
 
 .. image:: ../images/ui_search.png
    :alt: Use Search to find messages, replies, and the contents of files shared across channels.

--- a/source/channels/search-for-messages.rst
+++ b/source/channels/search-for-messages.rst
@@ -18,6 +18,11 @@ Search for messages
   :target: https://mattermost.com/deploy
   :alt: Available for Mattermost Self-Hosted deployments.
 
+.. |product-list| image:: ../images/products_E82F.svg
+  :height: 24px
+  :width: 24px
+  :alt: Navigate between Channels, Playbooks, and Boards using the Product menu icon.
+
 Use the Mattermost Search field to find messages, replies, and the contents of files shared across all channels you're a member of in your team's conversation history. File content search is available in Mattermost Server from v5.35 and in Mattermost Cloud, with mobile support coming soon.
 
 .. image:: ../images/ui_search.png
@@ -174,7 +179,7 @@ Searching Chinese, Korean, and Japanese
 Differences between PostgreSQL and MySQL search
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Mattermost uses full text search support included in MySQL and PostgreSQL. These databases have slightly different search behavior. Check **Product menu > About Mattermost** to see which database you’re using.
+By default, Mattermost uses full text search support included in MySQL and PostgreSQL. These databases have slightly different search behavior. Select the **Product menu** |product-list| then select **About Mattermost** to see which database you’re using.
 
 For example, different databases have different “stop words” filtered out of search results. See `MySQL <https://dev.mysql.com/doc/refman/5.7/en/fulltext-stopwords.html>`__ or `PostgreSQL <https://www.postgresql.org/docs/10/textsearch-dictionaries.html#TEXTSEARCH-STOPWORDS>`__ database documentation for a full list.
 
@@ -183,8 +188,10 @@ Other database-specific differences include:
 PostgreSQL:
 
 - Email addresses don't return results.
+- URLs don’t return results.
 - Hashtags or recent mentions of usernames containing a dash don't return results.
 - Terms containing a dash return incorrect results since dashes are ignored in the search engine.
+- From Mattermost v7.1, search results respect the ``default_text_search_config`` value instead of being hardcoded to English. We recommend that system admins review this value to ensure it's set correctly.
 
 MySQL:
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/20472
- Updated Search documentation to include support for PostgreSQL default_text_search_config values