### PR TITLE
Move sync drafts config setting

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -423,8 +423,6 @@ redirects = {
         "https://docs.mattermost.com/configure/configuration-settings.html#enable-latex-code-block-rendering",
 "configure/configuration-settings.html#environment":
         "https://docs.mattermost.com/configure/web-server-configuration-settings.html",
-"configure/experimental-configuration-settings.html#allow-synchronized-drafts":
-        "https://docs.mattermost.com/configure/site-configuration-settings.html#enable-server-syncing-of-message-drafts",
 "configure/configuration-settings.html#forward-port-80-to-443":
         "https://docs.mattermost.com/configure/environment-configuration-settings.html#forward-port-80-to-443",
 "configure/configuration-settings.html#groups":
@@ -1319,6 +1317,8 @@ redirects = {
         "https://docs.mattermost.com/configure/experimental-configuration-settings.html#export-output-directory",
 "configure/experimental-configuration-settings.html#export-settings-default-retention-days":
         "https://docs.mattermost.com/configure/experimental-configuration-settings.html#export-retention-days",
+"configure/experimental-configuration-settings.html#allow-synchronized-drafts":
+        "https://docs.mattermost.com/configure/site-configuration-settings.html#enable-server-syncing-of-message-drafts",
 "configure/authentication-configuration-settings.html#gitlab":
 	"https://docs.mattermost.com/configure/authentication-configuration-settings.html#gitlab-oauth-2-0-settings",
 "configure/authentication-configuration-settings.html#google":

--- a/source/conf.py
+++ b/source/conf.py
@@ -423,6 +423,8 @@ redirects = {
         "https://docs.mattermost.com/configure/configuration-settings.html#enable-latex-code-block-rendering",
 "configure/configuration-settings.html#environment":
         "https://docs.mattermost.com/configure/web-server-configuration-settings.html",
+"configure/experimental-configuration-settings.html#allow-synchronized-drafts":
+        "https://docs.mattermost.com/configure/site-configuration-settings.html#enable-server-syncing-of-message-drafts",
 "configure/configuration-settings.html#forward-port-80-to-443":
         "https://docs.mattermost.com/configure/environment-configuration-settings.html#forward-port-80-to-443",
 "configure/configuration-settings.html#groups":

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -632,19 +632,6 @@ This setting enables the Apps Bar and moves all Mattermost integration icons fro
 | This feature's ``config.json`` setting is ``"ExperimentalSettings.EnableAppBar": false`` with options ``true`` and ``false``. |
 +-------------------------------------------------------------------------------------------------------------------------------+
 
-Allow synchronized drafts
--------------------------
-
-This setting synchronizes draft messages across all supported Mattermost clients.
-
-**True**: **(Default)** Message drafts are saved on the server and may be accessed from different clients. Users may still disable server synchronization of draft messages by going to **Settings > Advanced Settings**. 
-
-**False**: Draft messages are only stored locally on each user's device.
-
-+------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ServiceSettings.AllowSyncedDrafts": true`` with options ``true`` and ``false``. |
-+------------------------------------------------------------------------------------------------------------------------------+
-
 Patch React DOM used by plugins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/configure/site-configuration-settings.rst
+++ b/source/configure/site-configuration-settings.rst
@@ -1245,6 +1245,29 @@ Google API key
 | - This key is used in client-side Javascript.                                                                                                                                                                                                                                                                                           |
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. config:setting:: posts-AllowSyncedDrafts
+  :displayname: Enable server syncing of message drafts (Posts)
+  :systemconsole: Site Configuration > Posts
+  :configjson: .ServiceSettings.AllowSyncedDrafts
+  :environment: MM_SERVICESETTINGS_ALLOWSYNCEDDRAFTS
+  :description: Enable or disable the ability to synchronize draft messages across all supported Mattermost clients.
+
+Enable server syncing of message drafts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++------------------------------------------------------+--------------------------------------------------------------------------------------+
+| Enable or disable the ability to synchronize draft   | - System Config path: **Site Configuration > Posts**                                 |
+| messages across all supported Mattermost clients.    | - ``config.json`` setting: ``".ServiceSettings.AllowSyncedDrafts: true,``            |
+|                                                      | - Environment variable: ``MM_SERVICESETTINGS_ALLOWSYNCEDDRAFTS``                     |
+| - **true**: **(Default)** Message drafts are saved   |                                                                                      |
+|   on the server and may be accessed from different   |                                                                                      |
+|   clients. Users may still disable server            |                                                                                      |
+|   synchronization of draft messages by going         |                                                                                      |
+|   to **Settings > Advanced Settings**.               |                                                                                      |
+| - **false**: Draft messages are stored locally       |                                                                                      |
+|   on each device.                                    |                                                                                      |
++------------------------------------------------------+--------------------------------------------------------------------------------------+
+
 ----
 
 File sharing and downloads


### PR DESCRIPTION
Moved experimental setting **Allow synchronized drafts** to **Site Configuration > Posts**, and added a redirect.