### PR TITLE
Small fixes identified while following

### DIFF
--- a/source/onboard/migrating-to-mattermost.rst
+++ b/source/onboard/migrating-to-mattermost.rst
@@ -184,17 +184,19 @@ Next, run this command to do the conversion. Replace ``<TEAM NAME>`` with the na
 
     ./mmetl transform slack --team <TEAM NAME> --file export-with-emails-and-attachments.zip --output mattermost_import.jsonl
 
-Next you have to create a zip file with the ``mattermost_import.jsonl`` file and the directory ``bulk-export-attachments`` that contains the attachments. On Linux and Mac you can use this command:
+Next you have to create a zip file with the ``mattermost_import.jsonl`` file and the directory ``bulk-export-attachments`` (which needs to be moved to a subdirectory ``data`` first) that contains the attachments. On Linux and Mac you can use this command:
 
 .. code:: bash
 
-    zip -r mattermost-bulk-import.zip bulk-export-attachments mattermost_import.jsonl
+    mkdir data
+    mv bulk-export-attachments data
+    zip -r mattermost-bulk-import.zip data mattermost_import.jsonl
 
 The file ``mattermost-bulk-import.zip`` is now ready to import into Mattermost.
 
 **5. Import into Mattermost**
 
-Now you can start the import process. Once you have ``mmctl`` installed and authenticated use this command to upload ``mattermost-bulk-export.zip``:
+Now you can start the import process. Once you have ``mmctl`` installed and authenticated use this command to upload ``mattermost-bulk-import.zip``:
 
 .. code:: bash
 


### PR DESCRIPTION
I tried to follow the instructions today and recognized a few issues with this documentation.

If you do not move the "bulk-export-attachments" folder to a "data" subfolder, the import process is not able to find the attachments.
Also the filename "mattermost-bulk-export.zip" was wrong (should be import).

I also saw that this document uses content backlinks top, others don't. What's the default setting of that option? I mean the documentation looks a bit different anways depending on what site you are (anchor links on the left, anchor links on the right, clickable headings yes/no)...

Changing the "backlinks" option to "none" here fixes this problem and it's much more intuitive IMHO if you want to share the link to a section, but then again, you cannot go back to the TOC with just one click.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

