### PR TITLE
Site URL clarifications for Desktop App server management

### DIFF
--- a/source/welcome/manage-desktop-app-server-connections.rst
+++ b/source/welcome/manage-desktop-app-server-connections.rst
@@ -35,6 +35,11 @@ Using the Mattermost Desktop App, you can connect to multiple Mattermost servers
 
     2. Enter the server name as it will appear in the Desktop App.
     3. Enter the server URL. Server URLs must begin with either ``http://`` or ``https://``.
+
+       .. tip::
+
+        Can't find your Mattermost server URL? Ask your company’s IT department or your Mattermost System Admin for your organization’s **Mattermost Site URL**. It’ll look something like ``https://example.com/company/mattermost``, ``mattermost.yourcompanydomain.com``, or ``chat.yourcompanydomain.com``. These URLs could also end in ``.net``.
+
     4. Select **Add**.
 
       .. image:: ../images/desktop-server-add2.png


### PR DESCRIPTION
Incorporated the same Site URL context for end users managing their Desktop App servers available on the log in page.