### PR TITLE
Document channel deletion with content (#5953)

### DIFF
--- a/source/configure/user-management-configuration-settings.rst
+++ b/source/configure/user-management-configuration-settings.rst
@@ -71,6 +71,9 @@ Channels
 |                                                                         | - ``config.json setting``: N/A                              |
 |                                                                         | - Environment variable: N/A                                 |
 +-------------------------------------------------------------------------+-------------------------------------------------------------+
+| Channels can be deleted with all content, including posts in the database, using the `mmctl channel delete                            |
+| </manage/mmctl-command-line-tool.html#mmctl-channel-delete>`__ tool.                                                                  |
++-------------------------------------------------------------------------+-------------------------------------------------------------+
 | **Note**: You can search for channels by channel name or by channel ID.                                                               |
 +-------------------------------------------------------------------------+-------------------------------------------------------------+
 


### PR DESCRIPTION
#### Summary
Updated `/configure/user-management-configuration-settings.html` to include a link and explanation about `mmctl channel delete`.

#### Ticket Link
Fixes https://github.com/mattermost/docs/issues/5953