### PR TITLE
Update `mmctl plugin marketplace install` command to reflect behavior of only installing latest plugin versions

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -4285,22 +4285,18 @@ mmctl plugin marketplace install
 
 **Description**
 
-Install a plugin available on the Plugin Marketplace server.
+Install a plugin available on the Plugin Marketplace server. The latest version of the plugin will be installed.
 
 **Format**
 
 .. code-block:: sh
 
-   mmctl plugin marketplace install <id> [version] [flags]
+   mmctl plugin marketplace install <id> [flags]
 
 **Examples**
 
 .. code-block:: sh
 
-   # you can specify both the plugin id and its version
-   $ mmctl plugin marketplace install jitsi 2.0.0
-
-   # if you don't specify a version, the latest version will be installed
    $ mmctl plugin marketplace install jitsi
 
 **Options**


### PR DESCRIPTION
#### Summary

As of https://github.com/mattermost/mmctl/pull/489, the `mmctl plugin marketplace install` no longer accepts a version as an argument, as only the latest version of the plugin will be installed. This PR makes it so mention of the plugin version argument is removed.

#### Ticket Link

Fixes https://github.com/mattermost/docs/issues/5794