### PR TITLE
Remove CTA button in nav

### DIFF
--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -410,11 +410,8 @@
 							</figure>
 						</div>
 					</li>
-					<li class="site-nav__toplink site-nav__button">
-						<a class="mm-button mm-button-solid mm-button-blue" href="https://mattermost.com/get-started/" data-ol-has-click-handler="">Get Started</a>
-					</li>
 					<li class="site-nav__toplink site-nav__button site-nav__button--secondary">
-						<a class="mm-button mm-button-outline--thin mm-button-outline--thin-blue" href="https://mattermost.com/contact-sales/" data-ol-has-click-handler="">Contact Sales</a>
+						<a class="mm-button mm-button-solid mm-button-blue" href="https://mattermost.com/contact-sales/" data-ol-has-click-handler="">Contact Sales</a>
 					</li>
 				</ul>
 			</div>


### PR DESCRIPTION
#### Summary

This PR removes the Get Started CTA button in the navigation. We just changed the link to `/download/` on the mm.com site to pivot towards SH. But for docs if we're on the installation pages, we're creating a circular journey – and for all the other pages the docs are mostly targeted towards current users - so download may not be necessary (?). There's also the possibility to use the button for another CTA if one works better on docs.

Wanted to push this up to open the discussion here – tagging @aaron-l-thompson to chime in with any other details.

TY~