### PR TITLE
Update hardware requirements

### DIFF
--- a/source/install/software-hardware-requirements.rst
+++ b/source/install/software-hardware-requirements.rst
@@ -85,7 +85,7 @@ Server software
 Mattermost server operating system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Ubuntu 18.04, Debian Buster, CentOS 6+, CentOS 7+, RedHat Enterprise Linux 7+, Oracle Linux 6+, Oracle Linux 7+.
+- Ubuntu 20.04, Debian Buster, CentOS 6+, CentOS 7+, RedHat Enterprise Linux 7+, Oracle Linux 6+, Oracle Linux 7+.
 - Using the Mattermost `Docker deployment <https://github.com/mattermost/docker>`__ on a Docker-compatible operating system (Linux-based OS) is still recommended.
 
 While community support exists for Fedora, FreeBSD, and Arch Linux, Mattermost does not currently include production support for these platforms.


### PR DESCRIPTION
Based on this thread, the supported Ubuntu version is now 20.04 https://community.mattermost.com/private-core/pl/48an6do9rbyh3kggbh7iqntmpy. I'll also add a note to the changelog.