### PR TITLE
Deprecated Insights

### DIFF
--- a/source/guides/welcome-to-mattermost.rst
+++ b/source/guides/welcome-to-mattermost.rst
@@ -37,7 +37,6 @@ Mattermost basics
    Team keyboard shortcuts </welcome/team-keyboard-shortcuts>
    About user roles </welcome/about-user-roles>
    Add people to your workspace </welcome/add-people>
-   About insights </welcome/insights>
 
 * :doc:`Get started with Mattermost Channels </welcome/get-started-mattermost-channels>` - Learn how to communicate and collaborate with your team using Mattermost Channels.
 * :doc:`Get started with Mattermost Playbooks </playbooks/work-with-playbooks>` - Learn how to create and refine repeatable, measurable workflows for a range of scenarios using Mattermost Playbooks.
@@ -48,7 +47,6 @@ Mattermost basics
 * :doc:`Team keyboard shortcuts </welcome/team-keyboard-shortcuts>` Make more efficient use of your keyboard with keyboard shortcuts.
 * :doc:`About user roles </welcome/about-user-roles>` - Learn more about the six types of user roles and their permissions in Mattermost.
 * :doc:`Add people to your workspace </welcome/add-people>` - Learn how to add new users to Mattermost and add users to existing teams and channels.
-* :doc:`Insights </welcome/insights>` - Get insights into the most important events happening on each team within your Mattermost workspace.
 
 Customize your Mattermost experience
 ------------------------------------

--- a/source/install/deprecated-features.rst
+++ b/source/install/deprecated-features.rst
@@ -13,7 +13,7 @@ Mattermost Server v8.0.0
 
   - All Mattermost-supported plugins are updated to the latest versions.
   - Any other plugins have been updated to support React 17. See the `Important Upgrade Notes <https://docs.mattermost.com/upgrade/important-upgrade-notes.html>`__ for v7.7 for more information.
-- Disabling Insights for all new instances and for existing servers that upgrade to Mattermost v8.0. You can re-enable Insights with an environment variable via ``MM_FEATUREFLAGS_INSIGHTSENABLED=true``.
+- Disabling Insights for all new instances and for existing servers that upgrade to Mattermost v8.0.
 - Removing deprecated ``PermissionUseSlashCommands``.
 - Removing deprecated ``model.CommandArgs.Session``.
 - Removing support for PostgreSQL v10. The new minimum PostgreSQL version will be v11.

--- a/source/install/deprecated-features.rst
+++ b/source/install/deprecated-features.rst
@@ -4,24 +4,26 @@ Removed and deprecated features for Mattermost
 This page describes features that are removed from support for Mattermost, or will be removed in a future update (deprecated), and provides early notice about future changes that might affect your use of Mattermost. This information is subject to change with future releases, and might not include each deprecated feature.
 
 Removed features in upcoming versions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 
 Mattermost Server v8.0.0
-^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Removing ``ExperimentalSettings.PatchPluginsReactDOM``. If this setting was previously enabled, confirm that:
-    1. All Mattermost-supported plugins are updated to the latest versions.
-    2. Any other plugins have been updated to support React 17. See the `Important Upgrade Notes <https://docs.mattermost.com/upgrade/important-upgrade-notes.html>`__ for v7.7 for more information.
+
+  - All Mattermost-supported plugins are updated to the latest versions.
+  - Any other plugins have been updated to support React 17. See the `Important Upgrade Notes <https://docs.mattermost.com/upgrade/important-upgrade-notes.html>`__ for v7.7 for more information.
+- Disabling Insights for all new instances and for existing servers that upgrade to Mattermost v8.0. You can re-enable Insights with an environment variable via ``MM_FEATUREFLAGS_INSIGHTSENABLED=true``.
 - Removing deprecated ``PermissionUseSlashCommands``.
 - Removing deprecated ``model.CommandArgs.Session``.
 - Removing support for PostgreSQL v10. The new minimum PostgreSQL version will be v11.
 - Deprecating the ``AdvancedLoggingConfig`` fields, and replacing them with ``AdvancedLoggingJSON`` fields which accept inline JSON or a filename.
 
 Removed features by Mattermost version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 
 Mattermost Server v6.0.0
-^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 - `Legacy Command Line Tools </manage/command-line-tools.html>`__. Most commands have been replaced by `mmctl </manage/mmctl-command-line-tool.html>`_ and new commands have been added over the last few months, making this tool a full and robust replacement.
 - `Slack Import via the web app </administration/migrating.html?highlight=mmetl#migrating-from-slack-using-the-mattermost-web-app>`_. The Slack import tool accessible via the Team Setting menu is being replaced by the mmetl tool that is much more comprehensive for the types of data it can assist in uploading.
