### PR TITLE
Cloud configuration defaults

### DIFF
--- a/source/configure/authentication-configuration-settings.rst
+++ b/source/configure/authentication-configuration-settings.rst
@@ -11,7 +11,7 @@ Mattermost supports up to four distinct, concurrent methods of **Authentication*
 - An LDAP instance (e.g., Active Directory, OpenLDAP)
 - Email and Password
 
-Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Authentication**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Authentication**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables.
 
 - `Signup <#signup>`__
 - `Email <#email>`__

--- a/source/configure/authentication-configuration-settings.rst
+++ b/source/configure/authentication-configuration-settings.rst
@@ -64,9 +64,10 @@ Enable email invitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +--------------------------------------------------------+------------------------------------------------------------------------+
-| - **true**: Allows users to send email invitations.    | - System Config path: **Authentication > Signup**                      |
-| - **false**: **(Default)** Disables email invitations. | - ``config.json`` setting: ``.ServiceSettings.EnableEmailInvitations`` |
-|                                                        | - Environment variable: ``MM_SERVICESETTINGS_ENABLEEMAILINVITATIONS``  |
+| - **true**: **(Default for Cloud deployments)**        | - System Config path: **Authentication > Signup**                      |
+|   Allows users to send email invitations.              | - ``config.json`` setting: ``.ServiceSettings.EnableEmailInvitations`` |
+| - **false**: **(Default for self-hosted deployments)** | - Environment variable: ``MM_SERVICESETTINGS_ENABLEEMAILINVITATIONS``  |
+|   Disables email invitations.                          |                                                                        |
 +--------------------------------------------------------+------------------------------------------------------------------------+
 
 Invalidate pending email invites
@@ -100,11 +101,14 @@ Enable account creation with email
 Require email verification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------+
-| - **true**: Requires email verification for new accounts before allowing the user to sign-in.                                       | - System Config path: **Authentication > Email**                       |
-| - **false**: **(Default)** Disables email verification. This can be used to speed development by skipping the verification process. | - ``config.json`` setting: ``.EmailSettings.RequireEmailVerification`` |
-|                                                                                                                                     | - Environment variable: ``MM_EMAILSETTINGS_REQUIREEMAILVERIFICATION``  |
-+-------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------+
++-------------------------------------------------------------------------------+-------------------------------------------------------------------------------+
+| - **true**: **(Default for Cloud deployments)**                               | - System Config path: **Authentication > Email**                              |
+|   Requires email verification for new accounts                                | - ``config.json`` setting: ``.EmailSettings.RequireEmailVerification: false`` |
+|   before allowing the user to sign-in.                                        | - Environment variable: ``MM_EMAILSETTINGS_REQUIREEMAILVERIFICATION``         |
+| - **false**: **(Default for self-hosted deployments)**                        |                                                                               |
+|   Disables email verification. can be used to speed development by            |                                                                               |
+|   skipping the verification process.                                          |                                                                               |
++-------------------------------------------------------------------------------+-------------------------------------------------------------------------------+
 
 Enable sign-in with email
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -279,13 +283,19 @@ Connection security
 
 *Available in legacy Enterprise Edition E10 and E20*
 
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------+
-| This setting controls the type of security Mattermost uses to connect to the AD/LDAP server, with these options:                                                                                         | - System Config path: **Authentication > AD/LDAP**              |
-|                                                                                                                                                                                                          | - ``config.json`` setting: ``.LdapSettings.ConnectionSecurity`` |
-| - **None**: **(Default)** No encryption. With this option, it is **highly recommended** that the connection be secured outside of Mattermost, such as by a stunnel proxy. ``config.json`` option: ``""`` | - Environment variable: ``MM_LDAPSETTINGS_CONNECTIONSECURITY``  |
-| - **TLS**: Encrypts communication with TLS. ``config.json`` option: ``"TLS"``                                                                                                                            |                                                                 |
-| - **STARTTLS**: Attempts to upgrade an existing insecure connection to a secure connection with TLS. ``config.json`` option: ``"STARTTLS"``                                                              |                                                                 |
-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------+
++------------------------------------------------------------------------------+-----------------------------------------------------------------+
+| This setting controls the type of security Mattermost uses to                | - System Config path: **Authentication > AD/LDAP**              |
+| connect to the AD/LDAP server, with these options:                           | - ``config.json`` setting: ``.LdapSettings.ConnectionSecurity`` |
+|                                                                              | - Environment variable: ``MM_LDAPSETTINGS_CONNECTIONSECURITY``  |
+| - **None**: **(Default for self-hosted deployments)** No encryption.         |                                                                 |
+|   With this option, it is **highly recommended** that the connection be      |                                                                 |
+|   secured outside of Mattermost, such as by a stunnel proxy.                 |                                                                 |
+|   ``config.json`` option: ``""``                                             |                                                                 |
+| - **TLS**: **(Default for Cloud deployments)** Encrypts                      |                                                                 |
+|   communication with TLS. ``config.json`` option: ``"TLS"``                  |                                                                 |
+| - **STARTTLS**: Attempts to upgrade an existing insecure connection          |                                                                 |
+|   to a secure connection with TLS. ``config.json`` option: ``"STARTTLS"``    |                                                                 |
++------------------------------------------------------------------------------+-----------------------------------------------------------------+
 
 Skip certificate verification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/configure/authentication-configuration-settings.rst
