### PR TITLE
OAuth 2.0 deprecation notes removed

### DIFF
--- a/source/configure/authentication-configuration-settings.rst
+++ b/source/configure/authentication-configuration-settings.rst
@@ -1737,10 +1737,6 @@ OAuth 2.0
 
 Access the following configuration settings in the System Console by going to **Authentication > OAuth 2.0**. Settings for GitLab OAuth authentication can also be accessed under **Authentication > GitLab** in self-hosted deployments.
 
-.. note::
-
-  OAuth 2.0 is being deprecated and will be replaced by `OpenID Connect <https://docs.mattermost.com/configure/configuration-settings.html#openid-connect>`__ in a future release.
-
 Use these settings to configure OAuth 2.0 for account creation and login.
 
 .. config:setting:: oauth-selectprovider

--- a/source/onboard/common-converting-oauth-to-openidconnect.rst
+++ b/source/onboard/common-converting-oauth-to-openidconnect.rst
@@ -5,5 +5,4 @@ Using the System Console, Mattermost Enterprise and Professional customers can m
 Select **Convert to OpenID Connect** to migrate your active service provider configuration to the new standard. No further changes are required. 
 
 .. note::
-  - Inactive service providers configured for OAuth 2.0 are also migrated to the new OpenID Connect standard. 
-  - Converting to OpenID Connect removes the **OAuth 2.0** option from the System Console menu.
+  - Inactive service providers configured for OAuth 2.0 are also migrated to the new OpenID Connect standard.


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-webapp/pull/11614