### PR TITLE
[MM-53010] Add slack additional slack import tools

### DIFF
--- a/source/onboard/migrating-to-mattermost.rst
+++ b/source/onboard/migrating-to-mattermost.rst
@@ -211,6 +211,13 @@ Debugging imports
 
 The ``mmctl import job show`` shows a detailed error message. If you run into problems which the error message does not help to resolve, your best bet is to use the ``mattermost bulk import`` command. The ``mmctl`` import process does not give you any additional debugging information, even in the Mattermost server logs.
 
+Additional tools
+^^^^^^^^^^^^^^^^
+
+* `mm-emoji <https://github.com/maxwellpower/mm-emoji>`__ - Designed to smoothly transition emojis from a Slack instance to Mattermost.
+* `mm-importjs <https://github.com/mickmister/mmimportjs>`__ - Breaks up large import files into smaller ones, as well as automatically remove null characters in post content when importing data to Mattermost.
+* `slack-migrate-pinned-posts <https://github.com/svelle/slack-migrate-pinned-posts>`__ - Migrates pinned posts from Slack to Mattermost.
+
 Use the Mattermost web app (deprecated)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Summary

Adds the following tools to onboarding docs:

* https://github.com/maxwellpower/mm-emoji - Designed to smoothly transition emojis from a Slack instance to Mattermost.
* https://github.com/mickmister/mmimportjs - Breaks up large import files into smaller ones, as well as automatically remove null characters in post content when importing data to Mattermost.
* https://github.com/svelle/slack-migrate-pinned-posts - Migrates pinned posts from Slack to Mattermost.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-53010