### PR TITLE
Fix wrong filename and format

### DIFF
--- a/source/onboard/run-bulk-loading-command.rst
+++ b/source/onboard/run-bulk-loading-command.rst
@@ -10,11 +10,11 @@ Before running the bulk loading command, you must first create a `JSONL <https:/
 
   .. tab:: Use mmctl
 
-    1. After you create the file, upload the file to the database by running the `mmctl import upload </manage/mmctl-command-line-tool.html#mmctl-import-upload>`__ command. For example: ``mmctl import upload data.jsonl``.
+    1. After you created the JSONL file, you need to zip it (`zip -r data.zip data.jsonl`) and upload the ZIP file to the database by running the `mmctl import upload </manage/mmctl-command-line-tool.html#mmctl-import-upload>`__ command. For example: ``mmctl import upload data.zip``.
 
     2. Confirm that the file is uploaded and ready for use by running the `mmctl import list available </manage/mmctl-command-line-tool.html#mmctl-import-list-available>`__ command. 
 
-    3. Import your uploaded file by running the `mmctl import process </manage/mmctl-command-line-tool.html#mmctl-import-process>`__ command. For example: ``mmctl import process data.jsonl``.
+    3. Import your uploaded file by running the `mmctl import process </manage/mmctl-command-line-tool.html#mmctl-import-process>`__ command. For example: ``mmctl import process <importedid>_data.zip`` (use the name of the uploaded file from `mmctl import list available </manage/mmctl-command-line-tool.html#mmctl-import-list-available>`__ command).
 
   .. tab:: Use CLI
 


### PR DESCRIPTION
This command does not work, the processed import file always gets an ID generated and prepended to the file and needs to be specified for the import process command. Additionally, JSONL Files cannot be uploaded directly, only ZIP files are supported.

The preview didn't work for me here, so I'm not 100% sure I got it right as far as formatting is concerned, sorry.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

