### PR TITLE
Added related link

### DIFF
--- a/source/install/trouble_mysql.rst
+++ b/source/install/trouble_mysql.rst
@@ -4,8 +4,11 @@ MySQL installation troubleshooting
 .. include:: ../_static/badges/allplans-selfhosted.rst
   :start-after: :nosearch:
 
-Before you can run the Mattermost server, you must first install and configure a database. You can start Mattermost by navigating to the ``/opt/mattermost`` directory and entering the command
-``sudo -u mattermost bin/mattermost``. If the Mattermost server cannot connect to the database, it will fail to start. This section deals with MySQL database issues that you may encounter when you start up Mattermost for the first time.
+Before you can run the Mattermost server, you must first install and configure a database. You can start Mattermost by navigating to the ``/opt/mattermost`` directory and entering the command ``sudo -u mattermost bin/mattermost``. If the Mattermost server cannot connect to the database, it will fail to start. This section deals with MySQL database issues that you may encounter when you start up Mattermost for the first time.
+
+.. note::
+
+    Additional database tuning guidance is available for specific Mattermost releases. See the `important upgrade notes </upgrade/important-upgrade-notes.html>`__ documentation for more details.
 
 How you install MySQL varies depending upon which Linux distribution you use. However, once MySQL is installed, the configuration instructions are the
 same. For all distributions you must create a ``mattermost`` database and a ``mattermost`` database user. Failure to create these database

--- a/source/install/trouble_mysql.rst
+++ b/source/install/trouble_mysql.rst
@@ -4,7 +4,7 @@ MySQL installation troubleshooting
 .. include:: ../_static/badges/allplans-selfhosted.rst
   :start-after: :nosearch:
 
-Before you can run the Mattermost server, you must first install and configure a database. You can start Mattermost by navigating to the ``/opt/mattermost`` directory and entering the command ``sudo -u mattermost bin/mattermost``. If the Mattermost server cannot connect to the database, it will fail to start. This section deals with MySQL database issues that you may encounter when you start up Mattermost for the first time.
+Before you can run the Mattermost server, you must first install and configure a database. You can start Mattermost by navigating to the ``/opt/mattermost`` directory and entering the command ``sudo -u mattermost bin/mattermost``. If the Mattermost server can't connect to the database, it will fail to start. This section deals with MySQL database issues that you may encounter when you start up Mattermost for the first time.
 
 .. note::
 


### PR DESCRIPTION
Docs listening: Added related link from MySQL troubleshooting to available DB tuning guidance based on the following documentation feedback: "Can we add links here to the Postgres and MYSQL Tuning guidance? I'm looking for them now".