### PR TITLE
Add cloud tag to compliance monitoring docs

### DIFF
--- a/source/comply/compliance-monitoring.rst
+++ b/source/comply/compliance-monitoring.rst
@@ -3,7 +3,7 @@ Compliance monitoring
 
 .. This page is intentionally NOT accessible from the LHS.
 
-|enterprise| |self-hosted|
+|enterprise| |cloud| |self-hosted|
 
 .. |enterprise| image:: ../images/enterprise-badge.png
   :scale: 30

--- a/source/comply/compliance-monitoring.rst
+++ b/source/comply/compliance-monitoring.rst
@@ -10,6 +10,11 @@ Compliance monitoring
   :target: https://mattermost.com/pricing
   :alt: Available in the Mattermost Enterprise subscription plan.
 
+.. |cloud| image:: ../images/cloud-badge.png
+  :scale: 30
+  :target: https://mattermost.com/sign-up
+  :alt: Available for Mattermost Cloud deployments.
+
 .. |self-hosted| image:: ../images/self-hosted-badge.png
   :scale: 30
   :target: https://mattermost.com/deploy


### PR DESCRIPTION
Compliance monitoring is available in Cloud. Below is a screenshot showing the feature in the admin console, under the Enterprise plan

<img width="181" alt="image" src="https://user-images.githubusercontent.com/13119842/183496305-ca0d8e12-5418-4008-b04c-36c98a73edb6.png">
<img width="459" alt="image" src="https://user-images.githubusercontent.com/13119842/183496375-700ea156-2140-4544-b139-8edac9d0ac3e.png">