### PR TITLE
Update Calls limitations section

### DIFF
--- a/source/channels/make-calls.rst
+++ b/source/channels/make-calls.rst
@@ -52,8 +52,8 @@ Client
 Limitations
 -----------
 
-- In Mattermost Cloud, up to eight participants per channel can join a call. This is a temporary and evolving limitation during public beta.
-- In Mattermost self-hosted deployments, the default maximum number of participants is unlimited. The recommended maximum number of participants, across all calls in all channels on the server, is 200. This setting can be changed in **System Console > Plugin Management > Calls > Max call participants**.
+- In Mattermost Cloud, up to forty participants per channel can join a call. This is a temporary and evolving limitation during public beta.
+- In Mattermost self-hosted deployments, the default maximum number of participants is unlimited. The recommended maximum number of participants per call is 200. This setting can be changed in **System Console > Plugin Management > Calls > Max call participants**. There is no limit to the total number of participants across all calls as the supported value greatly depends on instance resources. For more details, refer to the performance section below.
 
 Configuration
 -------------

--- a/source/channels/make-calls.rst
+++ b/source/channels/make-calls.rst
@@ -52,7 +52,7 @@ Client
 Limitations
 -----------
 
-- In Mattermost Cloud, up to forty participants per channel can join a call. This is a temporary and evolving limitation during public beta.
+- In Mattermost Cloud, up to 40 participants per channel can join a call. This is a temporary and evolving limitation during public beta.
 - In Mattermost self-hosted deployments, the default maximum number of participants is unlimited. The recommended maximum number of participants per call is 200. This setting can be changed in **System Console > Plugin Management > Calls > Max call participants**. There's no limit to the total number of participants across all calls as the supported value greatly depends on instance resources. For more details, refer to the performance section below.
 
 Configuration

--- a/source/channels/make-calls.rst
+++ b/source/channels/make-calls.rst
@@ -53,7 +53,7 @@ Limitations
 -----------
 
 - In Mattermost Cloud, up to forty participants per channel can join a call. This is a temporary and evolving limitation during public beta.
-- In Mattermost self-hosted deployments, the default maximum number of participants is unlimited. The recommended maximum number of participants per call is 200. This setting can be changed in **System Console > Plugin Management > Calls > Max call participants**. There is no limit to the total number of participants across all calls as the supported value greatly depends on instance resources. For more details, refer to the performance section below.
+- In Mattermost self-hosted deployments, the default maximum number of participants is unlimited. The recommended maximum number of participants per call is 200. This setting can be changed in **System Console > Plugin Management > Calls > Max call participants**. There's no limit to the total number of participants across all calls as the supported value greatly depends on instance resources. For more details, refer to the performance section below.
 
 Configuration
 -------------


### PR DESCRIPTION
#### Summary

A couple of changes:

- Cloud limit was updated to 40 last week.
- Fixing the self-hosted limit description as it's per call and not global.
