### PR TITLE
Update main CTA button in nav

### DIFF
--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -348,7 +348,7 @@
 						</div>
 					</li>
 					<li class="site-nav__toplink site-nav__button">
-						<a class="mm-button mm-button-solid mm-button-blue" href="https://mattermost.com/trial/" data-ol-has-click-handler="">Free Trial</a>
+						<a class="mm-button mm-button-solid mm-button-blue" href="https://mattermost.com/get-started/" data-ol-has-click-handler="">Get Started</a>
 					</li>
 					<li class="site-nav__toplink site-nav__button site-nav__button--secondary">
 						<a class="mm-button mm-button-outline--thin mm-button-outline--thin-blue" href="https://mattermost.com/contact-sales/" data-ol-has-click-handler="">Contact Sales</a>


### PR DESCRIPTION
#### Summary

This pull request updates the main CTA button in the nav from `Free Trial` to `Get Started`.
A full navigation sync between docs and mm.com will be coming in the next several days, as we've iterated on it quite a bit.

TY!
