### PR TITLE
Elasticsearch documentation updates

### DIFF
--- a/source/configure/elasticsearch-configuration-settings.rst
+++ b/source/configure/elasticsearch-configuration-settings.rst
@@ -3,7 +3,7 @@
 
 Elasticsearch provides enterprise-scale deployments with optimized search performance and prevents performance degradation and timeouts. Learn more about `Elasticsearch </scale/elasticsearch.html>`__ in our product documentation. 
 
-You can configure the Elasticsearch environment in which Mattermost is deployed by going to **System Console > Environment > Elasticsearch**, or by editing the ``config.json`` file as described in the following tables. Changes to configuration settings in this section require a server restart before taking effect.
+You can configure the Elasticsearch environment in which Mattermost is deployed in **System Console > Environment > Elasticsearch**. You can also edit the ``config.json`` file as described in the following tables. Changes to configuration settings in this section require a server restart before taking effect.
 
 Enable Elasticsearch indexing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/configure/elasticsearch-configuration-settings.rst
+++ b/source/configure/elasticsearch-configuration-settings.rst
@@ -3,7 +3,7 @@
 
 Elasticsearch provides enterprise-scale deployments with optimized search performance and prevents performance degradation and timeouts. Learn more about `Elasticsearch </scale/elasticsearch.html>`__ in our product documentation. 
 
-Configure the Elasticsearch environment in which Mattermost is deployed by going to **System Console > Environment > Elasticsearch**, or by editing the ``config.json`` file as described in the following tables. Changes to configuration settings in this section require a server restart before taking effect.
+You can configure the Elasticsearch environment in which Mattermost is deployed by going to **System Console > Environment > Elasticsearch**, or by editing the ``config.json`` file as described in the following tables. Changes to configuration settings in this section require a server restart before taking effect.
 
 Enable Elasticsearch indexing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -281,25 +281,6 @@ Live indexing batch size
 | **Note**: It may be necessary to increase this value to avoid hitting the rate limit of your Elasticsearch cluster on installs handling           | 
 | multiple messages per second.                                                                                                                     |    
 +---------------------------------------------------------------+-----------------------------------------------------------------------------------+
-
-Bulk indexing time window
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-*Available in legacy Enterprise Edition E10/E20*
-
-+---------------------------------------------------------------+----------------------------------------------------------------------------------------------+
-| The maximum time window, in seconds, for a batch of posts     | - System Config path: **Environment > Elasticsearch**                                        |
-| being indexed by the Bulk Indexer. This setting serves as a   | - ``config.json`` setting: ``".Elasticsearchsettings.BulkIndexingTimeWindowSeconds: 3600",`` |
-| performance optimization for installs with over               | - Environment variable: ``MM_ELASTICSEARCHSETTINGS_BULKINDEXINGTIMEWINDOWSECONDS``           |
-|  ~10 million posts in the database.                           |                                                                                              |
-|                                                               |                                                                                              |
-| Numerical input in seconds. Default is **3600** seconds       |                                                                                              |
-| (1 hour). Approximate this value based on the average number  |                                                                                              |
-| of seconds for 2,000 posts to be added to the database on a   |                                                                                              |
-| typical day in production.                                    |                                                                                              |
-+---------------------------------------------------------------+----------------------------------------------------------------------------------------------+
-| **Note**: Setting this value too low will cause bulk indexing jobs to run slowly.                                                                            |
-+---------------------------------------------------------------+----------------------------------------------------------------------------------------------+
 
 Request timeout
 ~~~~~~~~~~~~~~~

--- a/source/scale/elasticsearch.rst
+++ b/source/scale/elasticsearch.rst
@@ -34,6 +34,10 @@ Configure Elasticsearch in Mattermost
 
 Follow these steps to connect your Elasticsearch server to Mattermost and to generate the post index.
 
+.. tip::
+
+    Advanced Elasticsearch configuration settings for large deployments can be configured outside the System Console in the ``config.json`` file. See the `Elasticsearch configuration settings </configure/configuration-settings.html#elasticsearch>`__ documentation to learn more. 
+
 1. Go to **System Console > Environment > Elasticsearch**.
 2. Set **Enable Elasticsearch Indexing** to ``true`` to enable the other the settings on the page. Once the configuration is saved, new posts made to the database are automatically indexed on the Elasticsearch server.
 3. Set the Elasticsearch server connection details:
@@ -108,15 +112,6 @@ How do I monitor system health of an Elasticsearch server?
 You can use this Prometheus exporter to monitor `various metrics <https://github.com/justwatchcom/elasticsearch_exporter#metrics>`__ about Elasticsearch: `justwatchcom/elasticsearch_exporter <https://github.com/justwatchcom/elasticsearch_exporter>`__.
 
 You can also refer to this `article about Elasticsearch performance monitoring <https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics/#key-elasticsearch-performance-metrics-to-monitor>`__. It's not written specifically for Prometheus, which `Mattermost's performance monitoring </scale/performance-monitoring.html>`__ system uses, but has several tips and best practices.
-
-Why does a 25,000 post database take a long time to index in Elasticsearch?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-There are a few possible reasons:
-
-- Querying the posts out of the database is resource limited (i.e., the machine the database is on is not powerful enough).
-- The Elasticsearch cluster is performance limited (i.e., the machines are not powerful enough).
-- The 25,000 messages are spread out over a long time window, and the ``BulkIndexingTimeWindowSeconds`` configuration value is too low for efficient indexing of such a "sparse" database. The value of that config should ideally be set so that the median number of posts falling within any period of that time in the database is around 700 to 800. The default value is one hour, so if you are doing a lot less than 800 posts an hour on average, then the indexing will be much slower in terms of "posts per unit time". This can be sped up by increasing that time window.
  
 What form of data is sent to Elasticsearch?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Based on docs feedback from the Customer Success team:

- Removed the deprecated bulk indexing time window configuration setting from the Elasticsearch config settings page. This information is available on the deprecated config settings page.
- Removed the Elasticsearch FAQ topic about 25,000 post databases taking a long time to index.
- Added a link to the Elasticsearch configuration documentation that points to advanced Elasticsearch configuration settings available for large deployments.