### PR TITLE
Muted channels aren't returned via Find Channels

### DIFF
--- a/source/channels/find-channels.rst
+++ b/source/channels/find-channels.rst
@@ -11,7 +11,7 @@ To see all available public channels you can join that you're not already a memb
 
 .. tip:: 
   
-  Want to see all of the channels you're already a member of? Select **Find Channel** in the channel sidebar to see all of the channels you're currently a member of across all of your teams, including public and private channels, direct and group messages, channels with unread messages, and threads.
+  Want to see all of the channels you're already a member of? Select **Find Channel** in the channel sidebar to see all of the channels you're currently a member of across all of your teams, including public and private channels, direct and group messages, channels with unread messages, and threads. Channels you have `muted <https://docs.mattermost.com/channels/set-channel-preferences.html#mute-channel>`__ aren't included in results.
 
 Revisit recent channels
 -----------------------


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-webapp/pull/10971
- Updated Find Channels documentation to note that muted channels aren't included in results.