### PR TITLE
Add support for Focalboard, newer Apache and SSL

### DIFF
--- a/source/configure/config-proxy-apache2.rst
+++ b/source/configure/config-proxy-apache2.rst
@@ -16,11 +16,11 @@ On a Debian-based operating system such as Ubuntu, Apache2 reverse proxy configu
 3. Create the above mentioned configuration file. It is often helpful to start with a copy of ``000-default.conf`` or ``default-ssl.conf`` (on Ubuntu).
 4. Edit your configuration using the guide below:
 
-    1. If you're not setting up a subdomain, your ``ServerName`` will simply be set to ``mymattermost.tld``.
-    2. ``ServerAlias`` can been added too if you want to capture any other (sub)domains.
-    3. Remember to change the values to match your server's name, etc.
-    4. If you have enabled TLS in the Mattermost settings, you must also enable the SSL module in Apache (usually with ``a2enmod ssl``) and change the ``http://`` part of the proxy destination to ``https://`` additionally to enabling the ``SSLProxyEngine``.
-    5. To serve requests on a different port (such as 8443), in addition to setting the port in the VirtualHost element, add ``Listen 8443`` on a separate line before the VirtualHost line.
+    a. If you're not setting up a subdomain, your ``ServerName`` will simply be set to ``mymattermost.tld``.
+    b. ``ServerAlias`` can been added too if you want to capture any other (sub)domains.
+    c. Remember to change the values to match your server's name, etc.
+    d. If you have enabled TLS in the Mattermost settings, you must also enable the SSL module in Apache (usually with ``a2enmod ssl``) and change the ``http://`` part of the proxy destination to ``https://`` additionally to enabling the ``SSLProxyEngine``.
+    e. To serve requests on a different port (such as 8443), in addition to setting the port in the VirtualHost element, add ``Listen 8443`` on a separate line before the VirtualHost line.
 
 .. code-block:: apacheconf
 
@@ -55,7 +55,7 @@ On a Debian-based operating system such as Ubuntu, Apache2 reverse proxy configu
           # SSLProxyEngine On
         </VirtualHost>
 
-6. Restart Apache2.
+5. Restart Apache2.
 
     - On Ubuntu 14.04 and RHEL 6: ``sudo service apache2 restart``
     - On Ubuntu 16.04+ and RHEL 7+: ``sudo systemctl restart apache2``
@@ -110,4 +110,4 @@ You should be all set! Ensure that your Mattermost config file is pointing to th
           # SSLProxyEngine On
         </VirtualHost>
 
- 3. If you have enabled TLS in the Mattermost settings, you must also enable the SSL module in Apache (usually with ``a2enmod ssl``) and change the ``http://`` part of the proxy destination to ``https://`` and the websocket protocol from ``ws://`` to ``wss://`` additionally to enabling the ``SSLProxyEngine``.
+3. If you have enabled TLS in the Mattermost settings, you must also enable the SSL module in Apache (usually with ``a2enmod ssl``) and change the ``http://`` part of the proxy destination to ``https://`` and the websocket protocol from ``ws://`` to ``wss://`` additionally to enabling the ``SSLProxyEngine``.

--- a/source/configure/config-proxy-apache2.rst
+++ b/source/configure/config-proxy-apache2.rst
@@ -2,38 +2,95 @@
 
 .. _config-proxy-apache2:
 
-Configuring Apache2 as a proxy for Mattermost Server (Unofficial)
+Configuring Apache2 as a reverse proxy for Mattermost Server (Unofficial)
 -----------------------------------------------------------------
 
 .. important:: This unofficial guide is maintained by the Mattermost community and this deployment configuration is not yet officially supported by Mattermost, Inc. `Community testing, feedback and improvements are welcome and greatly appreciated <https://github.com/mattermost/docs/issues/1295>`__. You can `edit this page on GitHub <https://github.com/mattermost/docs/blob/master/source/configure/config-proxy-apache2.rst>`__.
 
-On a Debian-based operating system such as Ubuntu, Apache2 proxy configuration is done in the ``/etc/apache2/sites-available`` directory. Red Hat-based systems organize Apache configuration files `differently <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-web_servers>`__. If you're setting up Mattermost on a subdomain, you'll want to create a new configuration file along the lines of ``mysubdomain.mydomain.com.conf``.
+On a Debian-based operating system such as Ubuntu, Apache2 reverse proxy configuration is done in the ``/etc/apache2/sites-available`` directory. Red Hat-based systems organize Apache configuration files `differently <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-web_servers>`__. If you're setting up Mattermost on a subdomain, you'll want to create a new configuration file along the lines of ``mysubdomain.mydomain.com.conf`` and enable it afterwards (usually with ``a2ensite mysubdomain.mydomain.com``).
 
