### PR TITLE
Updated official MS Teams terminology, plan details, removed duplicate page

### DIFF
--- a/source/about/embed-mattermost-app-within-microsoft-teams.rst
+++ b/source/about/embed-mattermost-app-within-microsoft-teams.rst
@@ -1,14 +1,10 @@
 Embed the Mattermost App within Microsoft Teams
 ================================================
 
-.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-.. tip::
-
-  Looking to `install the Mattermost for Microsoft Teams plugin </about/install-mattermost-for-microsoft-teams-plugin.html>`__ instead?
-
-With `Mattermost for Microsoft Teams </about/mattermost-for-microsoft-teams.html>`__, you can embed your Mattermost workspace within your Microsoft Teams instance and take advantage of `embedded app features <#benefits-of-the-embedded-app>`_.
+With the `Microsoft Teams plugin </about/mattermost-for-microsoft-teams.html>`__, you can embed your Mattermost workspace within your Microsoft Teams instance and take advantage of `embedded app features <#benefits-of-the-embedded-app>`_.
 
 .. important::
 

--- a/source/about/install-mattermost-for-microsoft-teams-plugin.rst
+++ b/source/about/install-mattermost-for-microsoft-teams-plugin.rst
@@ -1,7 +1,7 @@
 Install the Mattermost for Microsoft Teams plugin
 =================================================
 
-.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
 .. contents:: On this page
@@ -12,7 +12,7 @@ Install the Mattermost for Microsoft Teams plugin
 
   Looking to `embed Mattermost within Microsoft Teams </about/embed-mattermost-within-microsoft-teams.html>`__ instead?
 
-To install the `Mattermost for Microsoft Teams integration </configure/plugins-configuration-settings.html#ms-teams-sync>`__ in Mattermost:
+To install the `Microsoft Teams plugin </configure/plugins-configuration-settings.html#ms-teams-sync>`__ in Mattermost:
 
 1. Log in to your Mattermost workspace as a system administrator.
 2. Download the latest version of `the plugin binary release <https://github.com/mattermost/mattermost-plugin-msteams-sync/releases>`__, compatible with Mattermost v8.0.1 and later. If you are using an earlier version of Mattermost, `follow our documentation </upgrade/upgrading-mattermost-server.html>`__ to upgrade to Mattermost v8.0.1 or later.
@@ -96,7 +96,7 @@ Step 2: Create a user account to act as a bot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Create a regular user account. We will connect this account later from the Mattermost side.
-2. This account is needed for creating messages on MS Teams on behalf of users who are present in Mattermost but not on MS Teams.
+2. This account is needed for creating messages on Microsoft Teams on behalf of users who are present in Mattermost but not on Microsoft Teams.
 3. This account is also needed when users on Mattermost have not connected their accounts and some messages need to be posted on their behalf. See the screenshot below:
 
    .. image:: ../images/teams-user-as-bot.png
@@ -104,7 +104,7 @@ Step 2: Create a user account to act as a bot
 
 .. note::
   
-  After you've connected the bot user to the account on MS Teams, all the messages that are posted from the account on MS Teams won't be synchronized back to Mattermost since it's a "bot", and messages from bots are ignored.
+  After you've connected the bot user to the account on Microsoft Teams, all the messages that are posted from the account on Microsoft Teams won't be synchronized back to Mattermost since it's a "bot", and messages from bots are ignored.
 
 Step 3: Ensure you have the metered APIs enabled (and the pay subscription associated to it)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,7 +129,7 @@ Mattermost admins can configure Mattermost to automatically prompt users to conn
 Configure the plugin
 --------------------
 
-Additional configuration settings are available for this plugin. See the `MS Teams Sync plugin configuration settings </configure/plugins-configuration-settings.html#ms-teams-sync>`__ documentation for details.
+Additional configuration settings are available for this plugin. See the `Microsoft Teams Sync plugin configuration settings </configure/plugins-configuration-settings.html#ms-teams-sync>`__ documentation for details.
 
 Monitor plugin performance
 --------------------------
