### PR TITLE
Fix rm with -rf to avoid "rm: missing operand"

### DIFF
--- a/source/upgrade/upgrading-mattermost-server.rst
+++ b/source/upgrade/upgrading-mattermost-server.rst
@@ -72,7 +72,7 @@ Upgrade Mattermost Server
 
    .. code-block:: sh
 
-     sudo find mattermost/ mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/client -o -path mattermost/client/plugins -o -path mattermost/config -o -path mattermost/logs -o -path mattermost/plugins -o -path mattermost/data \) -prune \) | sort | sudo xargs rm -r
+     sudo find mattermost/ mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path mattermost/client -o -path mattermost/client/plugins -o -path mattermost/config -o -path mattermost/logs -o -path mattermost/plugins -o -path mattermost/data \) -prune \) | sort | sudo xargs rm -rf
 
    **What's preserved on upgrade?**
   


### PR DESCRIPTION
#### Summary
This is a fix for the "rm: missing operand" error

<img width="1108" alt="Screenshot 2022-12-03 at 8 28 23 PM" src="https://user-images.githubusercontent.com/800668/205447166-ac4ff55e-d64c-4372-8019-fd2d3ebf8012.png">
