### PR TITLE
Corrected Bleve access to be self-hosted only

### DIFF
--- a/source/deploy/bleve-search.rst
+++ b/source/deploy/bleve-search.rst
@@ -1,7 +1,7 @@
 Bleve search (experimental)
 ===========================
 
-.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
+.. include:: ../_static/badges/allplans-selfhosted.rst
   :start-after: :nosearch:
 
 Bleve is a search engine that uses Lucene-style full-text search and indexing. This style of search and indexing helps overcome limitations of the default database search such as challenges with characters and advanced search capabilities.


### PR DESCRIPTION
Docs listening: Bleve isn't supported in HA environments, and therefore not available via Cloud workspaces. Corrected docs deployment details.