### PR TITLE
Removed Allow prefetch channel posts

### DIFF
--- a/source/configure/developer-mode-configuration-settings.rst
+++ b/source/configure/developer-mode-configuration-settings.rst
@@ -71,8 +71,8 @@ Enable client debugging
 
 +---------------------------------------------------+---------------------------------------------------------------------------------------------+
 | Enable or disable client-side debugging settings  | - System Config path: **Environment > Developer**                                           |
-| found in *Settings > Advanced > Debugging* for    | - ``config.json setting``: ``".ServiceSettings.EnableClientPerformanceDebugging": false",`` |
-| individual users.                                 | - Environment variable: ``MM_SERVICESETTINGS_ENABLECLIENTPERFORMANCEDEBUGGING``             |
+| found in **Settings > Advanced > Debugging**      | - ``config.json setting``: ``".ServiceSettings.EnableClientPerformanceDebugging": false",`` |
+| for individual users.                             | - Environment variable: ``MM_SERVICESETTINGS_ENABLECLIENTPERFORMANCEDEBUGGING``             |
 |                                                   |                                                                                             |
 | - **true**: Those settings are visible and can    |                                                                                             |
 |   be enabled by users.                            |                                                                                             |

--- a/source/preferences/manage-advanced-options.rst
+++ b/source/preferences/manage-advanced-options.rst
@@ -136,21 +136,6 @@ By default, `message drafts </send-messages.html#draft-messages>`__ are synchron
 
         This option isn't applicable to the mobile app.
 
-Allow Mattermost to prefetch channel posts
-------------------------------------------
-
-By default, Mattermost pre-fetches messages and user information when you start Mattermost in a browser. You can disable webapp pre-fetching so that Mattermost prefetches messages and user information as you open channels instead. Disabling prefetch is recommended for users with a high unread channel count in order to improve application performance.
-
-.. tabs::
-
-    .. tab:: Web/Desktop
-
-        Select **Allow Mattermost to prefetch channel posts** to disable webapp pre-fetching on startup, and pre-fetch the data as you open channels.
-    
-    .. tab:: Mobile
-
-        This option isn't applicable to the mobile app.
-
 Delete local files
 ------------------
 


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost/pull/25251

Removed Allow Mattermost to prefetch channel posts preference documentation introduced in v9.2 for testing purposes.