### PR TITLE
Update keyboard-shortcuts-for-channels.rst

### DIFF
--- a/source/channels/keyboard-shortcuts-for-channels.rst
+++ b/source/channels/keyboard-shortcuts-for-channels.rst
@@ -31,7 +31,7 @@ The following keyboard shortcuts are supported in all `supported browsers </inst
 +-------------------------------------+------------------------------+----------------------------------------------------------------------------------+
 | :kbd:`Alt` + select channel         | :kbd:`⌥` + select channel    | Mark the last post in the channel as unread.                                     |
 +-------------------------------------+------------------------------+----------------------------------------------------------------------------------+
-| :kbd:`Ctrl` :kbd:`K`                | :kbd:`⌘` :kbd:`K`            | Open the **Find Channels** dialog.                                               |
+| :kbd:`Ctrl` :kbd:`K`                | :kbd:`⌘` :kbd:`K`            | Open the **Find Channels** dialog. If text is highlighted, a hyperlink is created|
 +-------------------------------------+------------------------------+----------------------------------------------------------------------------------+
 | :kbd:`Ctrl` :kbd:`Shift` :kbd:`K`   | :kbd:`⌘` :kbd:`⇧` :kbd:`K`   | Open the **Direct Messages** dialog.                                             |
 +-------------------------------------+------------------------------+----------------------------------------------------------------------------------+


### PR DESCRIPTION
Update `Ctrl + K` to mention the functionality of making a text into a hyperlink

@cwarnermm thoughts on this? Currently, `Ctrl + K` only works as "Find Channels if no link is created".

That said, there's also a thought to entertain: Should `Ctrl + K` be used as a keyboard shortcut to "Find Channels"?