### PR TITLE
Fix broken link to docs for enabling local mode

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -161,7 +161,7 @@ The API that the socket exposes follows the same specification that can be found
 Activating local mode
 ~~~~~~~~~~~~~~~~~~~~~
 
-To use local mode, the Mattermost server first needs to `have local mode enabled </configure/configuration-settings.html#enable-local-mode>`_. When local mode is enabled, a socket is created at ``/var/tmp/mattermost_local.socket`` by default.
+To use local mode, the Mattermost server first needs to `have local mode enabled </configure/experimental-configuration-settings.html#enable-local-mode-for-mmctl>`_. When local mode is enabled, a socket is created at ``/var/tmp/mattermost_local.socket`` by default.
 
 .. tip::
 


### PR DESCRIPTION
#### Summary
The link was broken. The next link pointing to https://docs.mattermost.com/configure/configuration-settings.html#enable-local-mode-socket-location works (it somehow redirects to experimental settings page). That's how I found the correct link target. I tried only fixing the URL's anchor first, but the automatic redirect did not work as it does with the other link somehow. So I added a link that directly points to the experimental settings page.

#### Ticket Link
(none)
