### PR TITLE
Fix wrong query

### DIFF
--- a/source/upgrade/important-upgrade-notes.rst
+++ b/source/upgrade/important-upgrade-notes.rst
@@ -22,7 +22,7 @@ Important Upgrade Notes
 |                                                    |                                                                                                                                                                  |
 |                                                    | SQL to check the presence of duplicate data:                                                                                                                     |
 |                                                    |                                                                                                                                                                  |
-|                                                    | ``SELECT user_id, board_id, count(*) AS count FROM focalboard_category_boards WHERE delete_at = 0 GROUP BY user_id, board_id HAVING count(*) > 1;``              |
+|                                                    | ``SELECT user_id, board_id, count(*) AS count FROM focalboard_category_boards GROUP BY user_id, board_id HAVING count(*) > 1;``                                  |
 |                                                    |                                                                                                                                                                  |
 |                                                    | SQL to delete duplicate data:                                                                                                                                    |
 |                                                    |                                                                                                                                                                  |


### PR DESCRIPTION
This query was wrong, there is no column `delete_at` anymore since DB migration 34 and since it was unused, the same query will also work for all older releases. I'm not sure where else this needs to be fixed, since it's probably part of a complex release process, so please take it from there.

Thread with more details: https://community.mattermost.com/core/pl/ret351hkwincmctwqmmim74g4a

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

