### PR TITLE
Clarified release details to remove user

### DIFF
--- a/source/channels/manage-channel-members.rst
+++ b/source/channels/manage-channel-members.rst
@@ -52,7 +52,7 @@ Remove members from a channel
 Using Mattermost in a web browser or the desktop app, any member of a channel can remove other members from a channel using one of the following options:
 
 - Select the channel name at the top of the center pane to access the drop-down menu, then select **Manage Members**. Select the member's `user role </welcome/about-user-roles.html>`__, then select **Remove from Channel**.
-- Select the channel's **View Info** |channel-info| icon, and select **Members** in the right pane. From there, select **Manage**, select a user's role, then select **Remove from Channel**.
+- From Mattermost v7.7, you can alternatively select the channel's **View Info** |channel-info| icon, and select **Members** in the right pane. From there, select **Manage**, select a user's role, then select **Remove from Channel**.
 
 .. image:: ../images/remove-member-from-channel.png
     :alt: Use options available through the channel name to remove a member from a channel.


### PR DESCRIPTION
Docs listening: Clarified that the Remove member from channel feature via Channel membership list is available to customers using Mattermost v7.7 or later based on the following docs feedback: "Remove Member from Channel" is not available. Page should contain a hint, that "Remove" is available in Enterprise Version only (if so ...)"