### PR TITLE
v7.6 packaging changes

### DIFF
--- a/source/_static/badges/entpro-cloud-free.rst
+++ b/source/_static/badges/entpro-cloud-free.rst
@@ -1,0 +1,26 @@
+:orphan:
+:nosearch:
+
+.. raw:: html
+
+  <div class="mm-badge">
+
+|plans-img| Available on `Enterprise and Professional <https://mattermost.com/pricing/>`__ plans
+
+|deployment-img| `self-hosted <https://mattermost.com/deploy/>`__ deployments
+
+.. |plans-img| image:: ../_static/images/badges/flag_icon.svg
+
+.. |deployment-img| image:: ../_static/images/badges/deployment_icon.svg
+
+.. raw:: html
+
+  </div>&nbsp;&nbsp;&nbsp;<div class="mm-badge">
+
+|plans-img| Available on `all plans <https://mattermost.com/pricing/>`__
+
+|deployment-img| `Cloud <https://customers.mattermost.com/cloud/signup/>`__ deployments
+
+.. raw:: html
+
+  </div>

--- a/source/about/editions-and-offerings.rst
+++ b/source/about/editions-and-offerings.rst
@@ -62,7 +62,7 @@ Features include:
 - Pre-packaged integrations with most common developer tools, including Jira, Confluence, GitHub, GitLab, CircleCI, Zoom, Jitsi, and more.
 - Tools for `custom branding </configure/custom-branding-tools.html>`__ and `themes </messaging/customizing-theme-colors.html>`__.
 - `Multi-factor authentication </onboard/multi-factor-authentication.html>`__.
-- `Single Sign-on with GitLab </onboard/sso-gitlab.html>`__ (Self-hosted only).
+- `Single Sign-on with GitLab </onboard/sso-gitlab.html>`, `Google </onboard/sso-google.html>`, or `OpenID Connect </onboard/sso-openidconnect.html>`__.
 - `Granular system permissions </onboard/advanced-permissions.html>`__.
 - Highly customizable `third-party bots, integrations <https://mattermost.com/marketplace/#publicApps>`__, and `command line tools </manage/mmctl-command-line-tool.html>`__.
 - Extensive integration support via `webhooks, APIs, drivers <https://developers.mattermost.com/integrate/other-integrations/>`__, and `third-party extensions <https://mattermost.com/marketplace/>`__.
@@ -78,14 +78,14 @@ Mattermost Professional
 Mattermost Professional is the set of collaboration features that enables you to build and scale your sophisticated developer workflows across multiple cross-functional teams to deliver mission-critical software.
 
 * *Self-hosted deployments* - **Mattermost Professional** is available to our self-hosted community who either run, or upgrade to, our self-hosted commercial Mattermost Enterprise Edition (see `deployment guides </guides/deployment.html#install-guides>`__), who purchase the appropriate subscription license key either through `online purchase </about/self-hosted-subscriptions.html>`__, through a `channel reseller <https://mattermost.com/partners/#resellers>`__ or by contacting `the Mattermost sales organization <https://mattermost.com/contact-sales/>`__, and who then install the license key onto their Mattermost server. A 30-day free trial to preview the features in this subscription can be activated either in-product (**System Console > Edition and License > Start trial**) or via an online request at https://mattermost.com/trial/.
-* *Cloud deployments* - For our cloud community, the Mattermost Professional feature set is available through `online purchase </about/self-hosted-subscriptions.html>`__. Some `workspace limits </onboard/mattermost-limits.html>`_ may apply.
+* *Cloud deployments* - For our cloud community, the Mattermost Professional feature set is available through `online purchase </about/self-hosted-subscriptions.html>`__. Some `workspace limits </onboard/mattermost-limits.html>`__ may apply.
 
 This offering includes all the features of Mattermost Free, plus: 
 
 - `Guest access </onboard/guest-accounts.html>`__.
 - Unlimited playbooks, retrospective reports, and timelines.
 - `Active Directory/LDAP Single Sign-on and user synchronization </onboard/ad-ldap.html>`__.
