### PR TITLE
source/configure: add config in db editing limitations

### DIFF
--- a/source/configure/configuation-in-mattermost-database.rst
+++ b/source/configure/configuation-in-mattermost-database.rst
@@ -14,6 +14,12 @@ Benefits to using this option:
 * Ensure all servers in a High Availability deployment have the same configuration, even when new servers are added to the cluster.
 * Automatically deploy SAML certificates and keys to all servers in the cluster.
 
+Note that once you start using configuration in the database, you can't manually edit the active configuration row. You will either need to do one of:
+
+* Use the System Console to make changes to the configuration.
+* Use ``mmctl`` to make changes to the configuration.
+* Stop any of the running mattermost-server instances and edit the active configuration row directly in the ``Configurations`` table.
+
 How to migrate configuration to the database
 --------------------------------------------
 


### PR DESCRIPTION
#### Summary
Add the some of the limitations of using Configuration in a Database. 

PS: Wondering if also need to rebrand this as "Configuration in a Database" rather than "Configuration in the Mattermost Database"? We actually allow to use different databases for Configuration and Mattermost itself.
