### PR TITLE
Added note for Omnibus Ubuntu Support

### DIFF
--- a/source/install/installing-mattermost-omnibus.rst
+++ b/source/install/installing-mattermost-omnibus.rst
@@ -39,6 +39,10 @@ Install Mattermost Omnibus
   :local:
   :depth: 1
 
+.. note::
+
+ Omnibus supports Ubuntu distributions only. We recommend to not try installing it on any other Linux distros.``.
+
 Mattermost Omnibus packages the free, unlicensed Mattermost Enterprise version of Mattermost, a PostgreSQL database, and when required, NGINX as the application proxy. A custom CLI (``mmomni``) and ansible recipes link the components together and configures them. Mattermost Omnibus is only supported on Ubuntu distributions. 
 
 Add the Mattermost PPA repositories


### PR DESCRIPTION
#### Summary

This PR adds a note to the Omnibus installation page to clarify that it can only be installed on Ubuntu distributions.

#### Ticket Link

Fixes #6598 

