### PR TITLE
Replaced regular log levels for audit-specific levels

### DIFF
--- a/source/comply/audit-log.rst
+++ b/source/comply/audit-log.rst
@@ -77,7 +77,6 @@ Examples of values for the ``AdvancedLoggingJSON`` setting are:
       }
     }
 
-
 2. Multi-line JSON in the ``config.json`` file:
 
   .. code-block:: json
@@ -94,7 +93,7 @@ Examples of values for the ``AdvancedLoggingJSON`` setting are:
                 ],
                 "Options": {
                     "Compress": true,
-                    "Filename": "mattermost_logr.log",
+                    "Filename": "audit.log",
                     "MaxAgeDays": 1,
                     "MaxBackups": 10,
                     "MaxSizeMB": 500 

--- a/source/comply/audit-log.rst
+++ b/source/comply/audit-log.rst
@@ -87,12 +87,10 @@ Examples of values for the ``AdvancedLoggingJSON`` setting are:
                 "Type": "file",
                 "Format": "plain",
                 "Levels": [
-                    {"ID": 5, "Name": "debug", "Stacktrace": false},
-                    {"ID": 4, "Name": "info", "Stacktrace": false},
-                    {"ID": 3, "Name": "warn", "Stacktrace": false},
-                    {"ID": 2, "Name": "error", "Stacktrace": true},
-                    {"ID": 1, "Name": "fatal", "Stacktrace": true},
-                    {"ID": 0, "Name": "panic", "Stacktrace": true}
+                  { "id": 100, "name": "audit-api" },
+                  { "id": 101, "name": "audit-content" },
+                  { "id": 102, "name": "audit-permissions" },
+                  { "id": 103, "name": "audit-cli" }
                 ],
                 "Options": {
                     "Compress": true,


### PR DESCRIPTION
Addresses docs error raised by community member who encountered issues working with the documentation examples.