### PR TITLE
Default value for EnableOAuthServiceProvider

### DIFF
--- a/source/configure/integrations-configuration-settings.rst
+++ b/source/configure/integrations-configuration-settings.rst
@@ -99,8 +99,8 @@ Slash commands send events to external integrations that send a response back to
   :configjson: EnableOAuthServiceProvider
   :environment: N/A
 
-  - **true**: Mattermost acts as an OAuth 2.0 service provider allowing Mattermost to authorize API requests from external applications.
-  - **false**: **(Default)** Mattermost does not function as an OAuth 2.0 service provider.
+  - **true**: **(Default)** Mattermost acts as an OAuth 2.0 service provider allowing Mattermost to authorize API requests from external applications.
+  - **false**: Mattermost does not function as an OAuth 2.0 service provider.
 
 Enable OAuth 2.0 service provider
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -110,7 +110,7 @@ Enable OAuth 2.0 service provider
 **False**: Mattermost does not function as an OAuth 2.0 service provider.
 
 +------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableOAuthServiceProvider": false`` with options ``true`` and ``false``. |
+| This feature's ``config.json`` setting is ``"EnableOAuthServiceProvider": true`` with options ``true`` and ``false``.  |
 +------------------------------------------------------------------------------------------------------------------------+
 
 .. note::


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost-server/pull/22175

Please confirm that both the config setting documentation and the search results content returned when searching for EnableOAuthServiceProvider has been updated as expected. The default for EnableOAuthServiceProvider as of v7.8 is ``true``.