### PR TITLE
mmctl clarifications

### DIFF
--- a/source/configure/configuation-in-mattermost-database.rst
+++ b/source/configure/configuation-in-mattermost-database.rst
@@ -42,7 +42,7 @@ To use the ``mattermost config get`` command:
 
    sudo su mattermost
    cd /opt/mattermost
-   bin/mattermost config get SqlSettings.DataSource
+   config get SqlSettings.DataSource
 
 Example output:
 
@@ -170,7 +170,7 @@ The CLI command to migrate the config to the database should always be run as th
 
    sudo su mattermost
    cd /opt/mattermost
-   bin/mattermost config migrate ./config/config.json 'mysql://mmuser:mostest@tcp(127.0.0.1:3306)/mattermost?charset=utf8mb4,utf8&writeTimeout=30s'
+   config migrate ./config/config.json 'mysql://mmuser:mostest@tcp(127.0.0.1:3306)/mattermost?charset=utf8mb4,utf8&writeTimeout=30s'
 
 .. warning::
    When migrating config, Mattermost will incorporate configuration from any existing ``MM_*`` environment variables set in the current shell. See `Environment Variables  <https://docs.mattermost.com/configure/configuration-settings.html>`_

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -76,6 +76,7 @@ mmctl usage notes
   - We recommend you add the path to the Mattermost ``bin`` folder into your ``$PATH`` environment variable. This ensures that you can run mmctl commands locally regardless of your current directory location.
   - If the ``bin`` directory is not added to the ``$PATH`` environment variable, each time you use mmctl you must be in the ``bin`` directory to run mmctl commands, and the commands must be prefixed with ``./``. If you're working from a different directory, make sure you specify the full path to mmctl when running mmctl commands.
 - Parameters in CLI commands are order-specific.
+- You can use the ``--local`` flag with mmctl commands to run them without authentication by allowing communicating with the server through a unix socket.
 - If special characters (``!``, ``|``, ``(``, ``)``, ``\``, ``'``, and ``"``) are used, the entire argument needs to be surrounded by single quotes (e.g. ``-password 'mypassword!'``, or the individual characters need to be escaped out (e.g. ``password mypassword\!``).
 - Team name and channel name refer to the handles, not the display names. So in the URL ``https://community.mattermost.com/core/channels/town-square`` team name would be ``core`` and channel name would be ``town-square``.
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/docs/issues/5667
- Updated the configuration in Mattermost database documentation to replace existing CLI examples with mmctl examples

In addition, added a usage bullet point to the mmctl documentation clarifying what the ``--local`` flag offers to address documentation feedback provided through the site feedback widget.