### PR TITLE
Updated channel sidebar keyboard navigation

### DIFF
--- a/source/channels/keyboard-accessibility.rst
+++ b/source/channels/keyboard-accessibility.rst
@@ -72,7 +72,7 @@ For example, a message read by a screen reader may sound like the following:
 Channel sidebar navigation
 --------------------------
 
-When the channel sidebar region is focused, use the :kbd:`↑` or :kbd:`↓` arrow keys to focus individual sidebar sections, such as Favorites, public channels, private channels, and direct messages. Press :kbd:`Tab` to navigate through channels or other buttons within a sidebar section.
+When the channel sidebar region is focused, use the :kbd:`↑` or :kbd:`↓` arrow keys to focus individual sidebar sections, such as Insights, Threads, Favorites, custom categories, public channels, private channels, and direct messages. Press :kbd:`Tab` to navigate through channels or other buttons within a sidebar section.
 
 .. image:: ../images/channel-sidebar-navigation.gif
   :alt: Navigate the Mattermost channel sidebar using a keyboard.


### PR DESCRIPTION
Insights and drafts are now included when navigating through channels in the channel sidebar using ALT+UP/DOWN arrow keyboard keys.