### PR TITLE
Updated mmctl export create command flag

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -2278,7 +2278,7 @@ Create an export file including message attachments.
 
 .. code-block:: sh
 
-   --no-attachments              Include to omit file attachments in the export file.
+   --no-attachments              Omit file attachments in the export file.
    --include-archived-channels   Include archived channels in the export file.
    -h, --help                    help for create
 


### PR DESCRIPTION
Updated mmctl export create command flag to align with mmctl source code (updated via https://github.com/mattermost/mattermost/pull/25474)