### PR TITLE
Adjust documentation for downgrading a cloud subscription

### DIFF
--- a/source/about/cloud-subscriptions.rst
+++ b/source/about/cloud-subscriptions.rst
@@ -111,12 +111,12 @@ What happens if I decide to purchase a subscription to Mattermost Enterprise dur
 
 Your plan immediately changes to the plan you've upgraded to. Your trial will continue and on day 31 billing will commence. You won't incur any charges of your new plan until the trial period is over. Depending on what day of the month this is, you'll be billed prorata. You'll receive your bill at the end of the calendar month for this month and going forward.
 
-How do I downgrade my subscription?
+How do I change my subscription to Cloud Free?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you are on the Cloud Enterprise plan and wish to adjust your subscription, please contact our `Support team <mailto:support@mattermost.com>`_.
 
-To downgrade your subscription from Cloud Professional to Cloud Free:
+To change your subscription from Cloud Professional to Cloud Free:
 - Navigate to your system console's Subscription and Billing page (Go to https://<your workspace url>/admin_console/billing/subscription)
 - Click the "View Plans" button
 - A modal will appear. To downgrade, click the "Downgrade" button

--- a/source/about/cloud-subscriptions.rst
+++ b/source/about/cloud-subscriptions.rst
@@ -117,7 +117,7 @@ How do I change my subscription to Cloud Free?
 If you are on the Cloud Enterprise plan and wish to adjust your subscription, please contact our `Support team <mailto:support@mattermost.com>`_.
 
 To change your subscription from Cloud Professional to Cloud Free:
-- Navigate to your system console's Subscription and Billing page (Go to https://<your workspace url>/admin_console/billing/subscription)
+- Navigate to your system console's Billing & Account > Subscription page (Or, go to https://<your workspace url>/admin_console/billing/subscription in your browser)
 - Click the "View Plans" button
 - A modal will appear. To downgrade, click the "Downgrade" button
 

--- a/source/about/cloud-subscriptions.rst
+++ b/source/about/cloud-subscriptions.rst
@@ -111,10 +111,15 @@ What happens if I decide to purchase a subscription to Mattermost Enterprise dur
 
 Your plan immediately changes to the plan you've upgraded to. Your trial will continue and on day 31 billing will commence. You won't incur any charges of your new plan until the trial period is over. Depending on what day of the month this is, you'll be billed prorata. You'll receive your bill at the end of the calendar month for this month and going forward.
 
-How do I change my subscription from Mattermost Enterprise to Mattermost Professional?
+How do I downgrade my subscription?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To downgrade, please contact our `Support team <mailto:support@mattermost.com>`_.
+If you are on the Cloud Enterprise plan and wish to adjust your subscription, please contact our `Support team <mailto:support@mattermost.com>`_.
+
+To downgrade your subscription from Cloud Professional to Cloud Free:
+- Navigate to your system console's Subscription and Billing page (Go to https://<your workspace url>/admin_console/billing/subscription)
+- Click the "View Plans" button
+- A modal will appear. To downgrade, click the "Downgrade" button
 
 Can I purchase an annual Mattermost Cloud subscription?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
Update to the documentation. Previously you couldn't self-serve downgrade at all. Now you can do so to go from Professional to Free - Enterprise still requires a support ticket. 

#### Ticket Link
N/A - noticed this when trying to send documentation to a customer so figured I'd update it. 
