### PR TITLE
Remove openid from required scopes in GitLab integration

### DIFF
--- a/source/onboard/sso-gitlab.rst
+++ b/source/onboard/sso-gitlab.rst
@@ -36,7 +36,7 @@ Step 1: Add an OpenID Connect application to your GitLab account
 
   c. Select scopes.
   
-     - For Mattermost Team Edition, select ``read_user`` and ``openid``.
+     - For Mattermost Team Edition, select ``read_user``.
      - For Mattermost Enterprise, select ``openid``, ``profile``, and ``email``.
 
 3. Select **Save application**.
@@ -52,7 +52,7 @@ Step 2: Configure Mattermost for GitLab SSO
 4. The **Discovery Endpoint** for OpenID Connect with GitLab is prepopulated with ``https://gitlab.com/.well-known/openid-configuration``.
 5. Paste the **Application ID** from GitLab as the **Client ID** in Mattermost.
 6. Paste the **Application Secret Key** from GitLab as the **Client Secret** in Mattermost. 
-7. Update the ``config.json`` file to specify the scopes selected for the ``GitLabSettings`` property. At a minimum, ``openid`` is a required scope for the connector to work. Changes to this setting require a server restart before taking effect. 
+7. Update the ``config.json`` file and specify the scopes you selected in GitLab for the ``GitLabSettings`` property. At a minimum, ``openid`` is a required scope for the connector to work. Changes to this setting require a server restart before taking effect. 
 8. Select **Save**.
 
 .. note::

--- a/source/onboard/sso-gitlab.rst
+++ b/source/onboard/sso-gitlab.rst
@@ -52,7 +52,7 @@ Step 2: Configure Mattermost for GitLab SSO
 4. The **Discovery Endpoint** for OpenID Connect with GitLab is prepopulated with ``https://gitlab.com/.well-known/openid-configuration``.
 5. Paste the **Application ID** from GitLab as the **Client ID** in Mattermost.
 6. Paste the **Application Secret Key** from GitLab as the **Client Secret** in Mattermost. 
-7. Update the ``config.json`` file and specify the scopes you selected in GitLab for the ``GitLabSettings`` property. At a minimum, ``openid`` is a required scope for the connector to work. Changes to this setting require a server restart before taking effect. 
+7. Update the ``config.json`` file and specify the scopes you selected in GitLab under the ``GitLabSettings`` property. At a minimum, ``openid`` is a required scope for Mattermost Professional and Enterprise, and `read_user` is a required scope for Mattermost Team . Changes to this setting require a server restart before taking effect. 
 8. Select **Save**.
 
 .. note::

--- a/source/onboard/sso-gitlab.rst
+++ b/source/onboard/sso-gitlab.rst
@@ -52,7 +52,7 @@ Step 2: Configure Mattermost for GitLab SSO
 4. The **Discovery Endpoint** for OpenID Connect with GitLab is prepopulated with ``https://gitlab.com/.well-known/openid-configuration``.
 5. Paste the **Application ID** from GitLab as the **Client ID** in Mattermost.
 6. Paste the **Application Secret Key** from GitLab as the **Client Secret** in Mattermost. 
-7. Update the ``config.json`` file and specify the scopes you selected in GitLab under the ``GitLabSettings`` property. At a minimum, ``openid`` is a required scope for Mattermost Professional and Enterprise, and `read_user` is a required scope for Mattermost Team . Changes to this setting require a server restart before taking effect. 
+7. Update the ``config.json`` file and specify the scopes you selected in GitLab under the ``GitLabSettings`` property. At a minimum, ``openid`` is a required scope for Mattermost Professional and Enterprise, and `read_user` is a required scope for Mattermost Team Edition. Changes to this setting require a server restart before taking effect. 
 8. Select **Save**.
 
 .. note::


### PR DESCRIPTION
The GitLab SSO only needs the `read_user` scope for Mattermost Team Edition.

This was previously discussed in
https://github.com/mattermost/docs/pull/5317#pullrequestreview-830627647,
but it seems the `openid`   scope was documented anyway.

Also mentioned in https://github.com/mattermost/mattermost-server/issues/20499.

