### PR TITLE
Docs listening: Update location of macOS logs

### DIFF
--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -114,7 +114,7 @@ The desktop app log file can be found in the user directory:
 
 - **Windows:** ``%userprofile%\AppData\Roaming\Mattermost\logs``
 - **Linux:** ``~/.local/share/Mattermost/logs`` OR ``~/.config/Mattermost/logs``
-- **MacOS:** ``~/Library/Logs/Mattermost`` (prior to Monterey/macOS 12) OR ``~Library/Containters/Mattermost.Desktop/Data/Library/Logs/Mattermost``
+- **macOS:** ``~/Library/Logs/Mattermost`` (prior to Monterey/macOS 12) OR ``~Library/Containters/Mattermost.Desktop/Data/Library/Logs/Mattermost``
 
 Mattermost Browser App logs
 ---------------------------

--- a/source/install/troubleshooting.rst
+++ b/source/install/troubleshooting.rst
@@ -114,7 +114,7 @@ The desktop app log file can be found in the user directory:
 
 - **Windows:** ``%userprofile%\AppData\Roaming\Mattermost\logs``
 - **Linux:** ``~/.local/share/Mattermost/logs`` OR ``~/.config/Mattermost/logs``
-- **MacOS:** ``~/Library/Logs/Mattermost``
+- **MacOS:** ``~/Library/Logs/Mattermost`` (prior to Monterey/macOS 12) OR ``~Library/Containters/Mattermost.Desktop/Data/Library/Logs/Mattermost``
 
 Mattermost Browser App logs
 ---------------------------


### PR DESCRIPTION
From Monterey/macOS 12, Mattermost logs have moved to ~Library/Containters/Mattermost.Desktop/Data/Library/Logs/Mattermost