@@ -151,7 +151,7 @@ Grafana dashboards `are available on GitHub <https://github.com/mattermost/matte
 Get started with the plugin
 ---------------------------
 
-See our `collaborate using Mattermost for MS Teams </collaborate/collaborate-using-mattermost-for-microsoft-teams>`__ documentation for details on how to collaborate across both Mattermost and Microsoft Teams at the same time.
+See our `collaborate using the Microsoft Teams plugin </collaborate/collaborate-using-mattermost-for-microsoft-teams>`__ documentation for details on how to collaborate across both Mattermost and Microsoft Teams at the same time.
 
 Trobleshooting
 --------------

--- a/source/about/mattermost-for-microsoft-teams.rst
+++ b/source/about/mattermost-for-microsoft-teams.rst
@@ -1,12 +1,10 @@
 Mattermost for Microsoft Teams
 ==============================
 
-.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-Mattermost for Microsoft Teams enables you to collaborate with technical and operations teams seamlessly through the Mattermost app, without leaving Microsoft Teams. Two integrations are available: a `connected integration <#connect-mattermost-with-microsoft-teams>`__ and an `embedded integration <#embed-mattermost-within-mattermost-teams>`__.
-
-
+The Mattermost for Microsoft Teams plugin enables you to collaborate with technical and operations teams seamlessly through the Mattermost app, without leaving Microsoft Teams. Two integrations are available: a `connected integration <#connect-mattermost-with-microsoft-teams>`__ and an `embedded integration <#embed-mattermost-within-mattermost-teams>`__.
 
 .. include:: ../_static/badges/academy-msteams.rst
   :start-after: :nosearch:
@@ -20,7 +18,7 @@ A connected Mattermost integration with Microsoft Teams enables direct message, 
 
 Install this integration by visiting the `install the Mattermost for Microsoft Teams plugin </about/install-mattermost-for-microsoft-teams-plugin.html>`__ documentation.
 
-Visit the `collaborate within a connected Microsoft Teams instance </collaborate/collaborate-within-connected-microsoft-teams.html>`__ to learn how to use this integration. 
+Visit the `collaborate within a Microsoft Teams instance </collaborate/collaborate-within-connected-microsoft-teams.html>`__ to learn how to use this integration. 
 
 Embed Mattermost within Mattermost Teams
 ----------------------------------------

--- a/source/about/unified-collaboration.rst
+++ b/source/about/unified-collaboration.rst
@@ -11,7 +11,7 @@ Unified communication
 
 Mattermost's Unified Communication solution is designed to provide an extended collaboration experience for technical and operational teams to teams on other collaboration systems.
 
-* :doc:`Mattermost for Microsoft Teams </about/mattermost-for-microsoft-teams>` - Learn how organizations can easily connect operational workflows through the Mattermost app while staying connected to the all-employee platform, all in one place.
+* :doc:`Mattermost for Microsoft Teams plugin</about/mattermost-for-microsoft-teams>` - Learn how organizations can easily connect operational workflows through the Mattermost app while staying connected to the all-employee platform, all in one place.
 * :doc:`Mattermost Google Calendar integration </about/mattermost-google-calendar-integration>` - Learn how to enable a two-way integration between Mattermost and Google Calendar.
 
 `Contact us <https://mattermost.com/contact-sales/>`_ to learn more about this solution and to discuss whether it’s the right one for you.

--- a/source/archive/embed-mattermost-within-microsoft-teams.rst
+++ b/source/archive/embed-mattermost-within-microsoft-teams.rst
@@ -1,3 +1,6 @@
+:orphan:
+:nosearch:
+
 Embed Mattermost within Microsoft Teams
 =======================================
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst

--- a/source/collaborate/collaborate-within-connected-microsoft-teams.rst
+++ b/source/collaborate/collaborate-within-connected-microsoft-teams.rst
@@ -1,21 +1,21 @@
-Collaborate within connected Microsoft Teams
-============================================
+Collaborate within Microsoft Teams
+==================================
 
-.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
 .. |plus-icon| image:: ../images/plus_F0415.svg
   :alt: Open menus using the plus icon.
 
-The `Connected Mattermost for Microsoft Teams </about/mattermost-for-microsoft-teams.html>`__ integration enables you to collaborate with Microsoft Teams users without leaving Mattermost.
+The `Mattermost for Microsoft Teams plugin </about/mattermost-for-microsoft-teams.html>`__ integration enables you to collaborate with Microsoft Teams users without leaving Mattermost.
 
 .. include:: ../_static/badges/academy-msteams.rst
   :start-after: :nosearch:
 
-Connect your Mattermost account to your MS Teams account
----------------------------------------------------------
+Connect your Mattermost account to your Microsoft Teams account
+---------------------------------------------------------------
 
-To use the Mattermost for Microsoft Teams plugin, you must connect your Mattermost user account to Microsoft Teams. You only need to complete this step once.
+To use the Microsoft Teams plugin, you must connect your Mattermost user account to Microsoft Teams. You only need to complete this step once.
 
 1. Log into Mattermost using your credentials. 
 2. When you log in, you’ll be prompted to enter your Microsoft Teams user information, including your Microsoft Teams email address and your Microsoft Teams password.

--- a/source/collaborate/collaborate-within-embedded-microsoft-teams.rst
+++ b/source/collaborate/collaborate-within-embedded-microsoft-teams.rst
@@ -1,10 +1,10 @@
 Collaborate within embedded Microsoft Teams
 ===========================================
 