-**To configure Apache2 as a proxy**
+**To configure Apache2 (>= 2.4.47) as a reverse proxy**
 
 1. SSH into your server.
-2. Make sure the Apache modules ``mod_rewrite`` , ``mod_proxy``, ``mod_proxy_http``, and ``mod_proxy_wstunnel`` are installed and enabled. If not, follow the instructions from your Linux distribution to do so.
+2. Make sure the Apache modules ``mod_rewrite``, ``mod_proxy`` and ``mod_proxy_http`` are installed and enabled. If not, follow the instructions from your Linux distribution to do so (usually this is being done with ``a2enmod rewrite``, ``a2enmod proxy`` and ``a2enmod proxy_http``).
 3. Create the above mentioned configuration file. It is often helpful to start with a copy of ``000-default.conf`` or ``default-ssl.conf`` (on Ubuntu).
 4. Edit your configuration using the guide below:
 
-    1. If you're not setting up a subdomain, your ``ServerName`` will simply be set to ``mydomain.com``.
-    2. ``ServerAlias`` can been added too if you want to capture ``www.mydomain.com``.
+    1. If you're not setting up a subdomain, your ``ServerName`` will simply be set to ``mymattermost.tld``.
+    2. ``ServerAlias`` can been added too if you want to capture any other (sub)domains.
     3. Remember to change the values to match your server's name, etc.
-    4. If you have enabled TLS in the Mattermost settings, you must use the protocol ``wss://`` instead of ``ws://`` in the ``RewriteRule``.
+    4. If you have enabled TLS in the Mattermost settings, you must also enable the SSL module in Apache (usually with ``a2enmod ssl``) and change the ``http://`` part of the proxy destination to ``https://`` additionally to enabling the ``SSLProxyEngine``.
     5. To serve requests on a different port (such as 8443), in addition to setting the port in the VirtualHost element, add ``Listen 8443`` on a separate line before the VirtualHost line.
 
 .. code-block:: apacheconf
 
         <VirtualHost *:80>
-          # If you're not using a subdomain you may need to set a ServerAlias to:
-          # ServerAlias www.mydomain.com
-          ServerName mysubdomain.mydomain.com
-          ServerAdmin hostmaster@mydomain.com
+          ServerName mymattermost.tld
+          # Uncomment the following line if this host also should be reachable on a different domain
+          # ServerAlias sub.mymattermost.tld
+          ServerAdmin hostmaster@mymattermost.tld
+          
+          RewriteEngine On
+          RewriteRule "^/(.*)" "https://mymattermost.tld/$1" [R=301,L]
+        </VirtualHost>
+          
+        <VirtualHost *:443>
+          ServerName mymattermost.tld
+          # Uncomment the following line if this host also should be reachable on a different domain
+          # ServerAlias sub.mymattermost.tld
+          ServerAdmin hostmaster@mymattermost.tld
+          ProxyPreserveHost On
+
+          ProxyPassMatch "^/(api/v[0-9]+/(users/)?websocket)$" "http://127.0.0.1:8065/$1" upgrade=websocket
+          ProxyPassMatch "^/(plugins/focalboard/ws/.*$)" "http://127.0.0.1:8065/$1" upgrade=websocket
+          ProxyPass / http://127.0.0.1:8065/
+          ProxyPassReverse / http://127.0.0.1:8065/
+          ProxyPassReverseCookieDomain 127.0.0.1 mymattermost.tld
+          
+          SSLEngine On
+          SSLCertificateFile /path/to/your/certificate.pem
+          SSLCertificateKeyFile /path/to/your/certificate.key
+          
+          # Uncomment the following line if your Mattermost server is requiring SSL/TLS connections
+          # SSLProxyEngine On
+        </VirtualHost>
+
+6. Restart Apache2.
+
+    - On Ubuntu 14.04 and RHEL 6: ``sudo service apache2 restart``
+    - On Ubuntu 16.04+ and RHEL 7+: ``sudo systemctl restart apache2``
+
+You should be all set! Ensure that your Mattermost config file is pointing to the correct URL (which may include a port), and then ensure that your socket connection is not dropping once deployed. To prevent external access to Mattermost on port 8065, in the config file, set ``ListenAddress`` to ``localhost:8065`` instead of ``:8065``.
+
+**To configure Apache2 (< 2.4.47) as a reverse proxy**
+
+1. Follow the instructions from above, but additionally also install and enable the ``mod_proxy_wstunnel`` module (usually with ``a2enmod proxy_wstunnel`` after it has been installed)
+
+2. Use the following configuration
+
+.. code-block:: apacheconf
+
+        <VirtualHost *:80>
+          ServerName mymattermost.tld
+          # Uncomment the following line if this host also should be reachable on a different domain
+          # ServerAlias sub.mymattermost.tld
+          ServerAdmin hostmaster@mymattermost.tld
+          
+          RewriteEngine On
+          RewriteRule "^/(.*)" "https://mymattermost.tld/$1" [R=301,L]
+        </VirtualHost>
+
+        <VirtualHost *:443>
+          ServerName mymattermost.tld
+          # Uncomment the following line if this host also should be reachable on a different domain
+          # ServerAlias sub.mymattermost.tld
+          ServerAdmin hostmaster@mymattermost.tld
           ProxyPreserveHost On
 
           # Set web sockets
           RewriteEngine On
