### PR TITLE
Add copy to Workspace Limits page

### DIFF
--- a/source/onboard/mattermost-limits.rst
+++ b/source/onboard/mattermost-limits.rst
@@ -29,14 +29,16 @@ Mattermost Starter limits
 - Maximum 5 saved views per board.
 - Only the 500 most recently updated cards on the server are displayed.
 
+.. note::
+   
+   Mattermost reserves the right to archive or delete messages and establish or change (1) limits as to how many messages can be stored, (2) how long such messages will be stored, and (3) charges for storing such messages. Mattermost further reserves the right to establish or change limits on periods of inactivity that may result in the termination of your messages cloud storage and deletion or archiving of any stored messages.
+
 Mattermost Professional limits
 ------------------------------
 
 **Platform limits**
 
 - 250GB file storage limit.
-
-Mattermost reserves the right to archive or delete messages and establish or change (1) limits as to how many messages can be stored, (2) how long such messages will be stored, and (3) charges for storing such messages. Mattermost further reserves the right to establish or change limits on periods of inactivity that may result in the termination of your messages cloud storage and deletion or archiving of any stored messages.
 
 Frequently Asked Questions
 --------------------------

--- a/source/onboard/mattermost-limits.rst
+++ b/source/onboard/mattermost-limits.rst
@@ -36,6 +36,8 @@ Mattermost Professional limits
 
 - 250GB file storage limit.
 
+Mattermost reserves the right to archive or delete messages and establish or change (1) limits as to how many messages can be stored, (2) how long such messages will be stored, and (3) charges for storing such messages. Mattermost further reserves the right to establish or change limits on periods of inactivity that may result in the termination of your messages cloud storage and deletion or archiving of any stored messages.
+
 Frequently Asked Questions
 --------------------------
 


### PR DESCRIPTION
#### Summary
This PR adds legal copy to the Workspace Limits page.

Directive was to add the following sentence before the FAQ: 

> Mattermost reserves the right to archive or delete messages and establish or change (1) limits as to how many messages can be stored, (2) how long such messages will be stored, and (3) charges for storing such messages. Mattermost further reserves the right to establish or change limits on periods of inactivity that may result in the termination of your messages cloud storage and deletion or archiving of any stored messages.

@jasonblais Changes as per the thread with Nirosha. Let me know if we want to differentiate the new copy in any way (ex. putting it in a Note section as seen further up on the page where it says `These limits do not apply to self-hosted deployments.`, or changing the text styling, etc.

cc: @cwarnermm for general visibility, and in case there's already guidelines for how to treat this kind of copy.

Thanks!