### PR TITLE
Channel filters when browsing channels

### DIFF
--- a/source/collaborate/browse-channels.rst
+++ b/source/collaborate/browse-channels.rst
@@ -13,15 +13,23 @@ Browse channels
 
     1. Select the **Plus** |plus-icon| icon at the top of the channel sidebar to see all available public channels you can join that you're not already a member of.
     2. Select **Browse Channels**. 
-    3. Search for channels by name or scroll through the list. 
+    3. Search for channels by name or scroll through the list.
     4. Select **Join** next to any channel to become a member of that channel.
+
+    .. tip::
+
+      From Mattermost v9.1, you can filter the list of channels by public, private, or archived channels, and you can hide all channels you're already a member of.
 
   .. tab:: Mobile
 
     1. Tap the **Plus** |plus-icon| icon located in the top right corner of the app to see all available public channels you can join that you're not already a member of. 
     2. Tap **Browse Channels**. 
     3. Search for channels by name or filter the list of channels to show only public or archived channels. 
-    4. Tap a channel to become a member of that channel. 
+    4. Tap a channel to become a member of that channel.
+
+    .. tip::
+
+      You can filter the list of channels by public, archived, or shared channels.
 
 .. tip:: 
   


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost/pull/24099

@M-ZubairAhmed - Mobile app v2.8.1 includes channel filter options that differ from web/desktop. Is this intended? Or will mobile app v2.9 include the same filters as available via web/desktop?