+++ b/source/configure/authentication-configuration-settings.rst
@@ -11,7 +11,7 @@ Mattermost supports up to four distinct, concurrent methods of **Authentication*
 - An LDAP instance (e.g., Active Directory, OpenLDAP)
 - Email and Password
 
-Access the following configuration settings in the System Console by going to **Authentication**, or by editing the ``config.json`` file as described in the following tables:
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Authentication**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Signup <#signup>`__
 - `Email <#email>`__
@@ -63,12 +63,12 @@ Enable open server
 Enable email invitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+--------------------------------------------------------+------------------------------------------------------------------------+
-| - **true**: **(Default for Cloud deployments)**        | - System Config path: **Authentication > Signup**                      |
-|   Allows users to send email invitations.              | - ``config.json`` setting: ``.ServiceSettings.EnableEmailInvitations`` |
-| - **false**: **(Default for self-hosted deployments)** | - Environment variable: ``MM_SERVICESETTINGS_ENABLEEMAILINVITATIONS``  |
-|   Disables email invitations.                          |                                                                        |
-+--------------------------------------------------------+------------------------------------------------------------------------+
++--------------------------------------------------------+-------------------------------------------------------------------------------+
+| - **true**: **(Default for Cloud deployments)**        | - System Config path: **Authentication > Signup**                             |
+|   Allows users to send email invitations.              | - ``config.json`` setting: ``.ServiceSettings.EnableEmailInvitations: false`` |
+| - **false**: **(Default for self-hosted deployments)** | - Environment variable: ``MM_SERVICESETTINGS_ENABLEEMAILINVITATIONS``         |
+|   Disables email invitations.                          |                                                                               |
++--------------------------------------------------------+-------------------------------------------------------------------------------+
 
 Invalidate pending email invites
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -205,13 +205,17 @@ Enforce multi-factor authentication
 
 *Available in legacy Enterprise Edition E10 and E20*
 
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------+
-| - **true**: Requires `multi-factor authentication (MFA) <https://docs.mattermost.com/onboard/multi-factor-authentication.html>`__ for users who sign-in with AD/LDAP or an email address.  | - System Config path: **Authentication > MFA**                                   |
-| New users must configure MFA. Logged in users are redirected to the MFA setup page until configuration is complete.                                                                        | - ``config.json`` setting: ``.ServiceSettings.EnforceMultifactorAuthentication`` |
-| - **false**: MFA is optional.                                                                                                                                                              | - Environment variable: ``MM_SERVICESETTINGS_ENFORCEMULTIFACTORAUTHENTICATION``  |
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------+
-| Note: If your system has users who authenticate with methods other than AD/LDAP and email, MFA must be enforced with the authentication provider outside of Mattermost.                                                                                                       |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++----------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
+| - **true**: Requires `multi-factor authentication (MFA)                          | - System Config path: **Authentication > MFA**                                          |
+|   <https://docs.mattermost.com/onboard/multi-factor-authentication.html>`__      | - ``config.json`` setting: ``.ServiceSettings.EnforceMultifactorAuthentication: false`` |
+|   for users who sign-in with AD/LDAP or an email address. New users must         | - Environment variable: ``MM_SERVICESETTINGS_ENFORCEMULTIFACTORAUTHENTICATION``         |
+|   configure MFA. Logged in users are redirected to the MFA setup page            |                                                                                         |
+|   until configuration is complete.                                               |                                                                                         |
+| - **false**: **(Default)** MFA is optional.                                      |                                                                                         |
++----------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
+| **Note**: If your system has users who authenticate with methods other than AD/LDAP and email, MFA must be enforced with the authentication provider                       |
+| outside of Mattermost.                                                                                                                                                     |
++----------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
 
 ----
 
@@ -283,19 +287,19 @@ Connection security
 
 *Available in legacy Enterprise Edition E10 and E20*
 
