### PR TITLE
Remove unneeded steps

### DIFF
--- a/source/onboard/migrating-to-mattermost.rst
+++ b/source/onboard/migrating-to-mattermost.rst
@@ -173,8 +173,6 @@ Next you have to create a zip file with the ``mattermost_import.jsonl`` file and
 
 .. code:: bash
 
-    mkdir data
-    mv bulk-export-attachments data
     zip -r mattermost-bulk-import.zip data mattermost_import.jsonl
 
 The file ``mattermost-bulk-import.zip`` is now ready to import into Mattermost.


### PR DESCRIPTION
#### Summary

It appears that the mmetl job now outputs the data in the correct subfolder, making this step unnecssary.