### PR TITLE
desktop-app-install: fix typo on “configuation”

### DIFF
--- a/source/install/desktop-app-install.rst
+++ b/source/install/desktop-app-install.rst
@@ -200,7 +200,7 @@ The following additional documentation resources are also available for the Matt
 Troubleshooting your Desktop App installation
 ----------------------------------------------
 
-Where is configuation stored locally?
+Where is configuration stored locally?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The location of the Mattermost desktop app configuration file depends on the platform where you're running Mattermost (and, in the case of macOS, how you've chosen to install the app):


### PR DESCRIPTION
#### Summary
Fix typo.

#### Ticket Link
.