### PR TITLE
Update cloud-billing.rst

### DIFF
--- a/source/manage/cloud-billing.rst
+++ b/source/manage/cloud-billing.rst
@@ -4,11 +4,11 @@ Mattermost Cloud billing
 .. include:: ../_static/badges/allplans-cloud.rst
   :start-after: :nosearch:
 
-From February 2, 2023, Mattermost Cloud Professional and Enterprise plans are offered as an annual subscription service.
+From February 2, 2023, Mattermost Cloud Professional and Enterprise plans are offered as an annual subscription service. Existing customers billed monthly will no longer be supported as of July 27, 2023.
 
 .. note:: 
    
-   If you have an existing Cloud Professional monthly subscription you can keep it as is and are not required to switch to an annual subscription. If you'd like to switch, please follow these steps:
+   If you have an existing Cloud Professional monthly subscription, you have until July 27, 2023 to switch to annual billing.:
    
    1. Go to **System Console > Subscription**. In the **Switch to an annual plan today** section select **Learn More**. 
    2. Fill in your payment information.


### PR DESCRIPTION
Removed mentions of the switch to annual billing as an option, changing it as a requirement before full deprecation of monthly billing in July 27, 2023.