### PR TITLE
Addressed docs gap around user provisioning

### DIFF
--- a/source/guides/welcome-to-mattermost.rst
+++ b/source/guides/welcome-to-mattermost.rst
@@ -36,6 +36,7 @@ Mattermost basics
    Team settings </welcome/team-settings>
    Team keyboard shortcuts </welcome/team-keyboard-shortcuts>
    About user roles </welcome/about-user-roles>
+   Add people to your workspace </welcome/add-people>
    About insights </welcome/insights>
 
 * :doc:`Get started with Mattermost Channels </welcome/get-started-mattermost-channels>` - Learn how to communicate and collaborate with your team using Mattermost Channels.
@@ -46,6 +47,7 @@ Mattermost basics
 * :doc:`Team settings </welcome/team-settings>` - Configure team names, descriptions, icons, and invitation settings.
 * :doc:`Team keyboard shortcuts </welcome/team-keyboard-shortcuts>` Make more efficient use of your keyboard with keyboard shortcuts.
 * :doc:`About user roles </welcome/about-user-roles>` - Learn more about the six types of user roles and their permissions in Mattermost.
+* :doc:`Add people to your workspace </welcome/add-people>` - Learn how to add new users to Mattermost and add users to existing teams and channels.
 * :doc:`Insights </welcome/insights>` - Get insights into the most important events happening on each team within your Mattermost workspace.
 
 Customize your Mattermost experience

--- a/source/welcome/add-people.rst
+++ b/source/welcome/add-people.rst
@@ -1,0 +1,26 @@
+Add people to your workspace
+============================
+
+.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
+  :start-after: :nosearch:
+
+Getting people set up with a Mattermost account is something that happens when deploying and configuring the Mattermost workspace. A Mattermost system admin can `provision Mattermost users </onboard/user-provisioning-workflows.html>`__ using one or more of the following methods:
+
+- `Enable account creation </configure/authentication-configuration-settings.html#enable-account-creation>`__.
+- Use `mmctl user create </manage/mmctl-command-line-tool.html#mmctl-user-create>`__ or Mattermost `APIs <https://api.mattermost.com/#tag/users>`__ to create user accounts.
+- `Migrate user accounts </onboard/migrating-to-mattermost.html#migration-guide>`__ from other collaboration systems and `bulk load </onboard/bulk-loading-data.html>`__ that user data into Mattermost.
+- Connect an authentication service to assist with user provisioning, such as `AD/LDAP authentication </onboard/ad-ldap.html#active-directory-ldap-setup>`__ or `SAML authentication </onboard/sso-saml.html>`__.
+
+Add people on demand
+--------------------
+
+By default, `team admins </welcome/about-user-roles.html#team-admin>`__ can `invite people </welcome/about-teams.html#invite-people-to-teams>`__, including `guests </onboard/guest-accounts.html>`__, to a Mattermost team, and all users can add existing Mattermost users to a Mattermost team or channel, unless the system admin has restricted the ability for you to do so.
+
+- Inviting people to a team sends an email prompting recipients to create a Mattermost account on your Mattermost workspace.
+- Adding an existing user to a team or to a channel makes those users team or channel members.
+
+.. tip::
+
+    - Add users to a channel by selecting the channel name and selecting **Add Members**. 
+    - Add groups of users to a channel by `creating a custom group </welcome/manage-custom-groups.html>`__ and `@mentioning </channels/mention-people.html>`__ the custom group in a channel. Mattermost will prompt to you to add any users who aren't already members of that channel.
+    - Guests are restricted to only the channels you select.

--- a/source/welcome/manage-custom-groups.rst
+++ b/source/welcome/manage-custom-groups.rst
@@ -10,12 +10,14 @@ Custom groups (beta) reduce noise and improve focus by notifying the right peopl
 
 For example, perhaps you want to @mention a cross-functional team about a bug fixes needed for an upcoming feature release, without notifying everyone else in the channel. Using a custom group notifies the cross-functional team immediately, while keeping important stakeholders in the loop on the status of the feature release.
 
+Or perhaps you want to add a group of users to a channel. When you @mention a custom group in a channel, Mattermost prompts you to add anyone from that custom group who isn't already a channel member.
+
 Once a custom user group has been created, you can mention that group the same way you @mention another Mattermost member. See the `mention people in messages </channels/mention-people.html>`__ documentation for details.
 
 .. note::
   
-  - System Admins need to enable this feature. See our `Mattermost Configuration Settings </configure/configuration-settings.html#custom-user-groups>`__ documentation for details. 
-  - From Mattermost v7.2, System Admins can limit who can manage custom user groups through a system admin role, instead of all users being able to manage custom user groups. See the `system roles </onboard/system-admin-roles.html>`__ documentation for details.
+  - System admins need to enable this feature. See our `Mattermost Configuration Settings </configure/configuration-settings.html#custom-user-groups>`__ documentation for details. 
+  - From Mattermost v7.2, system admins can limit who can manage custom user groups through a system admin role, instead of all users being able to manage custom user groups. See the `system roles </onboard/system-admin-roles.html>`__ documentation for details.
   - The ability to create custom user groups on mobile will be available in a future release. @mentions for custom user groups on mobile work the same as `LDAP-synced groups </channels/mention-people.html#groupname>`__.
 
 Create a custom group


### PR DESCRIPTION
Based on documentation feedback, addressed a docs gap around getting new users into a Mattermost instance and adding existing users to teams and channels.