### PR TITLE
Update important-upgrade-notes.rst

### DIFF
--- a/source/upgrade/important-upgrade-notes.rst
+++ b/source/upgrade/important-upgrade-notes.rst
@@ -17,6 +17,7 @@ Important Upgrade Notes
    - Support for Mattermost Server v6.3 `Extended Support Release <https://docs.mattermost.com/upgrade/extended-support-release.html>`_ is coming to the end of its life cycle in October 15, 2022. Upgrading to Mattermost Server v7.1 `Extended Support Release <https://docs.mattermost.com/upgrade/extended-support-release.html>`_ or later is recommended.
    - MySQL 8.0.22 contains an `issue with JSON column types <https://bugs.mysql.com/bug.php?id=101284>`__ changing string values to integers which is preventing Mattermost from working properly. Users are advised to avoid this database version.
    - Upgrading the Microsoft Teams Calling plugin to v2.0.0 requires users to reconnect their accounts.
+   - When upgrading to 7.x from a 5.x release please make sure to upgrade to 5.37.9 first for the upgrade to complete successfully.
 
 +----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | If you’re upgrading from a version earlier than... | Then...                                                                                                                                                          |


### PR DESCRIPTION
Added a note to upgrade to 5.37.9 first when upgrading to 7.x from 5.x since there seem to be some migration steps missing.
Several community members ran into this issue so adding the note here could help for future updates, considering many folks are still on 5.x releases.