### PR TITLE
Remove legacy references for Boards

### DIFF
--- a/source/boards/getting-started.rst
+++ b/source/boards/getting-started.rst
@@ -4,24 +4,8 @@ Getting started
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Mattermost Boards (formerly known as Focalboard) is accessible from the Product menu in the top left corner of Mattermost.
-
-.. tabs::
-   
-  .. tab:: Mattermost v6.0 onwards
-   
-      If you're using Mattermost 6.0, select the Product menu in the top left corner of Mattermost to open Boards.
+Mattermost Boards (formerly known as Focalboard) is accessible from the Product menu in the top left corner of Mattermost. Select the Product menu in the top left corner of Mattermost to open Boards.
   
-  .. tab:: Mattermost v5.39 and earlier
-
-      For self-hosted deployments using versions 5.38 and earlier, Boards is available in the Marketplace.
-
-      1. As a system admin, go to **Main Menu > Marketplace**.
-      2. Search for **Boards**.
-      3. Select **Install** if not yet installed, then select **Configure** to enable.
-      4. From the plugin configuration page, set **Enable Plugin** to **true**.
-      5. Select **Save** to enable the plugin.
-
 Configuration
 -------------
 


### PR DESCRIPTION
#### Summary

This PR removes references to Mattermost v5.39 and earlier