-+------------------------------------------------------------------------------+-----------------------------------------------------------------+
-| This setting controls the type of security Mattermost uses to                | - System Config path: **Authentication > AD/LDAP**              |
-| connect to the AD/LDAP server, with these options:                           | - ``config.json`` setting: ``.LdapSettings.ConnectionSecurity`` |
-|                                                                              | - Environment variable: ``MM_LDAPSETTINGS_CONNECTIONSECURITY``  |
-| - **None**: **(Default for self-hosted deployments)** No encryption.         |                                                                 |
-|   With this option, it is **highly recommended** that the connection be      |                                                                 |
-|   secured outside of Mattermost, such as by a stunnel proxy.                 |                                                                 |
-|   ``config.json`` option: ``""``                                             |                                                                 |
-| - **TLS**: **(Default for Cloud deployments)** Encrypts                      |                                                                 |
-|   communication with TLS. ``config.json`` option: ``"TLS"``                  |                                                                 |
-| - **STARTTLS**: Attempts to upgrade an existing insecure connection          |                                                                 |
-|   to a secure connection with TLS. ``config.json`` option: ``"STARTTLS"``    |                                                                 |
-+------------------------------------------------------------------------------+-----------------------------------------------------------------+
++------------------------------------------------------------------------------+---------------------------------------------------------------------+
+| This setting controls the type of security Mattermost uses to                | - System Config path: **Authentication > AD/LDAP**                  |
+| connect to the AD/LDAP server, with these options:                           | - ``config.json`` setting: ``.LdapSettings.ConnectionSecurity: ""`` |
+|                                                                              | - Environment variable: ``MM_LDAPSETTINGS_CONNECTIONSECURITY``      |
+| - **None**: **(Default for self-hosted deployments)** No encryption.         |                                                                     |
+|   With this option, it is **highly recommended** that the connection be      |                                                                     |
+|   secured outside of Mattermost, such as by a stunnel proxy.                 |                                                                     |
+|   ``config.json`` option: ``""``                                             |                                                                     |
+| - **TLS**: **(Default for Cloud deployments)** Encrypts                      |                                                                     |
+|   communication with TLS. ``config.json`` option: ``"TLS"``                  |                                                                     |
+| - **STARTTLS**: Attempts to upgrade an existing insecure connection          |                                                                     |
+|   to a secure connection with TLS. ``config.json`` option: ``"STARTTLS"``    |                                                                     |
++------------------------------------------------------------------------------+---------------------------------------------------------------------+
 
 Skip certificate verification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1619,9 +1623,9 @@ Enable guest access
 
 *Available in legacy Enterprise Edition E10 and E20*
 
-**True**: Allow guest invitations to channels within teams. Please see `Guest Accounts documentation <https://docs.mattermost.com/onboard/guest-accounts.html>`__ for more information.
+**True**: **(Default for Cloud deployments)** Allow guest invitations to channels within teams. Please see `Guest Accounts documentation <https://docs.mattermost.com/onboard/guest-accounts.html>`__ for more information.
 
-**False**: Email signup is disabled. This limits signup to Single sign-on services like OAuth or AD/LDAP.
+**False**: **(Default for self-hosted deployments)** Email signup is disabled. This limits signup to Single sign-on services like OAuth or AD/LDAP.
 
 +----------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"Enable": false`` with options ``true`` and ``false``. |

--- a/source/configure/authentication-configuration-settings.rst
+++ b/source/configure/authentication-configuration-settings.rst
@@ -11,7 +11,7 @@ Mattermost supports up to four distinct, concurrent methods of **Authentication*
 - An LDAP instance (e.g., Active Directory, OpenLDAP)
 - Email and Password
 
-Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Authentication**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables.
+Both self-hosted and Cloud admins can access the following configuration settings in **System Console > Authentication**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables.
 
 - `Signup <#signup>`__
 - `Email <#email>`__

--- a/source/configure/compliance-configuration-settings.rst
+++ b/source/configure/compliance-configuration-settings.rst
@@ -4,7 +4,7 @@ Compliance configuration settings
 .. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Compliance**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
+Both self-hosted and Cloud admins can access the following configuration settings in **System Console > Compliance**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Data Retention Policies <#data-retention-policies>`__
 - `Compliance Export <#compliance-export>`__

--- a/source/configure/compliance-configuration-settings.rst
+++ b/source/configure/compliance-configuration-settings.rst
@@ -4,7 +4,7 @@ Compliance configuration settings
 .. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Access the following configuration settings in the System Console by going to **Compliance**, or by editing the ``config.json`` file as described in the following tables:
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Compliance**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Data Retention Policies <#data-retention-policies>`__
 - `Compliance Export <#compliance-export>`__

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -4,7 +4,11 @@ Configuration settings
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-System Admins for both self-hosted and Cloud Mattermost workspaces can manage Mattermost configuration using the System Console. Mattermost requires write permissions to ``config.json``, otherwise configuration changes made within the System Console will have no effect.
+System Admins for both self-hosted and Cloud Mattermost workspaces can manage Mattermost configuration using the System Console. For self-hosted deployments, admins can additionally edit the ``config.json`` file. 
+
+.. note::
+  
+  Mattermost requires write permissions to the ``config.json`` file; otherwise, configuration changes made within the System Console will have no effect.
 
 Mattermost configuration settings are organized into the following categories within the System Console:
 

