### PR TITLE
Update nav components for 9.0 announce

### DIFF
--- a/source/_static/myscript.js
+++ b/source/_static/myscript.js
@@ -174,8 +174,8 @@ $(document).ready(function () {
 
 	// Fallback for when a notification CTA expires - ie. webinar happens
 	const dateInFuture = (value) => new Date().getTime() <= new Date(value).getTime();
-    const expiryDate = '2023-07-24T15:00:00-0500';
-    // 2023-04-27 @ 3pm EST
+    const expiryDate = '2023-09-29T15:00:00-0500';
+    // 2023-09-29 @ 3pm EST
     const fallback_url = 'https://mattermost.com/solutions/mattermost-for-microsoft-teams/';
     const fallback_text = 'Learn more about Mattermost for Microsoft Teams »';
     

--- a/source/_static/myscript.js
+++ b/source/_static/myscript.js
@@ -192,7 +192,10 @@ $(document).ready(function () {
 	// So it will show up for new announcements
 	// Keep "mm_notification_banner__" at the beginning of the key
 	// Add system to clean out storage items that are no longer needed
-	const notification_banner_key = 'mm_notification_banner__8-0-release';
+	let notification_banner_key = 'mm_notification_banner__9-0-release';
+	if (!dateInFuture(expiryDate)) {
+		notification_banner_key = 'mm_notification_banner__fallback-mst';
+	}
 
 	if (localStorage.getItem(notification_banner_key) === null) {
 		localStorage.setItem(notification_banner_key, true);

--- a/source/conf.py
+++ b/source/conf.py
@@ -3364,7 +3364,7 @@ html_css_files = ["mytheme.css?version=v47", "css/compass-icons.css"]
 # A list of JavaScript filenames. The entry must be a filename string or a tuple containing the filename string and the
 # attributes dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like
 # https://example.org/script.js. The attributes is used for attributes of <script> tag. It defaults to an empty list.
-html_js_files = ["myscript.js?version=v17"]
+html_js_files = ["myscript.js?version=v18"]
 
 # The name of an image file, relative to the configuration directory, to use as favicon of the docs.  This file should
 # be a Windows icon file (.ico) being 16x16 or 32x32 pixels in size.

--- a/source/conf.py
+++ b/source/conf.py
@@ -3359,12 +3359,12 @@ html_static_path = ["_static"]
 # A list of CSS files. The entry must be a filename string or a tuple containing the filename string and the attributes
 # dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like
 # https://example.org/style.css. The attributes is used for attributes of <link> tag. It defaults to an empty list.
-html_css_files = ["mytheme.css?version=v46", "css/compass-icons.css"]
+html_css_files = ["mytheme.css?version=v47", "css/compass-icons.css"]
 
 # A list of JavaScript filenames. The entry must be a filename string or a tuple containing the filename string and the
 # attributes dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like
 # https://example.org/script.js. The attributes is used for attributes of <script> tag. It defaults to an empty list.
-html_js_files = ["myscript.js?version=v16"]
+html_js_files = ["myscript.js?version=v17"]
 
 # The name of an image file, relative to the configuration directory, to use as favicon of the docs.  This file should
 # be a Windows icon file (.ico) being 16x16 or 32x32 pixels in size.

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -214,7 +214,7 @@
 												</a>
 											</li>	
 											<li class="sub-menu__links--single">
-												<a href="https://academy.mattermost.com/p/mattermost-end-user-onboarding" data-ol-has-click-handler="">
+												<a href="https://academy.mattermost.com/" data-ol-has-click-handler="">
 												Academy
 												</a>
 											</li>
@@ -229,7 +229,7 @@
 												</a>
 											</li>
 											<li class="sub-menu__links--single">
-												<a href="https://docs.mattermost.com/administration/changelog.html" data-ol-has-click-handler="">
+												<a href="https://docs.mattermost.com/guides/changelogs.html" data-ol-has-click-handler="">
 													Release Notes
 												</a>
 											</li>

--- a/source/templates/header.html
+++ b/source/templates/header.html
@@ -4,7 +4,7 @@
             <span aria-hidden="true">×</span>
         </a>
 	    <div class="notification-bar__wrapper">
-		    <img src="{{ pathto('_static/images/notification-bar/icon-megaphone.svg', 1) }}" alt="" class="notification-bar__icon"><a href="https://mattermost.com/blog/mattermost-v8-0-is-now-available/" target="_blank" class="notification-bar__link">Mattermost Version 8.0 is Now Available »</a>
+		    <img src="{{ pathto('_static/images/notification-bar/icon-megaphone.svg', 1) }}" alt="" class="notification-bar__icon"><a href="https://mattermost.com/blog/mattermost-v9-0-is-now-available/" target="_blank" class="notification-bar__link">Mattermost Version 9.0 is Now Available »</a>
 		</div>
     </div>
 </div>
@@ -84,7 +84,12 @@
 										</li>
 										<li class="sub-menu__links--single">
 											<a href="https://mattermost.com/solutions/use-cases/accelerate-productivity/" data-ol-has-click-handler="">
-											Process &amp; Decision Optimization
+											Decision Optimization
+											</a>
+										</li>
+										<li class="sub-menu__links--single">
+											<a href="https://mattermost.com/open-source/" data-ol-has-click-handler="">
+											Open Source
 											</a>
 										</li>
 									</ul>


### PR DESCRIPTION
#### Summary
This PR adds the 9.0 announce blog to the notification banner (set for 2 weeks), and updates the global nav to align with mm.com.

@cwarnermm – Feel free to adjust the footer links and I'll mirror the changes on mm.com. 

Also, I am going to put a DNM tag on until I can chat with Aaron about the fallback link once two weeks is up. Should be taken off early this morning.

Thank you!

