### PR TITLE
Export file names include Job ID

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -2465,7 +2465,7 @@ mmctl export job list
 
 **Description**
 
-List export jobs. Export files contain the Job ID as the file name.
+List export jobs. Export files include the Job ID in the file name.
 
 **Format**
 
@@ -2546,7 +2546,7 @@ mmctl export list
 
 **Description**
 
-List export files. Export files contain the Job ID as the file name.
+List export files. Export files include the Job ID in the file name.
 
 **Format**
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -2465,7 +2465,7 @@ mmctl export job list
 
 **Description**
 
-List export jobs.
+List export jobs. Export files contain the Job ID as the file name.
 
 **Format**
 
@@ -2546,7 +2546,7 @@ mmctl export list
 
 **Description**
 
-List export files.
+List export files. Export files contain the Job ID as the file name.
 
 **Format**
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/20675
- Updated `mmctl export list` and `mmctl export job list` documentation to note that export files contain the Job ID in the file name.