-- Single Sign-on with SAML, `Google </onboard/sso-google.html>`__, `Office365 </onboard/sso-office.html>`__ or `OpenID Connect </onboard/sso-openidconnect.html>`__.
+- Single Sign-on with `SAML </onboard/sso-saml.html>` or `Office365 </onboard/sso-office.html>`__.
 - `MFA enforcement </onboard/multi-factor-authentication.html#enforcing-mfa-e10>`__.
 - `Advanced team permissions </onboard/advanced-permissions.html#team-override-schemes-e20>`__.
 - `Read-only announcement channels </manage/team-channel-members.html#channel-moderation-e20>`__.

--- a/source/onboard/mattermost-limits.rst
+++ b/source/onboard/mattermost-limits.rst
@@ -31,11 +31,6 @@ Mattermost Cloud Free limits
 
 - Up to 8 participants per channel can join calls that last up to 40 minutes.
 
-**Boards limits**
-
-- Maximum 5 saved views per board.
-- Only the 500 most recently updated cards on the server are displayed.
-
 .. note::
    
    Mattermost reserves the right to archive or delete messages and establish or change (1) limits as to how many messages can be stored, (2) how long such messages will be stored, and (3) charges for storing such messages. Mattermost further reserves the right to establish or change limits on periods of inactivity that may result in the termination of your messages cloud storage and deletion or archiving of any stored messages.

--- a/source/onboard/mattermost-limits.rst
+++ b/source/onboard/mattermost-limits.rst
@@ -1,5 +1,5 @@
-Workspace limits
-================
+Cloud Workspace limits
+=======================
 
 .. include:: ../_static/badges/allplans-cloud.rst
   :start-after: :nosearch:
@@ -14,18 +14,20 @@ In addition to these limits, visit our pricing page to see a complete list of fe
 
    These limits do not apply to self-hosted deployments. 
 
-Mattermost Free limits
-----------------------
+Mattermost Cloud Free limits
+----------------------------
 
 **Platform limits**
 
-- Maximum 1 team. Any additional teams created during a trial or on a paid plan will be archived.
-- 10 GB file storage across the platform, with 100 MB upload limit. The oldest files that exceed this limit will be archived.
 - Unlimited plugins can be installed but only 5 can be enabled at one time. Core plugins such as Boards, Calls, and Playbooks do not count toward this limit.
 
 **Channels limits**
 
 - 10,000 message history limit. The oldest messages that exceed this limit will be archived.
+
+**Calls limits**
+
+- Up to 8 participants per channel can join calls that last up to 40 minutes.
 
 **Boards limits**
 
@@ -35,13 +37,6 @@ Mattermost Free limits
 .. note::
    
    Mattermost reserves the right to archive or delete messages and establish or change (1) limits as to how many messages can be stored, (2) how long such messages will be stored, and (3) charges for storing such messages. Mattermost further reserves the right to establish or change limits on periods of inactivity that may result in the termination of your messages cloud storage and deletion or archiving of any stored messages.
-
-Mattermost Professional limits
-------------------------------
-
-**Platform limits**
-
-- 250GB file storage limit.
 
 Frequently asked questions
 --------------------------

--- a/source/onboard/mattermost-limits.rst
+++ b/source/onboard/mattermost-limits.rst
@@ -20,6 +20,8 @@ Mattermost Cloud Free limits
 **Platform limits**
 
 - Unlimited plugins can be installed but only 5 can be enabled at one time. Core plugins such as Boards, Calls, and Playbooks do not count toward this limit.
+- 1 GB file storage across the platform, with 100 MB upload limit. The oldest files that exceed this limit will be archived.
+- Maximum 1 team. Any additional teams created during a trial or on a paid plan will be archived.
 
 **Channels limits**
 

--- a/source/onboard/shared-channels.rst
+++ b/source/onboard/shared-channels.rst
@@ -1,7 +1,7 @@
 Shared channels (experimental)
 ==============================
 
