### PR TITLE
Change "Customizable ChatGPT Bot Framework" to "AI Bot Framework"

### DIFF
--- a/source/about/mattermost-customizable-ai-bot-framework.rst
+++ b/source/about/mattermost-customizable-ai-bot-framework.rst
@@ -1,7 +1,7 @@
 .. _mattermost-customizable-chatgpt-bot-framework:
 
-Customizable AI Bot Framework
-----------------------------------
+Customizable AI bot framework
+=============================
 
 Mattermost is committed to providing an open source platform for secure collaboration and control, especially in strict security environments. 
 
@@ -10,14 +10,19 @@ With a focus on AI augmentation and integration, Mattermost envisions providing 
 The vision is to allow users to integrate generative AI solutions like OpenAI's ChatGPT and private cloud LLMs (Large Language Models) into their Mattermost workflows. This integration can streamline communication, enhance decision-making, and automate tasks, enabling increased speed and efficiency in government, defense, and technology organizations.
 
 Control and data privacy
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 Mattermost's open source platform provides verifiable privacy assurances, data control, and granular permissions solutions. As AI becomes more prevalent globally, organizations need control over the AI's access to their data and the ability to use private cloud AI solutions like `Azure AI <https://azure.microsoft.com/en-us/solutions/ai/#benefits>`_ or `AWS AI <https://aws.amazon.com/machine-learning/ai-services/>`_.
 
 In the near term, this may involve integrating private-cloud AI with Mattermost, while in the long term, it could include training foundation models with an organization's data in a controlled environment.
 
-Sample open source OpenAI plugin
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Example open source Mattermost app AI framework
+------------------------------------------------
+
+The `mattermost/mattermost-ai-framework repository <https://github.com/mattermost/mattermost-ai-framework>`__ demonstrates a self-hosted AI app in a multi-user chat environment that can be fully private and off-grid AKA air-gapped. It can also be deployed and tested entirely in the browser via `Gitpod <https://github.com/mattermost/mattermost-ai-framework#gitpod>`__.
+
+Example open source OpenAI plugin
+----------------------------------
 
 An example of an OpenAI integration is the  `open source OpenAI plugin for Mattermost <https://github.com/Brightscout/mattermost-plugin-openai>`_ developed by Brightscout:
 
@@ -35,7 +40,7 @@ Two other examples of ChatGPT integrations built by Sebastian Müller include:
 
 *The LLaMa version, however, is not available for commercial use due to licensing restrictions on the language model.*
 
-Contact Sales
-~~~~~~~~~~~~~
+Contact sales
+--------------
 
 To learn more about Mattermost's AI-enhanced secure collaboration platform, request a custom AI integration, or inquire about pricing and plans, `contact our Sales team <https://mattermost.com/contact-sales/>`_ or `join the community <https://community.mattermost.com/core/channels/ask-chatgpt>`_ to discuss today.

--- a/source/about/mattermost-customizable-chatgpt-bot-framework.rst
+++ b/source/about/mattermost-customizable-chatgpt-bot-framework.rst
@@ -1,11 +1,11 @@
 .. _mattermost-customizable-chatgpt-bot-framework:
 
-Customizable ChatGPT Bot Framework
+Customizable AI Bot Framework
 ----------------------------------
 
 Mattermost is committed to providing an open source platform for secure collaboration and control, especially in strict security environments. 
 
-With a focus on AI augmentation and integration, Mattermost envisions providing an open source customizable ChatGPT bot framework with full control and data privacy for organizations that want to deploy AI solutions without sacrificing security.
+With a focus on AI augmentation and integration, Mattermost envisions providing an open source customizable AI bot framework with full control and data privacy for organizations that want to deploy AI solutions without sacrificing security.
 
 The vision is to allow users to integrate generative AI solutions like OpenAI's ChatGPT and private cloud LLMs (Large Language Models) into their Mattermost workflows. This integration can streamline communication, enhance decision-making, and automate tasks, enabling increased speed and efficiency in government, defense, and technology organizations.
 

--- a/source/about/use-cases.rst
+++ b/source/about/use-cases.rst
@@ -8,11 +8,11 @@ Use cases
    /about/secure-command-and-control.rst
    /about/devops-collaboration.rst
    /about/incident-response-collaboration.rst
-   /about/mattermost-customizable-chatgpt-bot-framework.rst
+   /about/mattermost-customizable-ai-bot-framework.rst
   
 Learn more about how to use Mattermost in agile software development, incident response, customer onboarding, and many other applications.
 
 * :doc:`Secure command and control </about/secure-command-and-control>` - Learn about the Mattermost Secure Command and Control solution, designed to provide fast and secure mobile communications for technical teams.
 * :doc:`How to: Build your Agile software development practice </about/devops-collaboration>` - Learn how accelerate software development and deployment processes and reduce costs.
-* :doc:`How to: Respond to incidents and outages quickly and effectively </agile/incident-response-collaboration>` - Maximize your Mattermost deployment with incident response collaboration. 
-* :doc:`How to: Integrate ChatGPT with Mattermost </about/mattermost-customizable-chatgpt-bot-framework>` - Learn about how to leverage ChatGPT for your Mattermost deployment.
+* :doc:`How to: Respond to incidents and outages quickly and effectively </about/incident-response-collaboration>` - Maximize your Mattermost deployment with incident response collaboration. 
+* :doc:`How to: Integrate AI with Mattermost </about/mattermost-customizable-ai-bot-framework>` - Learn about how to leverage AI for your Mattermost deployment.

--- a/source/conf.py
+++ b/source/conf.py
@@ -86,6 +86,8 @@ redirects = {
 	"https://docs.mattermost.com/about/faq-license.html#what-are-mattermost-s-policies-around-licensing-terms-of-use-and-privacy",
 "about/faq-mattermost-source-available-license.html":
 	"https://docs.mattermost.com/about/faq-license.html#source-available-licensing",
+"about/mattermost-customizable-chatgpt-bot-framework.html":
+        "https://docs.mattermost.com/about/mattermost-customizable-ai-bot-framework.html",
 
 # Administration redirects
 "administration/announcement-banner.html":


### PR DESCRIPTION
cc @azigler: Adjusting title of the page to "AI Bot Framework" to generalize from just ChatGPT