--- a/source/configure/database-configuration-settings.rst
+++ b/source/configure/database-configuration-settings.rst
@@ -84,7 +84,8 @@ Maximum open connections
 | The maximum number of idle connections held open       | - System Config path: **Environment > Database**                 |
 | to the database.                                       | - ``config.json`` setting: ``".SqlSettings.MaxOpenConns": 300,`` |
 |                                                        | - Environment variable: ``MM_SQLSETTINGS_MAXOPENCONNS``          |
-| Numerical input. Default is **300**.                   |                                                                  |
+| Numerical input. Default is **300** for self-hosted    |                                                                  |
+| deployments, and **100** for Cloud deployments.        |                                                                  |
 +--------------------------------------------------------+------------------------------------------------------------------+
 
 Query timeout

--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -7,7 +7,7 @@ Environment configuration settings
 .. include:: common-config-settings-notation.rst
     :start-after: :nosearch:
 
-Access the following configuration settings in the System Console by going to **Environment**, or by editing the ``config.json`` file as described in the following tables. 
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Environment**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Web server <#web-server>`__
 - `Database <#database>`__

--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -7,7 +7,7 @@ Environment configuration settings
 .. include:: common-config-settings-notation.rst
     :start-after: :nosearch:
 
-Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Environment**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
+Both self-hosted and Cloud admins can access the following configuration settings in **System Console > Environment**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Web server <#web-server>`__
 - `Database <#database>`__

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1,7 +1,7 @@
 Experimental configuration settings
 =====================================
 
-Access the following experimental configuration settings:
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Experimental System Console configuration settings <#experimental-system-console-configuration-settings>`__
 - `Experimental Bleve configuration settings <#experimental-bleve-configuration-settings>`__
@@ -379,9 +379,9 @@ This setting enables the Apps Bar and moves all Mattermost integration icons fro
   
   Integrations currently registered to the channel header will move to the Apps Bar automatically; however, we strongly encourage Mattermost integrators to update their integrations to provide the best user experience. See the `channel header plugin changes <https://forum.mattermost.com/t/channel-header-plugin-changes/13551>`__ user forum discussion for details on how to register integrations with the Apps Bar.
 
-**True**: All integration icons in the channel header move to the Apps Bar with the exception of the calls beta feature.
+**True**: **(Default for Cloud deployments)** All integration icons in the channel header move to the Apps Bar with the exception of the calls beta feature.
 
-**False**: All integration icons in the channel header display in the channel header.
+**False**: **(Default for self-hosted deployments)** All integration icons in the channel header display in the channel header.
 
 +----------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableAppBar": false`` with options ``true`` and ``false``. |
@@ -772,9 +772,9 @@ Restrict system admin
 
 This setting isn't available in the System Console and can only be set in ``config.json``.
 
-**True**: Restricts the System Admin from viewing and modifying a subset of server configuration settings from the System Console. Not recommended for use in on-prem installations. This is intended to support Mattermost Private Cloud in giving the System Admin role to users but restricting certain actions only for Cloud Admins.
+**True**: **(Default for Cloud deployments)** Restricts the System Admin from viewing and modifying a subset of server configuration settings from the System Console. Not recommended for use in on-prem installations. This is intended to support Mattermost Private Cloud in giving the System Admin role to users but restricting certain actions only for Cloud Admins.
 
-**False**: No restrictions are applied to the System Admin role.
+**False**: **(Default for self-host deployments)** No restrictions are applied to the System Admin role.
 
 +-------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"RestrictSystemAdmin": "false"`` with options ``true`` and ``false``. |

--- a/source/configure/high-availability-configuration-settings.rst
+++ b/source/configure/high-availability-configuration-settings.rst
@@ -96,9 +96,11 @@ Enable experimental gossip encryption
 | Gossip encryption uses AES-256 by default, and this value isn’t | - System Config path: **Environment > High Availability**                                    |
 | configurable by design.                                         | - ``config.json`` setting: ``".ClusterSettings.EnableExperimentalGossipEncryption: false”,`` |
 |                                                                 | - Environment variable: ``MM_CLUSTERSETTINGS_ENABLEEXPERIMENTALGOSSIPENCRYPTION``            |
