### PR TITLE
Adjust CTA for AI framework page to dev channel, instead of sales

### DIFF
--- a/source/about/mattermost-customizable-ai-bot-framework.rst
+++ b/source/about/mattermost-customizable-ai-bot-framework.rst
@@ -41,6 +41,6 @@ Two other examples of ChatGPT integrations built by Sebastian Müller include:
 *The LLaMa version, however, is not available for commercial use due to licensing restrictions on the language model.*
 
 Join the community
---------------
+-------------------
 
 To learn more about Mattermost's AI bot framework, share ideas, and contribute to the development, join the `Mattermost community channel <https://community.mattermost.com/core/channels/ai-exchange>`_ or the `peer-to-peer forums <https://forum.mattermost.com/c/ai-frameworks/40>`_ today.

--- a/source/about/mattermost-customizable-ai-bot-framework.rst
+++ b/source/about/mattermost-customizable-ai-bot-framework.rst
@@ -43,4 +43,4 @@ Two other examples of ChatGPT integrations built by Sebastian Müller include:
 Join the community
 --------------
 
-To learn more about Mattermost's AI-enhanced secure collaboration platform, share ideas, and contribute to the development, join the `Mattermost community channel <https://community.mattermost.com/core/channels/ai-exchange>`_ today.
+To learn more about Mattermost's AI bot framework, share ideas, and contribute to the development, join the `Mattermost community channel <https://community.mattermost.com/core/channels/ai-exchange>`_ or the `peer-to-peer forums <https://forum.mattermost.com/c/ai-frameworks/40>`_ today.

--- a/source/about/mattermost-customizable-ai-bot-framework.rst
+++ b/source/about/mattermost-customizable-ai-bot-framework.rst
@@ -40,7 +40,7 @@ Two other examples of ChatGPT integrations built by Sebastian Müller include:
 
 *The LLaMa version, however, is not available for commercial use due to licensing restrictions on the language model.*
 
-Join the discussion
+Join the community
 --------------
 
 To learn more about Mattermost's AI-enhanced secure collaboration platform, share ideas, and contribute to the development, join the `Mattermost community channel <https://community.mattermost.com/core/channels/ai-exchange>`_ today.

--- a/source/about/mattermost-customizable-ai-bot-framework.rst
+++ b/source/about/mattermost-customizable-ai-bot-framework.rst
@@ -40,7 +40,7 @@ Two other examples of ChatGPT integrations built by Sebastian Müller include:
 
 *The LLaMa version, however, is not available for commercial use due to licensing restrictions on the language model.*
 
-Contact sales
+Join the discussion
 --------------
 
-To learn more about Mattermost's AI-enhanced secure collaboration platform, request a custom AI integration, or inquire about pricing and plans, `contact our Sales team <https://mattermost.com/contact-sales/>`_ or `join the community <https://community.mattermost.com/core/channels/ask-chatgpt>`_ to discuss today.
+To learn more about Mattermost's AI-enhanced secure collaboration platform, share ideas, and contribute to the development, join the `Mattermost community channel <https://community.mattermost.com/core/channels/ai-exchange>`_ today.

--- a/source/about/mattermost-customizable-ai-bot-framework.rst
+++ b/source/about/mattermost-customizable-ai-bot-framework.rst
@@ -43,4 +43,4 @@ Two other examples of ChatGPT integrations built by Sebastian Müller include:
 Join the community
 -------------------
 
-To learn more about Mattermost's AI bot framework, share ideas, and contribute to the development, join the `Mattermost community channel <https://community.mattermost.com/core/channels/ai-exchange>`_ or the `peer-to-peer forums <https://forum.mattermost.com/c/ai-frameworks/40>`_ today.
+To learn more about Mattermost's AI bot framework, share ideas, and contribute to the development, join the `Mattermost community channel <https://community.mattermost.com/core/channels/ai-exchange>`__ or the `peer-to-peer forums <https://forum.mattermost.com/c/ai-frameworks/40>`__ today.


### PR DESCRIPTION
@azigler now that the discussion has shifted from top-level thought leadership to rapid technical prototyping, let's shift the CTA for folks to join our channel on community rather than contacting sales