-.. include:: ../_static/badges/pro-cloud-selfhosted.rst
+.. include:: ../_static/badges/ent-pro-cloud-selfhosted.rst
   :start-after: :nosearch:
 
 Shared channels is an experimental feature that brings people together from multiple Mattermost installations. For example, teams collaborating with external partners and customers using multiple Mattermost instances in a federated architecture.

--- a/source/onboard/shared-channels.rst
+++ b/source/onboard/shared-channels.rst
@@ -1,7 +1,7 @@
 Shared channels (experimental)
 ==============================
 
-.. include:: ../_static/badges/ent-cloud-selfhosted.rst
+.. include:: ../_static/badges/pro-cloud-selfhosted.rst
   :start-after: :nosearch:
 
 Shared channels is an experimental feature that brings people together from multiple Mattermost installations. For example, teams collaborating with external partners and customers using multiple Mattermost instances in a federated architecture.

--- a/source/onboard/sso-gitlab.rst
+++ b/source/onboard/sso-gitlab.rst
@@ -1,10 +1,8 @@
 GitLab Single Sign-On
 =====================
 
-.. include:: ../_static/badges/cloud-selfhosted.rst
+.. include:: ../_static/badges/entpro-cloud-free.rst
   :start-after: :nosearch:
-
-*Not available in Mattermost Cloud Free*
 
 Configuring GitLab as a Single Sign-On (SSO) service
 ----------------------------------------------------

--- a/source/onboard/sso-google.rst
+++ b/source/onboard/sso-google.rst
@@ -1,7 +1,7 @@
 Google Single Sign-On
 =====================
 
-.. include:: ../_static/badges/ent-pro-cloud-selfhosted.rst
+.. include:: ../_static/badges/entpro-cloud-free.rst
   :start-after: :nosearch:
 
 *Available in legacy Mattermost Enterprise Edition E20*

--- a/source/onboard/sso-openidconnect.rst
+++ b/source/onboard/sso-openidconnect.rst
@@ -1,7 +1,7 @@
 OpenID Connect Single Sign-On
 ==============================
 
-.. include:: ../_static/badges/ent-pro-cloud-selfhosted.rst
+.. include:: ../_static/badges/entpro-cloud-free.rst
   :start-after: :nosearch:
 
 *Available in legacy Mattermost Enterprise Edition E20*

--- a/source/welcome/insights.rst
+++ b/source/welcome/insights.rst
@@ -1,7 +1,7 @@
 Insights
 ========
 
-.. include:: ../_static/badges/ent-pro-cloud-selfhosted.rst
+.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
 Insights offer you visibility into top activities by surfacing the most important events happening within each team within your Mattermost workspace. 
@@ -46,6 +46,9 @@ My insights
 
 Team insights
 -------------
+
+.. include:: ../_static/badges/ent-pro-only.rst
+  :start-after: :nosearch:
 
 +-----------------------+-----------------------------------------------+
 | **Insight category**  | **Description**                               |


### PR DESCRIPTION
Documentation for:
- https://github.com/mattermost/mattermost-server/pull/21443
- https://github.com/mattermost/mattermost-webapp/pull/11346

Summary of changes:
- Updated [GitLab SSO](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/onboard/sso-gitlab.html), [Google SSO](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/onboard/sso-google.html), and [OpenID Connect SSO](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/onboard/sso-openidconnect.html) pages to add free on cloud badge
- Updated [Insights](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/welcome/insights.html) page to mark My Insights as free on cloud, and [Team Insights as paid](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/welcome/insights.html#team-insights).
- Updated Cloud Limitations page to [clarify group calls free on cloud](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/onboard/mattermost-limits.html#mattermost-cloud-free-limits), remove file storage limits, & remove Professional section altogether
- Updated [Shared Channels badge](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/onboard/shared-channels.html) from Enterprise to Professional & Enterprise
- Updated [Editions & Offerings](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6104/about/editions-and-offerings.html) page based on above changes