-| - **true**: All communication through the cluster using the     |                                                                                              |
-|   gossip protocol will be encrypted.                            |                                                                                              |
-| - **false**: **(Default)** All communication using gossip       |                                                                                              |
+| - **true**: **(Default for Cloud deployments)                   |                                                                                              |
+|   All communication through the cluster using the gossip        |                                                                                              |
+|   protocol will be encrypted.                                   |                                                                                              |
+| - **false**: **(Default for self-hosted deployments)**          |                                                                                              |
+|   All communication using gossip protocol remains unchanged.    |                                                                                              |
 |   protocol remains unencrypted.                                 |                                                                                              |
 +-----------------------------------------------------------------+----------------------------------------------------------------------------------------------+
 | **Note**: Alternatively, you can manually set the ``ClusterEncryptionKey`` row value in the **Systems** table. A key is a byte array converted to base64.      |
@@ -115,11 +117,13 @@ Enable gossip compression
 | or later, we recommend that you disable this configuration      | - ``config.json`` setting: ``".ClusterSettings.EnableGossipCompression: true”,`` |
 | setting for better performance.                                 | - Environment variable: ``MM_CLUSTERSETTINGS_ENABLE GOSSIPCOMPRESSION``          |
 |                                                                 |                                                                                  |
-| - **true**: **(Default)** All communication through the         |                                                                                  |
-|   cluster uses gossip compression. This setting is enabled by   |                                                                                  |
-|   default to maintain compatibility with older servers.         |                                                                                  |
-| - **false**: All communication using the gossip protocol        |                                                                                  |
-|   remains uncompressed.                                         |                                                                                  |
+| - **true**: **(Default for self-hosted deployments)**           |                                                                                  |
+|   All communication through the cluster uses gossip             |                                                                                  |
+|   compression. This setting is enabled by default to maintain   |                                                                                  |
+|   compatibility with older servers.                             |                                                                                  |
+| - **false**: **(Default for Cloud deployments)**                |                                                                                  |
+|   All communication using the gossip protocol remains           |                                                                                  |
+|   uncompressed.                                                 |                                                                                  |
 +-----------------------------------------------------------------+----------------------------------------------------------------------------------+
 
 Gossip port

--- a/source/configure/high-availability-configuration-settings.rst
+++ b/source/configure/high-availability-configuration-settings.rst
@@ -96,7 +96,7 @@ Enable experimental gossip encryption
 | Gossip encryption uses AES-256 by default, and this value isn’t | - System Config path: **Environment > High Availability**                                    |
 | configurable by design.                                         | - ``config.json`` setting: ``".ClusterSettings.EnableExperimentalGossipEncryption: false”,`` |
 |                                                                 | - Environment variable: ``MM_CLUSTERSETTINGS_ENABLEEXPERIMENTALGOSSIPENCRYPTION``            |
-| - **true**: **(Default for Cloud deployments)                   |                                                                                              |
+| - **true**: **(Default for Cloud deployments)**                 |                                                                                              |
 |   All communication through the cluster using the gossip        |                                                                                              |
 |   protocol will be encrypted.                                   |                                                                                              |
 | - **false**: **(Default for self-hosted deployments)**          |                                                                                              |

--- a/source/configure/integrations-configuration-settings.rst
+++ b/source/configure/integrations-configuration-settings.rst
@@ -4,7 +4,7 @@ Integrations configuration settings
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Access the following configuration settings in the System Console by going to **Integrations**, or by editing the ``config.json`` file as described in the following tables:
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Integrations**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Integrations management <#integrations-management>`__
 - `Bot Accounts <#bot-acocunts>`__

--- a/source/configure/integrations-configuration-settings.rst
+++ b/source/configure/integrations-configuration-settings.rst
@@ -125,9 +125,9 @@ Access the following configuration settings in the System Console by going to **
 Enable bot account creation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**True**: Users can create bot accounts for integrations in **Integrations > Bot Accounts**. Bot accounts are similar to user accounts except they cannot be used to log in. See `documentation <https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/>`__ to learn more.
+**True**: **(Default for Cloud deployments)** Users can create bot accounts for integrations in **Integrations > Bot Accounts**. Bot accounts are similar to user accounts except they cannot be used to log in. See `documentation <https://developers.mattermost.com/integrate/admin-guide/admin-bot-accounts/>`__ to learn more.
 
-**False**: Bot accounts cannot be created through the user interface or the RESTful API. Plugins can still create and manage bot accounts.
+**False**: **(Default for self-hosted deployments)** Bot accounts cannot be created through the user interface or the RESTful API. Plugins can still create and manage bot accounts.
 
 +----------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableBotAccountCreation": false`` with options ``true`` and ``false``. |

--- a/source/configure/integrations-configuration-settings.rst
+++ b/source/configure/integrations-configuration-settings.rst
@@ -4,7 +4,7 @@ Integrations configuration settings
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Integrations**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
+Both self-hosted and Cloud admins can access the following configuration settings in **System Console > Integrations**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Integrations management <#integrations-management>`__
 - `Bot Accounts <#bot-acocunts>`__

