### PR TITLE
Config defaults can't be modified by Cloud admins

### DIFF
--- a/source/configure/authentication-configuration-settings.rst
+++ b/source/configure/authentication-configuration-settings.rst
@@ -108,6 +108,8 @@ Enable email invitations
 | - **false**: **(Default for self-hosted deployments)** | - Environment variable: ``MM_SERVICESETTINGS_ENABLEEMAILINVITATIONS``         |
 |   Disables email invitations.                          |                                                                               |
 +--------------------------------------------------------+-------------------------------------------------------------------------------+
+| **Note**: Cloud admins can't modify this configuration setting.                                                                        |
++--------------------------------------------------------+-------------------------------------------------------------------------------+
 
 Invalidate pending email invites
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -140,11 +142,13 @@ Access the following configuration settings in the System Console by going to **
 Enable account creation with email
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-----------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+
-| - **true**: **(Default)** Allows creation of team and user accounts with email and password.                                                        | - System Config path: **Authentication > Email**                    |
-| - **false**: Disables creation of team and user accounts with email and password. This requries a single sign-on service to create accounts.        | - ``config.json`` setting: ``.EmailSettings.EnableSignUpWithEmail`` |
-|                                                                                                                                                     | - Environment variable: ``MM_EMAILSETTINGS_ENABLESIGNUPWITHEMAIL``  |
-+-----------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+
++-----------------------------------------------------------------------------------------------+---------------------------------------------------------------------+
+| - **true**: **(Default)** Allows creation of team and user accounts with email and password.  | - System Config path: **Authentication > Email**                    |
+| - **false**: Disables creation of team and user accounts with email and password. Requires    | - ``config.json`` setting: ``.EmailSettings.EnableSignUpWithEmail`` |
+|   a single sign-on (SSO) service to create accounts.                                          | - Environment variable: ``MM_EMAILSETTINGS_ENABLESIGNUPWITHEMAIL``  |
++-----------------------------------------------------------------------------------------------+---------------------------------------------------------------------+
+| **Note**: Cloud admins can't modify this configuration setting.                                                                                                     |
++-----------------------------------------------------------------------------------------------+---------------------------------------------------------------------+
 
 .. config:setting:: email-requireverification
   :displayname: Require email verification (Signup)

--- a/source/configure/integrations-configuration-settings.rst
+++ b/source/configure/integrations-configuration-settings.rst
@@ -113,6 +113,10 @@ Enable OAuth 2.0 service provider
 | This feature's ``config.json`` setting is ``"EnableOAuthServiceProvider": false`` with options ``true`` and ``false``. |
 +------------------------------------------------------------------------------------------------------------------------+
 
+.. note::
+
+  Cloud admins can't modify this configuration setting.
+
 .. config:setting:: integrate-enableusernameoverride
   :displayname: Enable integrations to override usernames (Integrations)
   :systemconsole: Integrations > Integration Management

--- a/source/configure/site-configuration-settings.rst
+++ b/source/configure/site-configuration-settings.rst
@@ -529,6 +529,8 @@ Allow users to view archived channels
 | - **false**: Users are unable to access content in archived channels.                                          | - ``config.json`` setting: ``.TeamSettings.ExperimentalViewArchivedChannels: true`` |
 |                                                                                                                | - Environment variable: ``MM_TEAMSETTINGS_EXPERIMENTALVIEWARCHIVEDCHANNELS``        |
 +----------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
+| **Note**: Cloud admins can't modify this configuration setting.                                                                                                                                      |
++----------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
 
 .. config:setting:: users-showemailaddress
   :displayname: Show email address (Users and teams)
@@ -667,8 +669,9 @@ Enable email notifications
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
 | **Notes**:                                                                                                                                                                                                                                                |
 |                                                                                                                                                                                                                                                           |
+| - Cloud admins can't modify this configuration setting.                                                                                                                                                                                                   |
 | - If this setting is **false**, and the SMTP server is set up, account-related emails (such as authentication messages) will be sent regardless of this setting.                                                                                          |
-| - Email invitations and account deactivation emails are not affected by this setting.                                                                                                                                                                     |
+| - Email invitations and account deactivation emails aren't affected by this setting.                                                                                                                                                                      |
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. config:setting:: notification-enablepreviewbanner
@@ -690,6 +693,8 @@ Enable preview mode banner
 | - **false**: Preview Mode banner does not appear.                                                                                                                            | - ``config.json`` setting: ``.EmailSettings.EnablePreviewModeBanner: true`` |
 |                                                                                                                                                                              | - Environment variable: ``MM_EMAILSETTINGS_ENABLEPREVIEWMODEBANNER``        |
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+| **Note**: Cloud admins can't modify this configuration setting.                                                                                                                                                                                            |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
 
 .. config:setting:: notification-enableemailbatching
   :displayname: Enable email batching (Notifications)
@@ -710,6 +715,7 @@ Enable email batching
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------+
 | **Notes**:                                                                                                                                                                                                                                                                                                                                              |
 |                                                                                                                                                                                                                                                                                                                                                         |
+| - Cloud admins can't modify this configuration setting.                                                                                                                                                                                                                                                                                                 |
 | - Regardless of this setting, a user can turn off these notifications under **Settings > Notifications**.                                                                                                                                                                                                                                               |
 | - The `Site Url <https://docs.mattermost.com/configure/environment-configuration-settings.html#site-url>`__ and `SMTP Email Server <https://docs.mattermost.com/configure/environment-configuration-settings.html#smtp-server>`__ must be configured to allow email batching.                                                                           |
 | - Email batching in `High Availability Mode <https://docs.mattermost.com/configure/environment-configuration-settings.html#enable-high-availability-mode>`__ is planned, but not yet supported.                                                                                                                                                         |


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-webapp/pull/11500

Added notes for config settings defaulted to True for Cloud deployments that cannot be modified by Cloud Admins.