### PR TITLE
Clarified that message formatting is available from Mattermost v7.2

### DIFF
--- a/source/channels/forward-messages.rst
+++ b/source/channels/forward-messages.rst
@@ -4,7 +4,7 @@ Forward messages
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-To forward messages in Mattermost, select the **More** |more-icon| icon next to a message, then select **Forward**. 
+From Mattermost v7.2, you can forward messages in Mattermost to another channel by selecting the **More** |more-icon| icon next to a message, then selecting **Forward**. 
 
 .. |more-icon| image:: ../images/dots-horizontal_F01D8.svg
   :alt: When you hover over messages, you can access more message options from the More icon.


### PR DESCRIPTION
Based on user feedback, updated the Channels end user product documentation to clarify that message formatting is available from Mattermost release v7.2.