@@ -44,43 +46,43 @@ Mattermost Server v6.0.0
 - Changes to mattermost-server/model for naming consistency.
 
 Mattermost Server v5.38.0
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - In the v5.38 release (August 16, 2021), the “config watcher” (the mechanism that automatically reloads the “config.json“ file), has been removed in favor of the “mmctl config“ command that will need to be run to apply configuration changes after they are made. This change will improve configuration performance and robustness.
 
 Mattermost Server v5.37.0
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The “platform“ binary and “–platform” flag have been removed. If you are using the “–platform” flag or are using the “platform“ binary directly to run the Mattermost server application via a systemd file or custom script, you will be required to use only the “mattermost“ binary.
 
 Mattermost Server v5.32.0
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - TLS versions 1.0 and 1.1 have been deprecated by browser vendors. Starting in Mattermost Server v5.32 (February 16), mmctl returns an error when connected to Mattermost servers deployed with these TLS versions and System Admins will need to explicitly add a flag in their commands to continue to use them. We recommend upgrading to TLS version 1.2 or higher.
 
 Mattermost Server v5.30.0
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - PostgreSQL ended long-term support for `version 9.4 in February 2020 <https://www.postgresql.org/support/versioning>`_. From v5.26 Mattermost officially supports PostgreSQL version 10 as PostgreSQL 9.4 is no longer supported. New installs will require PostgreSQL 10+. Previous Mattermost versions, including our current ESR, will continue to be compatible with PostgreSQL 9.4. PostgreSQL 9.4 and all 9.x versions are now fully deprecated in our v5.30 release (December 16). Please follow the instructions under the Upgrading Section within `the PostgreSQL documentation <https://www.postgresql.org/support/versioning/>`_.
 
 Mattermost Server v5.16.0
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Removed support for Internet Explorer (IE11) in Mattermost v5.16.0. Learn more in our `forum post <https://forum.mattermost.org/t/mattermost-is-dropping-support-for-internet-explorer-ie11-in-v5-16/7575>`_.
 
 Mattermost Server v5.12.0
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - ExperimentalEnablePostMetadata setting was removed. Post metadata, including post dimensions, is now stored in the database to correct scroll position and eliminate scroll jumps as content loads in a channel.
 
 Mattermost Server v5.6.0
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Removed support for WebRTC in beta, and replaced it with other video and audio calling solutions. Learn more in our `documentation </deployment/video-and-audio-calling.html>`_.
 - Removed support for IE11 Mobile View due to low usage and instability in order to invest that effort in maintaining a high quality experience on other more used browsers. End users on IE11 will thus have an increased minimum screen size. Mobile View is still supported on Chrome, Firefox, Safari, Edge as well as the desktop apps.
 
 Mattermost Server v5.0.0
-^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - All API v3 endpoints removed. API v3 endpoints are no longer supported as of Mattermost v4.6 release on January 16th, 2018, and are replaced by API v4 endpoints which were released on July 16th, 2017. See `https://api.mattermost.com <https://api.mattermost.com>`_ to learn more.
 - Desktop Notification Duration in Account Settings removed due to inconsistencies on various browsers and operating systems.
@@ -91,12 +93,12 @@ Mattermost Server v5.0.0
 - A new ``config.json`` setting to disable the `permanent APIv4 delete team parameter <https://api.mattermost.com/#tag/teams%2Fpaths%2F~1teams~1%7Bteam_id%7D%2Fput>`_ added. The setting is off by default for all new and existing installs, except those deployed on GitLab Omnibus. A System Admin can enable the API v4 endpoint from the ``config.json`` file.
 
 Mattermost Server v4.9.0
-^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - A number of permissions configuration settings will be migrated to roles in the database, and changing their config.json values will no longer take effect. These permissions can still be modified by their respective System Console settings. See `changelog </install/self-managed-changelog.html>`_ for more details.
 
 Mattermost Server v4.0.0
-^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - System Console settings in **Files > Images**, including:
   
@@ -108,7 +110,7 @@ Mattermost Server v4.0.0
 - Teammate Name Display setting moved to the System Console
 
 Mattermost Server v3.8.0
-^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Old CLI tool (replaced by `an upgraded CLI tool </administration/command-line-tools.html>`_)
 - APIv3 endpoints:
@@ -119,6 +121,6 @@ Mattermost Server v3.8.0
   - “POST at /users/status/set_active_channel” (replaced by “/channels/view”)
 
 Mattermost Server v3.7.0
-^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - “ServiceSettings: SegmentDeveloperKey” setting in ``config.json``

--- a/source/welcome/insights.rst
+++ b/source/welcome/insights.rst
@@ -4,17 +4,17 @@ Insights
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 
+.. important::
+
+  From Mattermost v8.0, Insights has been disabled for all new instances and for existing servers that upgrade to Mattermost v8.0. The Insights feature flag can be re-enabled with an environment variable via ``MM_FEATUREFLAGS_INSIGHTSENABLED=true``.
+
 Insights offer you visibility into top activities by surfacing the most important events happening within each team within your Mattermost workspace. 
 
 From Mattermost v7.1, insights are available for all users using Mattermost in a web browser or the desktop app, except guests. Mobile support for insights is coming in a future release.
 
 .. image:: ../images/myinsights_teaminsights.gif
   :alt: An example of the Mattermost Insights page that includes top user and team-based activities and events.
-  
-.. note:: 
-    
-   To disable Insights, system admins can set the feature flag ``MM_FEATUREFLAGS_INSIGHTSENABLED`` to ``false`` to disable it server-wide. It can't be disabled on a per-user basis. See the Knowledge Base article, `How to disable Insights in Mattermost <https://support.mattermost.com/hc/en-us/articles/13897774815636-How-to-disable-Insights-in-Mattermost>`__, for details.
-   
+
 Access insights
 ---------------
 

--- a/source/welcome/insights.rst
+++ b/source/welcome/insights.rst
@@ -6,7 +6,7 @@ Insights
 
 .. important::
 
-  From Mattermost v8.0, Insights has been disabled for all new instances and for existing servers that upgrade to Mattermost v8.0. The Insights feature flag can be re-enabled with an environment variable via ``MM_FEATUREFLAGS_INSIGHTSENABLED=true``.
+  From Mattermost v8.0, Insights has been disabled for all new instances and for existing servers that upgrade to Mattermost v8.0.
 
 Insights offer you visibility into top activities by surfacing the most important events happening within each team within your Mattermost workspace. 
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost/pull/23702

The Insights documentation page continues to be accessible, but only via search or directly via URL. The page is no longer included in the navigation pane or the Welcome landing page.