### PR TITLE
Fixed `ServiceSettings.WriteTimeout` doc example snippet

### DIFF
--- a/source/configure/web-server-configuration-settings.rst
+++ b/source/configure/web-server-configuration-settings.rst
@@ -196,7 +196,7 @@ Write timeout
 
 +----------------------------------------------------------+-----------------------------------------------------------------------------+
 | - If using HTTP (insecure), this is the maximum time     | - System Config path: **Environment > Web Server**                          |
-|   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeout: 300",`` |
+|   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeout: 300",``         |
 |   until the response is written.                         | - Environment variable: ``MM_SERVICESETTINGS_WRITETIMEOUTTIMEOUT``          |
 | - If using HTTPS, it's the total time from when the      |                                                                             |
 |   connection is accepted until the response is written.  |                                                                             |

--- a/source/configure/web-server-configuration-settings.rst
+++ b/source/configure/web-server-configuration-settings.rst
@@ -196,7 +196,7 @@ Write timeout
 
 +----------------------------------------------------------+-----------------------------------------------------------------------------+
 | - If using HTTP (insecure), this is the maximum time     | - System Config path: **Environment > Web Server**                          |
-|   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeout: 300",``         |
+|   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeout: 300",``        |
 |   until the response is written.                         | - Environment variable: ``MM_SERVICESETTINGS_WRITETIMEOUTTIMEOUT``          |
 | - If using HTTPS, it's the total time from when the      |                                                                             |
 |   connection is accepted until the response is written.  |                                                                             |

--- a/source/configure/web-server-configuration-settings.rst
+++ b/source/configure/web-server-configuration-settings.rst
@@ -197,7 +197,7 @@ Write timeout
 +----------------------------------------------------------+-----------------------------------------------------------------------------+
 | - If using HTTP (insecure), this is the maximum time     | - System Config path: **Environment > Web Server**                          |
 |   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeout: 300",``        |
-|   until the response is written.                         | - Environment variable: ``MM_SERVICESETTINGS_WRITETIMEOUT``               |
+|   until the response is written.                         | - Environment variable: ``MM_SERVICESETTINGS_WRITETIMEOUT``                 |
 | - If using HTTPS, it's the total time from when the      |                                                                             |
 |   connection is accepted until the response is written.  |                                                                             |
 |   accepted to when the request body is fully read.       |                                                                             |

--- a/source/configure/web-server-configuration-settings.rst
+++ b/source/configure/web-server-configuration-settings.rst
@@ -196,7 +196,7 @@ Write timeout
 
 +----------------------------------------------------------+-----------------------------------------------------------------------------+
 | - If using HTTP (insecure), this is the maximum time     | - System Config path: **Environment > Web Server**                          |
-|   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeoutTimeout: 300",`` |
+|   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeout: 300",`` |
 |   until the response is written.                         | - Environment variable: ``MM_SERVICESETTINGS_WRITETIMEOUTTIMEOUT``          |
 | - If using HTTPS, it's the total time from when the      |                                                                             |
 |   connection is accepted until the response is written.  |                                                                             |

--- a/source/configure/web-server-configuration-settings.rst
+++ b/source/configure/web-server-configuration-settings.rst
@@ -197,7 +197,7 @@ Write timeout
 +----------------------------------------------------------+-----------------------------------------------------------------------------+
 | - If using HTTP (insecure), this is the maximum time     | - System Config path: **Environment > Web Server**                          |
 |   allowed from the end of reading the request headers    | - ``config.json`` setting: ``".ServiceSettings.WriteTimeout: 300",``        |
-|   until the response is written.                         | - Environment variable: ``MM_SERVICESETTINGS_WRITETIMEOUTTIMEOUT``          |
+|   until the response is written.                         | - Environment variable: ``MM_SERVICESETTINGS_WRITETIMEOUT``               |
 | - If using HTTPS, it's the total time from when the      |                                                                             |
 |   connection is accepted until the response is written.  |                                                                             |
 |   accepted to when the request body is fully read.       |                                                                             |


### PR DESCRIPTION
The example snippet had the string `Timeout` written twice.
