### PR TITLE
Corrected auto-update desktop app content

### DIFF
--- a/source/install/desktop-app-install.rst
+++ b/source/install/desktop-app-install.rst
@@ -24,7 +24,7 @@ You can `download the desktop app directly from our Downloads page <https://matt
 
   .. tab:: Ubuntu/Debian
 
-    A ``.deb`` package is available for Debian 9 and for Ubuntu releases 18.04 LTS or later. Automatic app updates aren’t supported. You must update your app manually.
+    An official ``.deb`` package and APT repository is available for Debian 9 and for Ubuntu releases 18.04 LTS or later. Automatic app updates are supported and enabled. When a new version of the desktop app is released, your app updates automatically.
 
     1. At the command line, set up the Mattermost repository on your system: 
 
@@ -105,7 +105,7 @@ You can `download the desktop app directly from our Downloads page <https://matt
 
   .. tab:: Generic Linux
 
-    A beta AppImage distribution of a compressed tarball is available. Automatic app updates aren’t supported. You must update your app manually. 
+    A beta AppImage distribution of a compressed tarball is available. Automatic app updates are supported and enabled. When a new version of the desktop app is released, your app updates automatically. 
 
     1. Download the latest version of the Mattermost desktop app:
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/desktop/pull/2177

- Updated **Ubuntu/Debian** tab to clarify that auto-updates are supported and that an official APT repository is available for Debian 9 and Ubuntu 18.04.
- Updated **Generic Linux** tab to clarify that auto-updates are supported.