### PR TITLE
Shared Channels licensing updates

### DIFF
--- a/source/onboard/shared-channels.rst
+++ b/source/onboard/shared-channels.rst
@@ -1,7 +1,7 @@
 Shared channels (experimental)
 ==============================
 
-.. include:: ../_static/badges/ent-pro-cloud-selfhosted.rst
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
 Shared channels is an experimental feature that brings people together from multiple Mattermost installations. For example, teams collaborating with external partners and customers using multiple Mattermost instances in a federated architecture.


### PR DESCRIPTION
According to almost all other resources available, Shared Channels does not seem to be available in the Professional edition. References:
* https://docs.mattermost.com/configure/experimental-configuration-settings.html#exp-enablesharedchannels
* https://docs.mattermost.com/about/editions-and-offerings.html

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

