### PR TITLE
fix link to channels/organize-conversations

### DIFF
--- a/source/channels/reply-to-messages.rst
+++ b/source/channels/reply-to-messages.rst
@@ -34,4 +34,4 @@ To shrink the right-hand sidebar to its original width, select the same **Collap
 Work with Collapsed Reply Threads
 ---------------------------------
 
-Collapsed Reply Threads is generally available in Mattermost Cloud and from self-hosted Mattermost v7.0, and is enabled by default for all new Mattermost deployments. Collapsed Reply Threads offer a new way to organize conversations within channels. See our `Organizing Conversations using Collapsed Reply Threads </channels#organize-conversations.html>`__ documentation to learn more.
+Collapsed Reply Threads is generally available in Mattermost Cloud and from self-hosted Mattermost v7.0, and is enabled by default for all new Mattermost deployments. Collapsed Reply Threads offer a new way to organize conversations within channels. See our `Organizing Conversations using Collapsed Reply Threads </channels/organize-conversations.html>`__ documentation to learn more.


### PR DESCRIPTION
#### Summary
The link should now be correct. / instead of #.