-          RewriteCond %{REQUEST_URI} /api/v[0-9]+/(users/)?websocket [NC]
+          RewriteCond %{REQUEST_URI} /api/v[0-9]+/(users/)?websocket [NC,OR]
+          RewriteCond %{REQUEST_URI} /plugins/focalboard/ws/ [NC]
           RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC,OR]
           RewriteCond %{HTTP:CONNECTION} ^Upgrade$ [NC]
           RewriteRule .* ws://127.0.0.1:8065%{REQUEST_URI} [P,QSA,L]
@@ -42,16 +99,15 @@ On a Debian-based operating system such as Ubuntu, Apache2 proxy configuration i
             Require all granted
             ProxyPass http://127.0.0.1:8065/
             ProxyPassReverse http://127.0.0.1:8065/
-            ProxyPassReverseCookieDomain 127.0.0.1 mysubdomain.mydomain.com
+            ProxyPassReverseCookieDomain 127.0.0.1 mymattermost.tld
           </Location>
 
+          SSLEngine On
+          SSLCertificateFile /path/to/your/certificate.pem
+          SSLCertificateKeyFile /path/to/your/certificate.key
+          
+          # Uncomment the following line if your Mattermost server is requiring SSL/TLS connections
+          # SSLProxyEngine On
         </VirtualHost>
 
-5. (Debian/Ubuntu only) Because you'll likely have not set up the subdomain before now on Apache2, run ``a2ensite mysubdomain.mydomain.com`` to enable the site (do not run ``a2ensite mysubdomain.mydomain.com.conf``).
-
-6. Restart Apache2.
-
-    - On Ubuntu 14.04 and RHEL 6: ``sudo service apache2 restart``
-    - On Ubuntu 16.04+ and RHEL 7+: ``sudo systemctl restart apache2``
-
-You should be all set! Ensure that your Mattermost config file is pointing to the correct URL (which may include a port), and then ensure that your socket connection is not dropping once deployed. To prevent external access to Mattermost on port 8065, in the config file, set ``ListenAddress`` to ``localhost:8065`` instead of ``:8065``.
+ 3. If you have enabled TLS in the Mattermost settings, you must also enable the SSL module in Apache (usually with ``a2enmod ssl``) and change the ``http://`` part of the proxy destination to ``https://`` and the websocket protocol from ``ws://`` to ``wss://`` additionally to enabling the ``SSLProxyEngine``.


### PR DESCRIPTION
Based on some user complaints in the forum and the community channels, I had a look at the Apache documentation here and it was missing support for the focalboard websockets as well as SSL and newer mod_proxy_http-only setups on Apache 2.4.47+.

I did also rewrite some other parts to be more specific and give hints to the commands necessary.

I have no idea how to move the bulletpoint "3" at the end out of the codeblock, if someone could fix that for me (and let me know what I did wrong), this would be awesome :) Please read through it, an additional pair of eyes would be good - thanks!

The new configuration has been tested and verified working on one of my demo systems, I did not test the old config but assume it was working and still is.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

