### PR TITLE
Remove notification banner

### DIFF
--- a/source/_static/myscript.js
+++ b/source/_static/myscript.js
@@ -170,20 +170,24 @@ $(document).ready(function () {
 		}
 	});
 	// Notification Banner
-	if (localStorage.getItem("docsFeedback") === null) {
-		localStorage.setItem('docsFeedback', true);
-		$('.notification-bar').addClass('flex');
-		$('body').addClass('with-notification');
-	} else {
-		const docsFeedbackItem = localStorage.getItem('docsFeedback');
 
-		if (docsFeedbackItem == 'false') {
-			$('.notification-bar').remove();
-			$('body').removeClass('with-notification');
-		} else {
-			$('body').addClass('with-notification');
-		}
-	}
+	// For when we want to show the notification banner for feedback link
+	// if (localStorage.getItem("docsFeedback") === null) {
+	// 	localStorage.setItem('docsFeedback', true);
+	// 	$('.notification-bar').addClass('flex');
+	// 	$('body').addClass('with-notification');
+	// } else {
+	// 	const docsFeedbackItem = localStorage.getItem('docsFeedback');
+
+	// 	if (docsFeedbackItem == 'false') {
+	// 		$('.notification-bar').remove();
+	// 		$('body').removeClass('with-notification');
+	// 	} else {
+	// 		$('body').addClass('with-notification');
+	// 	}
+	// }
+
+
 	$('body').on('click', '.notification-bar__close', function(){
 		$('.notification-bar').remove();
 		$('body').removeClass('with-notification');

--- a/source/_static/myscript.js
+++ b/source/_static/myscript.js
@@ -191,7 +191,7 @@ $(document).ready(function () {
 	$('body').on('click', '.notification-bar__close', function(){
 		$('.notification-bar').remove();
 		$('body').removeClass('with-notification');
-		localStorage.setItem('docsFeedback', false);
+		// localStorage.setItem('docsFeedback', false);
 	});
 
 });

--- a/source/conf.py
+++ b/source/conf.py
@@ -2489,7 +2489,7 @@ html_css_files = ["mytheme.css?v=v7", "css/compass-icons.css"]
 # A list of JavaScript filenames. The entry must be a filename string or a tuple containing the filename string and the
 # attributes dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like
 # https://example.org/script.js. The attributes is used for attributes of <script> tag. It defaults to an empty list.
-html_js_files = ["myscript.js"]
+html_js_files = ["myscript.js?v=v2"]
 
 # The name of an image file, relative to the configuration directory, to use as favicon of the docs.  This file should
 # be a Windows icon file (.ico) being 16x16 or 32x32 pixels in size.

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -1,13 +1,13 @@
-<div data-swiftype-index=false class="notification-bar sticky-top">
+<!-- <div data-swiftype-index=false class="notification-bar sticky-top">
     <div class="notification-bar__content">
         <a class="notification-bar__close" data-ol-has-click-handler="">
             <span aria-hidden="true">×</span>
         </a>
 	    <div>
-		    <div><a href="https://mattermost.com/webinar/release-management-with-gitlab/">Learn how to streamline and standardize your release processes with Mattermost and GitLab on March 2nd »</a></div>
+		    <div><a href=""> »</a></div>
 		</div>
     </div>
-</div>
+</div> -->
 {%- if pagename == 'index' %}
 <header class="site-header" itemscope="" itemtype="https://schema.org/WebSite">
 {%- else %}


### PR DESCRIPTION
#### Summary
This PR removes the notification banner since the GitLab webinar has passed. I've commented the element out – for when we decide we need to turn it back on.

Thanks!

