### PR TITLE
Post formatting options can be disabled

### DIFF
--- a/source/channels/channels-settings.rst
+++ b/source/channels/channels-settings.rst
@@ -280,11 +280,7 @@ If disabled, pressing :kbd:`Shift` :kbd:`Enter` on Windows or Linux, or pressing
 Enable post formatting
 ~~~~~~~~~~~~~~~~~~~~~~
 
-This setting controls whether post formatting is rendered. When **On**, posts will be rendered with `Markdown formatting <https://docs.mattermost.com/channels/format-messages.html>`__, emoji, autolinked URLs, and line breaks. When **Off**, the raw text will be shown.
-
-.. note::
-
-  From Mattermost v7.0, this setting has been deprecated in favor of the `message formatting toolbar <https://docs.mattermost.com/channels/format-messages.html#use-the-messaging-formatting-toolbar>`__.
+This setting controls whether post formatting is rendered. When **On**, posts will be rendered with Markdown formatting, emoji, autolinked URLs, and line breaks. When **Off**, the raw text will be shown. See the `formatting messages <https://docs.mattermost.com/channels/format-messages.html#use-the-messaging-formatting-toolbar>`__ documentation for details.
 
 Enable join/leave messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -310,7 +306,7 @@ Configure where to start when viewing channels with unread messages. You can sta
 Performance debugging
 ~~~~~~~~~~~~~~~~~~~~~
 
-Turn on settings intended to help isolate performance issues while debugging. We don't recommend leaving these settings enabled for an extended period of time as they can negatively impact your user experience. Available only when `client performance debugging <https://docs.mattermost.com/configure/configuration-settings.html>`__ is enabled.
+Turn on settings intended to help isolate performance issues while debugging. We don't recommend leaving these settings enabled for an extended period of time as they can negatively impact your user experience. Available only when `client performance debugging <https://docs.mattermost.com/configure/environment-configuration-settings.html#enable-client-performance-debugging>`__ is enabled.
 
 Deactivate account
 ~~~~~~~~~~~~~~~~~~

--- a/source/channels/format-messages.rst
+++ b/source/channels/format-messages.rst
@@ -21,37 +21,31 @@ Format messages
 .. |bold-icon| image:: ../images/format-bold_F0264.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Bold message text using the Bold icon in the message formatting toolbar.
 
 .. |italics-icon| image:: ../images/format-italic_F0277.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Italicize message text using the Italic icon in the message formatting toolbar.
 
 .. |strikeout-icon| image:: ../images/format-strikethrough-variant_F0281.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Strike out message text using the Strikethrough icon in the message formatting toolbar.
 
 .. |headings-icon| image:: ../images/format-header_E81D.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Format message text as a heading using the Heading icon in the message formatting toolbar. Headings 1 through 6 are supported.
 
 .. |links-icon| image:: ../images/link-variant_F0339.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Add a message link using the Link icon in the message formatting toolbar.
 
 .. |attachments-icon| image:: ../images/paperclip_F03E2.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Add a message attachment using the Upload files icon in the message formatting toolbar.
 
 .. |numbered-icon| image:: ../images/format-list-numbered_F027B.svg
@@ -69,32 +63,32 @@ Format messages
 .. |quotes-icon| image:: ../images/format-quote-open_F0757.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Format message text as a quotation using the Quote icon in the message formatting toolbar.
 
 .. |code-icon| image:: ../images/code-tags_F0174.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Format message text as code using the Code icon in the message formatting toolbar.
 
 .. |emoji-icon| image:: ../images/emoticon-outline_F01F2.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Add emojis or GIFs to message text using the Emoji/Gif picker icon in the message formatting toolbar.
 
 .. |hide-formatting-icon| image:: ../images/format-letter-case_F0B34.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Hide formatting options in the message formatting toolbar using the Show/Hide Formatting icon.
 
 .. |preview-icon| image:: ../images/eye-outline_F06D0.svg
   :height: 24px
   :width: 24px
-  :target: https://mattermost.com/deploy
   :alt: Review your message text formatting using the Show/Hide preview icon in the message formatting toolbar.
+
+.. |settings-icon| image:: ../images/settings-outline_F08BB.svg
+  :height: 24px
+  :width: 24px
+  :alt: Access and manage your Channels settings using the Gear icon next to your user profile image.
 
 Use the messaging formatting toolbar
 ------------------------------------
@@ -128,7 +122,11 @@ The message formatting toolbar offers the following formatting options:
 
 Review how your message formatting will look when the message is sent by selecting the **Show/Hide Preview** |preview-icon| icon. Return to your draft message by selecting the icon again.
 
