### PR TITLE
Various updates to the changelogs

### DIFF
--- a/source/deploy/mobile-app-changelog.md
+++ b/source/deploy/mobile-app-changelog.md
@@ -10,7 +10,7 @@ Latest Mattermost Mobile Apps releases:
 - [1.55.0 Release](#id18)
 
 ## 2.2.0 Release
-- Release Date: March 16, 2023
+- Release Date: March 17, 2023
 - Server Versions Supported: Server v7.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
 ### Compatibility

--- a/source/install/self-managed-changelog.md
+++ b/source/install/self-managed-changelog.md
@@ -98,6 +98,7 @@ Mattermost v7.9.0 contains a low severity level security fix. [Upgrading](https:
 ### Known Issues
  - Compact display issues can be seen [MM-51489](https://mattermost.atlassian.net/browse/MM-51489).
  - ``NotifyAdmin`` job reports an error for unlicensed servers [MM-51467](https://mattermost.atlassian.net/browse/MM-51467).
+ - Users are unexpectedly forced to enable JSON logging [MM-51453](https://mattermost.atlassian.net/browse/MM-51453).
  - Checkmarks are missing from the left-hand side submenus [MM-51091](https://mattermost.atlassian.net/browse/MM-51091).
  - The new Insights feature has some performance costs that we are working to optimize. This feature can be disabled by setting the ``MM_FEATUREFLAGS_INSIGHTSENABLED`` environment variable to ``false``.
  - Adding an @mention at the start of a post draft and pressing the left or right arrow key can clear the post draft and the undo history [MM-33823](https://mattermost.atlassian.net/browse/MM-33823).


### PR DESCRIPTION
-Fixed mobile v2.2 release date
-Added a known issue for self-hosted changelog