--- a/source/configure/plugins-configuration-settings.rst
+++ b/source/configure/plugins-configuration-settings.rst
@@ -4,7 +4,7 @@ Plugins configuration settings
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Plugins**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
+Both self-hosted and Cloud admins can access the following configuration settings in **System Console > Plugins**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Plugin Management <#plugin-management>`__
 - `Agenda <#agenda>`__

--- a/source/configure/plugins-configuration-settings.rst
+++ b/source/configure/plugins-configuration-settings.rst
@@ -4,7 +4,7 @@ Plugins configuration settings
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Access the following configuration settings in the System Console by going to **Plugins**, or by editing the ``config.json`` file as described in the following tables:
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Plugins**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Plugin Management <#plugin-management>`__
 - `Agenda <#agenda>`__

--- a/source/configure/site-configuration-settings.rst
+++ b/source/configure/site-configuration-settings.rst
@@ -276,8 +276,8 @@ Max users per team
 | `Channels <https://docs.mattermost.com/guides/channels.html>`__ are          |                                                                   |
 | another way of organizing communications within teams on different topics.   |                                                                   |
 |                                                                              |                                                                   |
-| Numerical input. Default is 50 self-hosted deployments, and 10000 for Cloud  |                                                                   |
-| deployments.                                                                 |                                                                   |
+| Numerical input. Default is **50** self-hosted deployments, and **10000**    |                                                                   |
+| for Cloud deployments.                                                       |                                                                   |
 +------------------------------------------------------------------------------+-------------------------------------------------------------------+
 
 
@@ -287,8 +287,8 @@ Max channels per team
 +---------------------------------------------------------------------------------------+-----------------------------------------------------------------------+
 | The maximum number of channels per team, including both active and archived channels. | - System Config path: **Site Configuration > Users and teams**        |
 |                                                                                       | - ``config.json`` setting: ``.TeamSettings.MaxChannelsPerTeam: 2000`` |
-| Numerical input. Default is 2000 for self-hosted deployments, and 10000 for Cloud     | - Environment variable: ``MM_TEAMSETTINGS_MAXCHANNELSPERTEAM``        |
-| deployments.                                                                          |                                                                       |
+| Numerical input. Default is **2000** for self-hosted deployments, and **10000**       | - Environment variable: ``MM_TEAMSETTINGS_MAXCHANNELSPERTEAM``        |
+| for Cloud deployments.                                                                |                                                                       |
 +---------------------------------------------------------------------------------------+-----------------------------------------------------------------------+
 
 Enable users to open direct message channels with

--- a/source/configure/site-configuration-settings.rst
+++ b/source/configure/site-configuration-settings.rst
@@ -4,7 +4,7 @@ Site configuration settings
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Access the following configuration settings in the System Console by going to **Site Configuration**, or by editing the ``config.json`` file as described in the following tables:
+Both self-hosted and Cloud admins can access the following configuration settings in the System Console by going to **Site Configuration**. Self-hosted admins can also edit the ``config.json`` file as described in the following tables. 
 
 - `Customization <#customization>`__
 - `Localization <#localization>`__
@@ -264,7 +264,7 @@ Max users per team
 
 +------------------------------------------------------------------------------+-------------------------------------------------------------------+
 | The **Max users per team** is the maximum total number of users per team,    | - System Config path: **Site Configuration > Users and teams**    |
-| including active and inactive users.                                         | ``config.json`` setting: ``.TeamSettings.MaxUsersPerTeam: 50``    |
+| including active and inactive users.                                         | - ``config.json`` setting: ``.TeamSettings.MaxUsersPerTeam: 50``  |
 |                                                                              | - Environment variable: ``MM_TEAMSETTINGS_MAXUSERSPERTEAM``       |
 | In Mattermost, a team of people should be a small organization with a        |                                                                   |
 | specific goal. In the physical world, a team could sit around a single       |                                                                   |
@@ -320,7 +320,7 @@ Teammate name display
 |   If the user doesn't have a full name, their username is displayed. Recommended when using     |                                                                            |
 |   `SAML <https://docs.mattermost.com/onboard/sso-saml.html>`__ or                               |                                                                            |
 |   `LDAP <https://docs.mattermost.com/onboard/ad-ldap.html>`__ if first name and last name       |                                                                            |
-|    attributes are configured. ``config.json`` option: ``"full_name"``.                          |                                                                            |
+|   attributes are configured. ``config.json`` option: ``"full_name"``.                           |                                                                            |
 +-------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------+
 
 
@@ -624,7 +624,7 @@ Enable emoji picker
 Enable custom emoji
 ~~~~~~~~~~~~~~~~~~~
 
