### PR TITLE
Changes to MySQL install instructions for Ubuntu

### DIFF
--- a/source/install/install-ubuntu-1804-mysql.rst
+++ b/source/install/install-ubuntu-1804-mysql.rst
@@ -9,21 +9,13 @@ Install and set up the database for use by the Mattermost server. You can instal
 Install MySQL on Ubuntu Server 18.04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Log into the server that will host the database, and open a terminal window.
+1. Log into the server that will host the database, and install MySQL.
 
-2. Install MySQL.
-
-  ``sudo apt install mysql-server``
-
-3. Run ``mysql_secure_installation`` and follow the instructions.
-
-  ``sudo mysql_secure_installation``
-
-4. Log in to MySQL as root.
+2. Log in to MySQL as root.
 
   ``sudo mysql``
 
-5. Create the Mattermost user 'mmuser'.
+3. Create the Mattermost user 'mmuser'.
 
   ``mysql> create user 'mmuser'@'%' identified by 'mmuser-password';``
 
@@ -31,11 +23,11 @@ Install MySQL on Ubuntu Server 18.04
     1. Use a password that is more secure than 'mmuser-password'.
     2. The '%' means that mmuser can connect from any machine on the network. However, it's more secure to use the IP address of the machine that hosts Mattermost. For example, if you install Mattermost on the machine with IP address 10.10.10.2, then use the following command: ``mysql> create user 'mmuser'@'10.10.10.2' identified by 'mmuser-password';``
 
-6. Create the Mattermost database.
+4. Create the Mattermost database.
 
   ``mysql> create database mattermost;``
 
-7. Grant access privileges to the user 'mmuser'.
+5. Grant access privileges to the user 'mmuser'.
 
   ``mysql> grant all privileges on mattermost.* to 'mmuser'@'%';``
 
@@ -44,7 +36,7 @@ Install MySQL on Ubuntu Server 18.04
 
     ``mysql> GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, SELECT, UPDATE, REFERENCES ON mattermost.* TO 'mmuser'@'%';``
 
-8. Log out of MySQL.
+6. Log out of MySQL.
 
    ``mysql> exit``
 

--- a/source/install/install-ubuntu-2004-mysql.rst
+++ b/source/install/install-ubuntu-2004-mysql.rst
@@ -11,19 +11,13 @@ Install and set up the database for use by the Mattermost server. You can instal
 Install MySQL on Ubuntu Server 20.04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Log into the server that will host the database, and open a terminal window.
+1. Log into the server that will host the database and install MySQL.
 
-2. Install MySQL.
-
-  ``sudo apt install mysql-server``
-
-3. Run ``sudo mysql_secure_installation`` and follow the instructions.
-
-4. Log in to MySQL as *root*.
+2. Log in to MySQL as *root*.
 
   ``sudo mysql``
 
-5. Create the Mattermost user *mmuser*.
+3. Create the Mattermost user *mmuser*.
 
   ``mysql> create user 'mmuser'@'%' identified by 'mmuser-password';``
 
@@ -31,11 +25,11 @@ Install MySQL on Ubuntu Server 20.04
     1. Use a password that is more secure than 'mmuser-password'.
     2. The '%' means that mmuser can connect from any machine on the network. However, it's more secure to use the IP address of the machine that hosts Mattermost. For example, if you install Mattermost on the machine with IP address 10.10.10.2, then use the following command: ``mysql> create user 'mmuser'@'10.10.10.2' identified by 'mmuser-password';``
 
-6. Create the Mattermost database.
+4. Create the Mattermost database.
 
   ``mysql> create database mattermost;``
 
-7. Grant access privileges to the user *mmuser*.
+5. Grant access privileges to the user *mmuser*.
 
   ``mysql> grant all privileges on mattermost.* to 'mmuser'@'%';``
 
@@ -44,7 +38,7 @@ Install MySQL on Ubuntu Server 20.04
 
     ``mysql> GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, SELECT, UPDATE, REFERENCES ON mattermost.* TO 'mmuser'@'%';``
 
-8. Log out of MySQL.
+6. Log out of MySQL.
 
    ``mysql> exit``
 


### PR DESCRIPTION
#### Summary

This PR addresses an issue with the MySQL installation instructions for Ubuntu. In short, the instructions potentially caused a recursive loop due to conflicts between the `mysql_secure_installation` script and the default configuration of MySQL on Ubuntu. The issue is addressed in detail in this Digital Ocean article: https://www.digitalocean.com/community/tutorials/how-to-install-mysql-on-ubuntu-20-04.

This PR addresses the issue by removing the reference to the `mysql_secure_installation` and simply directing users to install MySQL, and presuming that the user can find other resources to accomplish that. This is similar to how the installation of PostgreSQL is handled in the Mattermost docs.

@cwarnermm and @nab-77, please review this PR. One potential change would be to link directly to the Digital Ocean article to help users with the install.