### PR TITLE
update mmctl migrate-auth docs

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -6008,6 +6008,32 @@ Migrate accounts from one authentication provider to another. For example, you c
 
    mmctl user migrate-auth [from_auth] [to_auth] [migration-options] [flags]
 
+**Arguments**
+
+   **from_auth:**
+      The authentication service to migrate users accounts from.
+      Supported options: email, gitlab, google, ldap, office365, saml.
+
+  **to_auth:**
+      The authentication service to migrate users to.
+      Supported options: ldap, saml.
+
+  **migration-options (ldap):**
+      match_field:
+         The field that is guaranteed to be the same in both authentication services. For example, if the users emails are consistent set to email.
+         Supported options: email, username.
+
+  **migration-options (saml):**
+      **users_file:**
+         The path of a json file with the usernames and emails of all users to migrate to SAML. The username and email must be the same that the SAML service provider store. And the email must match with the email in mattermost database.
+
+.. code-block:: json
+            Example json content:
+            {
+               "usr1@email.com": "usr.one",
+               "usr2@email.com": "usr.two"
+            }
+
 **Examples**
 
 .. code-block:: sh


### PR DESCRIPTION

#### Summary

Adds more examples and info to the migrate auth command (this is pulled from mmctl directly)