-.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
   :start-after: :nosearch:
 
-The `Embedded Mattermost for Microsoft Teams </about/mattermost-for-microsoft-teams.html>`__ integration enables you to collaborate with technical & operations teams seamlessly through the Mattermost app, without leaving Microsoft Teams.
+The `Mattermost for Microsoft Teams plugin </about/mattermost-for-microsoft-teams.html>`__ enables you to collaborate with technical & operations teams seamlessly through the Mattermost app, without leaving Microsoft Teams.
 
 Demonstration: Mattermost embedded in Microsoft Teams
 ------------------------------------------------------
@@ -13,4 +13,4 @@ Check out this `YouTube demo <https://youtu.be/Mg-stF7_Bjk>`__, from Doug Lauder
 
 .. raw:: html
   
-   <iframe width="560" height="315" src="https://www.youtube.com/embed/Mg-stF7_Bjk" alt="Install Matterrmost for Microsoft Teams plugin" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/Mg-stF7_Bjk" alt="Install Mattermost for Microsoft Teams plugin" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/source/collaborate/extend-mattermost-with-integrations.rst
+++ b/source/collaborate/extend-mattermost-with-integrations.rst
@@ -1,9 +1,6 @@
 Extend Mattermost with integrations
 ===================================
 
-.. include:: ../_static/badges/allplans-cloud-selfhosted.rst
-  :start-after: :nosearch:
-
 `Visit the Mattermost Marketplace <https://mattermost.com/marketplace/>`__ to find dozens of open source integrations to common tools like Jira, Jenkins, GitLab, with interactive bot applications (Hubot, mattermost-bot), and other communication tools (Email, IRC, XMPP, Threema) that are freely available for use and customization.
 
 Latest integrations
@@ -17,7 +14,7 @@ Latest integrations
    Collaborate within embedded MS Teams </collaborate/collaborate-within-embedded-microsoft-teams>
    Use the Mattermost Google Calendar plugin </collaborate/use-mattermost-google-calendar-plugin>
 
-* :doc:`Collaborate within a connected Microsoft Teams instance </collaborate/collaborate-within-connected-microsoft-teams>` - Learn how to collaborate with colleagues when Mattermost is connected to Microsoft Teams.
+* :doc:`Collaborate within a Microsoft Teams instance </collaborate/collaborate-within-connected-microsoft-teams>` - Learn how to collaborate with colleagues when Mattermost is connected to Microsoft Teams.
 * :doc:`Collaborate within an embedded Microsoft Teams instance </collaborate/collaborate-within-embedded-microsoft-teams>` - Learn how to collaborate with colleagues when Mattermost is embedded within Microsoft Teams.
 * :doc:`Use the Mattermost Google Calendar plugin </collaborate/use-mattermost-google-calendar-plugin>` - Learn how to manage events using a two-way integration between Mattermost and Google Calendar.
 
@@ -64,5 +61,3 @@ Video calling & screensharing
 
 - `Skype for Business <https://mattermost.com/marketplace/skype4business-plugin/>`__: Start and join voice calls, video calls, and use screensharing in Mattermost.
 - `Zoom <https://mattermost.com/marketplace/zoom-plugin/>`__: Start audio and video conferencing calls in Mattermost.
-
-

--- a/source/conf.py
+++ b/source/conf.py
@@ -1950,6 +1950,10 @@ redirects = {
 "developer/webhooks-incoming.html":
         "https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-incoming/",
 
+# Microsoft Teams redirects
+"about/embed-mattermost-within-microsoft-teams.html":
+        "about/embed-mattermost-app-within-microsoft-teams.html",
+
 # Focalboard redirects
 "focalboard/installing-boards":
 	"https://github.com/mattermost/focalboard/blob/main/docs/mattermost-boards-dev-guide.md",


### PR DESCRIPTION
- Updated product plugin terminology to be consistent.
- Labelled Microsoft Teams as requiring an Enterprise license.
- Removed erroneous duplicated page & added redirects
- Replaced one YouTube video with new asset.

Pages impacted:
- [Mattermost for Microsoft Teams](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6829/about/mattermost-for-microsoft-teams.html)
- [Install the Mattermost for Microsoft Teams plugin](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6829/about/install-mattermost-for-microsoft-teams-plugin.html#on-this-page)
- [Embed the Mattermost App within Microsoft Teams](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6829/about/embed-mattermost-app-within-microsoft-teams.html)
- [Collaborate within Microsoft Teams](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6829/collaborate/collaborate-within-connected-microsoft-teams.html)
- [Collaborate within embedded Microsoft Teams](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6829/collaborate/collaborate-within-embedded-microsoft-teams.html)