### PR TITLE
Capture ids from in-product linkouts

### DIFF
--- a/source/_static/myscript.js
+++ b/source/_static/myscript.js
@@ -192,7 +192,7 @@ $(document).ready(function () {
 	// So it will show up for new announcements
 	// Keep "mm_notification_banner__" at the beginning of the key
 	// Add system to clean out storage items that are no longer needed
-	const notification_banner_key = 'mm_notification_banner__webinar-prod';
+	const notification_banner_key = 'mm_notification_banner__mst';
 
 	if (localStorage.getItem(notification_banner_key) === null) {
 		localStorage.setItem(notification_banner_key, true);

--- a/source/_static/myscript.js
+++ b/source/_static/myscript.js
@@ -173,20 +173,20 @@ $(document).ready(function () {
 	// Notification Banner
 
 	// Fallback for when a notification CTA expires - ie. webinar happens
-	const dateInFuture = (value) => new Date().getTime() <= new Date(value).getTime();
-    const expiryDate = '2023-04-27T15:00:00-0500';
+	// const dateInFuture = (value) => new Date().getTime() <= new Date(value).getTime();
+    // const expiryDate = '2023-04-27T15:00:00-0500';
     // 2023-04-27 @ 3pm EST
-    const fallback_url = 'https://mattermost.com/solutions/mattermost-for-microsoft-teams/';
-    const fallback_text = 'Learn more about Mattermost for Microsoft Teams »';
+    // const fallback_url = 'https://mattermost.com/solutions/mattermost-for-microsoft-teams/';
+    // const fallback_text = 'Learn more about Mattermost for Microsoft Teams »';
     
-    if (!dateInFuture(expiryDate)) {
-        if ($(".notification-bar").length) {
-            // $('.notification-bar').remove();
-            // $('body').removeClass('with-notification');
-            $('.notification-bar__link').attr('href', fallback_url);
-            $('.notification-bar__link').text(fallback_text);
-        }
-    }
+    // if (!dateInFuture(expiryDate)) {
+    //     if ($(".notification-bar").length) {
+    //         // $('.notification-bar').remove();
+    //         // $('body').removeClass('with-notification');
+    //         $('.notification-bar__link').attr('href', fallback_url);
+    //         $('.notification-bar__link').text(fallback_text);
+    //     }
+    // }
 
 	// NOTE: Change the notification_banner_key to something unique everytime it changes
 	// So it will show up for new announcements

--- a/source/_static/myscript.js
+++ b/source/_static/myscript.js
@@ -254,6 +254,7 @@ $(document).ready(function () {
 		});
 		
 	});
+
 	// Navigation
 	const hamburger = document.getElementById('hamburger');
 	const subMenus = document.querySelectorAll('.site-nav__hassubnav a');
@@ -279,4 +280,5 @@ $(document).ready(function () {
 		document.body.classList.toggle('nav-open');
 		document.getElementById('navigation').classList.toggle('active');
 	});
+
 });

--- a/source/_static/uswid-cookie.js
+++ b/source/_static/uswid-cookie.js
@@ -1,0 +1,90 @@
+// USWID Cookie
+// In-product link-outs have u/sids in the URL
+// This cookie will be used to track those click identifiers
+// So they can be attached to form submissions
+// A cookie of the same name is set on mm.com
+
+const mm_id_cookie = 'mm_uswid';
+	
+const uswid_controller = {
+    enabled: false,
+    testing_local: true, //set this to true if you are testing locally with no https protocol
+    root_domain: window.location.hostname, 
+    // root_domain: 'mattermost.com', 
+
+    ACCEPTED_PARAM_KEYS: [
+        'uid',
+        'sid',
+    ],
+
+    Init: () => {
+        console.log('Init - ' + uswid_controller.root_domain);
+        uswid_controller.enabled = true; 
+        uswid_controller.SetMMUSWIDCookie();
+    },
+
+    DeleteMMUSWIDCookie: () => {
+        if (uswid_controller.enabled) {
+            document.cookie = `${mm_id_cookie}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Domain=.${uswid_controller.root_domain}; Path=/;`;
+        }
+    },
+
+    SetMMUSWIDCookie: () => {
+        // console.info('Setting USWID cookie');
+        const queryString = window.location.search;
+        if (queryString) {
+            // check if the query string contains uid/sid
+            const queryObj = new URLSearchParams(queryString);
+            if (queryObj.has('uid') && queryObj.has('sid')) {
+                const entries = queryObj.entries();
+                const entriesObj = Object.fromEntries(entries);
+                let cleanObj = {};
+
+                uswid_controller.ACCEPTED_PARAM_KEYS.forEach(key => {
+                    if (entriesObj[key]) {
+                        cleanObj[key] = entriesObj[key];
+                    }
+                });
+
+                // Logic to flag as SH (s)/Cloud (c)
+                if (queryObj.has('utm_medium')) {
+                    const utm_medium = queryObj.get('utm_medium');
+                    if (utm_medium === 'in-product-cloud') {
+                        cleanObj.mm_d = 'c';
+                    } else {
+                        cleanObj.mm_d = 's';
+                    }
+                } else {
+                    cleanObj.mm_d = 's';
+                }
+
+                // Cookie string info
+                const cookieValue = JSON.stringify(cleanObj);
+                let expirationTime = 31536000; // 1 year in seconds
+                expirationTime = expirationTime * 1000; // Converts expiration time to milliseconds
+                let date = new Date(); 
+                let dateTimeNow = date.getTime(); 
+                date.setTime(dateTimeNow + expirationTime); // Sets expiration time (Time now + one month)
+                let dateString = date.toUTCString(); // Converts milliseconds to UTC time string
+
+                let secure_flag = ' Secure;';
+
+                if (uswid_controller.testing_local) {
+                    secure_flag = '';
+                }
+
+                const cookieString = `${mm_id_cookie}=${cookieValue}; SameSite=Lax; Expires=${dateString}; Path=/;${secure_flag} Domain=.${uswid_controller.root_domain}`;
+                
+                document.cookie = cookieString; // Sets cookie for all subdomains
+            }
+        }
+        
+    }
+
+};
+
+$(document).ready(function () {
+    // Initialize the USWID Cookie logic
+    console.log('uswid cookie - v1.6');	
+	uswid_controller.Init();
+});

--- a/source/_static/uswid-cookie.js
+++ b/source/_static/uswid-cookie.js
@@ -18,7 +18,7 @@ const uswid_controller = {
     ],
 
     Init: () => {
-        console.log('Init - ' + uswid_controller.root_domain);
+        // console.log('Init - ' + uswid_controller.root_domain);
         uswid_controller.enabled = true; 
         uswid_controller.SetMMUSWIDCookie();
     },

--- a/source/conf.py
+++ b/source/conf.py
@@ -2497,7 +2497,7 @@ html_css_files = ["mytheme.css?version=v38", "css/compass-icons.css"]
 # A list of JavaScript filenames. The entry must be a filename string or a tuple containing the filename string and the
 # attributes dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like
 # https://example.org/script.js. The attributes is used for attributes of <script> tag. It defaults to an empty list.
-html_js_files = ["myscript.js?version=v14"]
+html_js_files = ["myscript.js?version=v14", "uswid-cookie.js?v=1.6"]
 
 # The name of an image file, relative to the configuration directory, to use as favicon of the docs.  This file should
 # be a Windows icon file (.ico) being 16x16 or 32x32 pixels in size.

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -4,7 +4,7 @@
             <span aria-hidden="true">×</span>
         </a>
 	    <div class="notification-bar__wrapper">
-		    <img src="{{ pathto('_static/images/notification-bar/icon-megaphone.svg', 1) }}" alt="" class="notification-bar__icon"><a href="https://mattermost.com/webinar/4-strategies-to-improve-technical-teams-productivity/" target="_blank" class="notification-bar__link">[Webinar] Learn how to optimize your technical teams' productivity on April 27th »</a>
+		    <img src="{{ pathto('_static/images/notification-bar/icon-megaphone.svg', 1) }}" alt="" class="notification-bar__icon"><a href="https://mattermost.com/solutions/mattermost-for-microsoft-teams/" target="_blank" class="notification-bar__link">Learn more about Mattermost for Microsoft Teams »</a>
 		</div>
     </div>
 </div>


### PR DESCRIPTION
#### Summary
This PR adds functionality to capture IDs from in-product linkouts, which we can then reference in analytics if they take certain actions down the funnel. The same mechanism will be in place on mm.com.

Still a work in progress – cc: @cwarnermm for visibility and if there's any questions first-blush. TY!

