### PR TITLE
Can include archived channels in export

### DIFF
--- a/source/manage/cloud-data-export.rst
+++ b/source/manage/cloud-data-export.rst
@@ -57,7 +57,7 @@ Once you're logged in, run the following ``mmctl`` command:
          
    mmctl export create
 
-Running this command creates a full export of the server, including attached files. Append ``--no-attachments`` if you do not wish to export attached files from your instance. This process can take some time, so ``mmctl`` will return immediately, and the job will run in the background on the Mattermost instance until the export is fully created. If successful, the command will immediately output a job ID, like this:
+Running this command creates a full export of the server, including attached files. Append ``--no-attachments`` if you do not wish to export attached files from your instance, and append ``--with-archived-channels`` to include archived channels in the export file. This process can take some time, so ``mmctl`` will return immediately, and the job will run in the background on the Mattermost instance until the export is fully created. If successful, the command will immediately output a job ID, like this:
 
 .. code::
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -2278,8 +2278,9 @@ Create an export file.
 
 .. code-block:: sh
 
-   --no-attachments     Omit to include file attachments in the export file.
-   -h, --help           help for create
+   --no-attachments              Omit to include file attachments in the export file.
+   --include-archived-channels   Include archived channels in the export file.
+   -h, --help                    help for create
 
 **Options inherited from parent commands**
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost/pull/23724

@JulienTant @nab-77 The ``--with-archived-channels`` flag appears to have been applied to both the ``mmctl export create`` command and the ``mattermost export bulk`` CLI command. Product docs have the CLI command as deprecated in favour of the mmctl command. Is that still accurate via the docs? If so, do we want to capture the CLI update at all within the docs somehow? Thoughts?