### PR TITLE
Fix windows mmctl URL

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -85,7 +85,7 @@ The mmctl tool comes bundled with Mattermost package. For customers that want to
 
    .. tab:: Using release package (Linux, macOS, Windows)
 
-      Starting release ``v8.0.0`` of Mattermost, you can download the mmctl builds at their release URL: ``https://releases.mattermost.com/mmctl/${MATTERMOST_VERSION}/${PLATFORM}_${ARCHITECTURE}.tar`` (for windows, substitute the `.tar` suffix with `.zip`)
+      Starting with the release ``v8.0.0`` of Mattermost, you can download the mmctl builds at their release URL: ``https://releases.mattermost.com/mmctl/${MATTERMOST_VERSION}/${PLATFORM}_${ARCHITECTURE}.tar`` (for windows, substitute the ``.tar`` suffix with ``.zip``)
 
       E.g. to download version ``v8.0.0`` of the mmctl amd64 build for linux, you can run the following:
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -85,7 +85,7 @@ The mmctl tool comes bundled with Mattermost package. For customers that want to
 
    .. tab:: Using release package (Linux, macOS, Windows)
 
-      Starting release ``v8.0.0`` of Mattermost, you can download the mmctl builds at their release URL: ``https://releases.mattermost.com/mmctl/${MATTERMOST_VERSION}/${PLATFORM}_${ARCHITECTURE}.tar``
+      Starting release ``v8.0.0`` of Mattermost, you can download the mmctl builds at their release URL: ``https://releases.mattermost.com/mmctl/${MATTERMOST_VERSION}/${PLATFORM}_${ARCHITECTURE}.tar`` (for windows, substitute the `.tar` suffix with `.zip`)
 
       E.g. to download version ``v8.0.0`` of the mmctl amd64 build for linux, you can run the following:
 


### PR DESCRIPTION
#### Summary

The URL for downloading the Windows builds of mmctl is wrong in the docs.

The Linux and Mac binaries are available as tarballs, but the windows ones are packaged as zips.

- Valid Linux link: https://releases.mattermost.com/mmctl/v8.1.2/linux_amd64.tar
- Valid windows link: https://releases.mattermost.com/mmctl/v8.1.2/windows_amd64.zip

#### Ticket Link

Noticed while looking at https://mattermost.atlassian.net/browse/MM-54576