-You can hide the formatting options by selecting the **Show/Hide Formatting** |hide-formatting-icon| icon. Select the icon again to show the formatting options.
+.. tip::
+
+  - Hide the formatting options by selecting the **Show/Hide Formatting** |hide-formatting-icon| icon. Select the icon again to show the formatting options. 
+  - Disable the formatting options by selecting the **Gear** |settings-icon| icon, going to **Settings > Advanced > Enable Post Formatting**, and setting this option to **Off**. 
+  - System Admins can disable the formatting options for all users in the System Console by going to **Environment > Developer > Enable Client Performance Debugging**. See the `configuration settings <https://docs.mattermost.com/configure/environment-configuration-settings.html#enable-client-performance-debugging>`__ documentation for details.
 
 Use Markdown
 -------------

--- a/source/channels/format-messages.rst
+++ b/source/channels/format-messages.rst
@@ -125,9 +125,8 @@ Review how your message formatting will look when the message is sent by selecti
 .. tip::
 
   - Hide the formatting options by selecting the **Show/Hide Formatting** |hide-formatting-icon| icon. Select the icon again to show the formatting options. 
-  - Disable the formatting options by selecting the **Gear** |settings-icon| icon, going to **Settings > Advanced > Enable Post Formatting**, and setting this option to **Off**. 
-  - System Admins can disable the formatting options for all users in the System Console by going to **Environment > Developer > Enable Client Performance Debugging**. See the `configuration settings <https://docs.mattermost.com/configure/environment-configuration-settings.html#enable-client-performance-debugging>`__ documentation for details.
-
+  - You can control whether post formatting is rendered within the message formatting editor. When disabled, raw text is shown. See the `Channels customization <https://docs.mattermost.com/channels/channels-settings.html#enable-post-formatting>`__ documentation for details. 
+ 
 Use Markdown
 -------------
 

--- a/source/configure/developer-mode-configuration-settings.rst
+++ b/source/configure/developer-mode-configuration-settings.rst
@@ -40,7 +40,7 @@ Enable testing commands
 *Available in legacy Enterprise Edition E10/E20*
 
 +---------------------------------------------------+--------------------------------------------------------------------------+
-| Enable or disable the ``/test`` slash command.    | - System Config path: **Environment > DeveloperFlags**                   |
+| Enable or disable the ``/test`` slash command.    | - System Config path: **Environment > Developer**                        |
 |                                                   | - ``config.json setting``: ``".ServiceSettings.EnableTesting": true",``  |
 | - **true**: **(Default)** The ``/test`` slash     | - Environment variable: ``MM_SERVICESETTINGS_ENABLETESTING``             |
 |   command is enabled to load test accounts        |                                                                          |
@@ -57,7 +57,7 @@ Enable developer mode
 *Available in legacy Enterprise Edition E10/E20*
 
 +-----------------------------------------------+---------------------------------------------------------------------------+
-| Enable or disable developer mode.             | - System Config path: **Environment > DeveloperFlags**                    |
+| Enable or disable developer mode.             | - System Config path: **Environment > Developer**                         |
 |                                               | - ``config.json setting``: ``".ServiceSettings.EnableDeveloper": true",`` |
 | - **true**: **(Default)** Javascript errors   | - Environment variable: ``MM_SERVICESETTINGS_ENABLEDEVELOPER``            |
 |   are shown in a banner at the top of         |                                                                           |
@@ -75,7 +75,7 @@ Enable client performance debugging
 *Available in legacy Enterprise Edition E10/E20*
 
 +---------------------------------------------------+------------------------------------------------------------------------------+
-| Enable or disable the ``/test`` slash command.    | - System Config path: **Environment > DeveloperFlags**                       |
+| Enable or disable the ``/test`` slash command.    | - System Config path: **Environment > Developer**                            |
 |                                                   | - ``config.json setting``: ``".ServiceSettings.EnableDeveloper": false",``   |
 | - **true**: **(Default)** The ``/test`` slash     | - Environment variable: ``MM_SERVICESETTINGS_ENABLEDEVELOPER``               |
 |   command is enabled to load test accounts        |                                                                              |
@@ -95,7 +95,7 @@ Allow untrusted internal connections
 *Available in legacy Enterprise Edition E10/E20*
 
 +-----------------------------------------------+-----------------------------------------------------------------------------------------------+
-| Limit the ability for the Mattermost server   | - System Config path: **Environment > DeveloperFlags**                                        |
+| Limit the ability for the Mattermost server   | - System Config path: **Environment > Developer**                                             |
 | to make untrusted requests within its local   | - ``config.json setting``: ``".ServiceSettings.AllowedUntrustedInternalConnections": "",``    |
 | network. A request is considered “untrusted”  | - Environment variable: ``MM_SERVICESETTINGS_ALLOWUNTRUSTEDINTERNALCONNECTIONS``              |
 | when it’s made on behalf of a client.         |                                                                                               |


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-webapp/pull/10881
- Clarified message formatting documentation with hide vs disable details
- corrected System Console paths for Environment > Developer config setting options