-+-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
++-------------------------------------------------------------------------------+--------------------------------------------------------------------------+
 | - **true**: **(Default)** Allows users to add emojis through a                | - System Config path: **Site Configuration > Emoji**                     |
 |   **Custom Emoji** option in the emoji picker. Emojis can be GIF, PNG, or     | - ``config.json`` setting: ``.ServiceSettings.EnableCustomEmoji: true``  |
 |   JPG files up to 1 MB.                                                       | - Environment variable: ``MM_SERVICESETTINGS_ENABLECUSTOMEMOJI``         |

--- a/source/configure/site-configuration-settings.rst
+++ b/source/configure/site-configuration-settings.rst
@@ -262,15 +262,23 @@ Access the following configuration settings in the System Console by going to **
 Max users per team
 ~~~~~~~~~~~~~~~~~~~
 
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------+
-| The **Max users per team** is the maximum total number of users per team, including active and inactive users.                                                                                                                                                                                                                                                                | - System Config path: **Site Configuration > Users and teams**   |
-|                                                                                                                                                                                                                                                                                                                                                                               | - ``config.json`` setting: ``.TeamSettings.MaxUsersPerTeam: 50`` |
-| In Mattermost, a team of people should be a small organization with a specific goal. In the physical world, a team could sit around a single table. The default maximum (50) should be enough for most teams, but with appropriate `hardware <https://docs.mattermost.com/install/software-hardware-requirements.html>`__, this limit can be increased to thousands of users. | - Environment variable: ``MM_TEAMSETTINGS_MAXUSERSPERTEAM``      |
-|                                                                                                                                                                                                                                                                                                                                                                               |                                                                  |
-| `Channels <https://docs.mattermost.com/guides/channels.html>`__ are another way of organizing communications within teams on different topics.                                                                                                                                                                                                                                |                                                                  |
-|                                                                                                                                                                                                                                                                                                                                                                               |                                                                  |
-| Numerical input. Default is 50.                                                                                                                                                                                                                                                                                                                                               |                                                                  |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------+
++------------------------------------------------------------------------------+-------------------------------------------------------------------+
+| The **Max users per team** is the maximum total number of users per team,    | - System Config path: **Site Configuration > Users and teams**    |
+| including active and inactive users.                                         | ``config.json`` setting: ``.TeamSettings.MaxUsersPerTeam: 50``    |
+|                                                                              | - Environment variable: ``MM_TEAMSETTINGS_MAXUSERSPERTEAM``       |
+| In Mattermost, a team of people should be a small organization with a        |                                                                   |
+| specific goal. In the physical world, a team could sit around a single       |                                                                   |
+| table. The default maximum (50) should be enough for most teams, but         |                                                                   |
+| with appropriate `hardware <https://docs.mattermost.com/install/             |                                                                   |
+| software-hardware-requirements.html>`__, this limit can be increased to      |                                                                   |
+| thousands of users.                                                          |                                                                   |
+|                                                                              |                                                                   |
+| `Channels <https://docs.mattermost.com/guides/channels.html>`__ are          |                                                                   |
+| another way of organizing communications within teams on different topics.   |                                                                   |
+|                                                                              |                                                                   |
+| Numerical input. Default is 50 self-hosted deployments, and 10000 for Cloud  |                                                                   |
+| deployments.                                                                 |                                                                   |
++------------------------------------------------------------------------------+-------------------------------------------------------------------+
 
 
 Max channels per team
@@ -279,7 +287,8 @@ Max channels per team
 +---------------------------------------------------------------------------------------+-----------------------------------------------------------------------+
 | The maximum number of channels per team, including both active and archived channels. | - System Config path: **Site Configuration > Users and teams**        |
 |                                                                                       | - ``config.json`` setting: ``.TeamSettings.MaxChannelsPerTeam: 2000`` |
-| Numerical input. Default is 2000.                                                     | - Environment variable: ``MM_TEAMSETTINGS_MAXCHANNELSPERTEAM``        |
+| Numerical input. Default is 2000 for self-hosted deployments, and 10000 for Cloud     | - Environment variable: ``MM_TEAMSETTINGS_MAXCHANNELSPERTEAM``        |
+| deployments.                                                                          |                                                                       |
 +---------------------------------------------------------------------------------------+-----------------------------------------------------------------------+
 
 Enable users to open direct message channels with
