### PR TITLE
Remove auth_data from example user object

### DIFF
--- a/source/onboard/bulk-loading-data-format.rst
+++ b/source/onboard/bulk-loading-data-format.rst
@@ -531,7 +531,6 @@ For clarity, the object is shown using regular JSON formatting, but in the data 
       "username": "username",
       "email": "email@example.com",
       "auth_service": "",
-      "auth_data": "",
       "password": "passw0rd",
       "nickname": "bobuser",
       "first_name": "Bob",


### PR DESCRIPTION
When trying to import the example user object, the import process fails with the error message:

Data: map[error:Error during job execution. — BulkImport: User AuthData and Password are mutually exclusive. 

The example is not valid, so I suggest to remove the "auth_data" option here.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