@@ -296,15 +305,23 @@ Enable users to open direct message channels with
 Teammate name display
 ~~~~~~~~~~~~~~~~~~~~~
 
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------+
-| This setting determines how names appear in posts and under the **Direct Messages** list. Users can change this setting in their interface under **Settings > Display > Teammate Name Display**, unless this setting is locked by a System Admin (see **Lock teammate name display...**).                                                                                                            | - System Config path: **Site Configuration > Users and teams**   |
-|                                                                                                                                                                                                                                                                                                                                                                                                      | - ``config.json`` setting: ``.TeamSettings.TeammateNameDisplay`` |
-| - **Show username**: **(Default)** Displays usernames. ``config.json`` option: ``"username"``.                                                                                                                                                                                                                                                                                                       | - Environment variable: ``MM_TEAMSETTINGS_TEAMMATENAMEDISPLAY``  |
-|                                                                                                                                                                                                                                                                                                                                                                                                      |                                                                  |
-| - **Show nickname if one exists...**: Displays the user’s nickname. If the user does not have a nickname, their full name is displayed. If the user does not have a full name, their username is displayed. ``config.json`` option: ``"nickname_full_name"``.                                                                                                                                        |                                                                  |
-|                                                                                                                                                                                                                                                                                                                                                                                                      |                                                                  |
-| - **Show first and last name**: Displays the user’s full name. If the user does not have a full name, their username is displayed. This option is recommended when using `SAML <https://docs.mattermost.com/onboard/sso-saml.html>`__ or `LDAP <https://docs.mattermost.com/onboard/ad-ldap.html>`__ if first name and last name attributes are configured. ``config.json`` option: ``"full_name"``. |                                                                  |
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------+
++-------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------+
+| This setting determines how names appear in posts and under the **Direct Messages** list.       | - System Config path: **Site Configuration > Users and teams**             |
+| Users can change this setting in their interface under **Settings > Display >                   | - ``config.json`` setting: ``.TeamSettings.TeammateNameDisplay: username`` |
+| Teammate Name Display**, unless this setting is locked by a System Admin                        | - Environment variable: ``MM_TEAMSETTINGS_TEAMMATENAMEDISPLAY``            |
+| via the **Lock teammate name display for all users** configuration setting.                     |                                                                            |
+|                                                                                                 |                                                                            |
+| - **Show username**: **(Default for self-hosted deployments)** Displays usernames.              |                                                                            |
+|   ``config.json`` option: ``"username"``.                                                       |                                                                            |
+| - **Show nickname if one exists...**: Displays the user’s nickname. If the user doesn't have a  |                                                                            |
+|   nickname, their full name is displayed. If the user doesn't have a full name, their username  |                                                                            |
+|   is displayed. ``config.json`` option: ``"nickname_full_name"``.                               |                                                                            |
+| - **Show first and last name**: **(Default for Cloud deployments)** Displays user’s full name.  |                                                                            |
+|   If the user doesn't have a full name, their username is displayed. Recommended when using     |                                                                            |
+|   `SAML <https://docs.mattermost.com/onboard/sso-saml.html>`__ or                               |                                                                            |
+|   `LDAP <https://docs.mattermost.com/onboard/ad-ldap.html>`__ if first name and last name       |                                                                            |
+|    attributes are configured. ``config.json`` option: ``"full_name"``.                          |                                                                            |
++-------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------+
 
 
 Lock teammate name display for all users
@@ -607,13 +624,14 @@ Enable emoji picker
 Enable custom emoji
 ~~~~~~~~~~~~~~~~~~~
 
-+------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------+
-| - **true**: Allows users to add emojis through a **Custom Emoji** option in the emoji picker. Emojis can be GIF, PNG, or JPG files up to 1 MB. | - System Config path: **Site Configuration > Emoji**                     |
-| - **false**: **(Default)** Disables custom emojis.                                                                                             | - ``config.json`` setting: ``.ServiceSettings.EnableCustomEmoji: false`` |
-|                                                                                                                                                | - Environment variable: ``MM_SERVICESETTINGS_ENABLECUSTOMEMOJI``         |
-+------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------+
-| **Note**: Too many custom emojis can slow your server’s performance.                                                                                                                                                      |
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------------------------------------------------+----------------------------------------------------------------------+
+| - **true**: **(Default)** Allows users to add emojis through a                | - System Config path: **Site Configuration > Emoji**                     |
+|   **Custom Emoji** option in the emoji picker. Emojis can be GIF, PNG, or     | - ``config.json`` setting: ``.ServiceSettings.EnableCustomEmoji: true``  |
+|   JPG files up to 1 MB.                                                       | - Environment variable: ``MM_SERVICESETTINGS_ENABLECUSTOMEMOJI``         |
+| - **false**:  Disables custom emojis.                                         |                                                                          |
++-------------------------------------------------------------------------------+--------------------------------------------------------------------------+
+| **Note**: Too many custom emojis can slow your server’s performance.          |                                                                          |
++-------------------------------------------------------------------------------+--------------------------------------------------------------------------+
 
 ----
 


### PR DESCRIPTION
Documented Cloud-specific default config setting values specified via https://github.com/mattermost/enterprise/blob/master/cloud/config/cloud_defaults.json

Updated config setting page introductions to clarify that only self-hosted admins can edit the ``config.json`` file.