### PR TITLE
Dedicated filestore for bulk and compliance exports

### DIFF
--- a/source/comply/compliance-export.rst
+++ b/source/comply/compliance-export.rst
@@ -30,8 +30,7 @@ Use the following guides to configure exports for CSV, Actiance XML, or Global R
 
 .. note::
    
-   - For self-hosted deployments, compliance exports are written to the ``exports`` subdirectory of the configured `Local Storage directory </configure/environment-configuration-settings.html#file-storage>`__ in the chosen format.
-   - If you've configured Mattermost to use S3 storage, the exports are written to the ``exports`` directory in the Mattermost bucket.
+   - For self-hosted deployments, compliance exports are written to the ``exports`` subdirectory of the configured filestore in the chosen format. This will either be in the `Local Storage directory </configure/environment-configuration-settings.html#file-storage>` or the Mattermost S3 bucket if S3 storage is configured.
    - Alternatively, you can specify an alternate filestore target and generate an S3 presigned URL for compliance exports. See the `dedicated export filestore target </configure/experimental-configuration-settings.html#enable-dedicated-export-filestore-target>`__ configuration settings documentation for details.
    - Compliance exports don't contain posts sent before the feature was enabled. For self-hosted deployments, you can export past history via the ``export`` :doc:`command line tool <../manage/command-line-tools>`. 
 

--- a/source/comply/compliance-export.rst
+++ b/source/comply/compliance-export.rst
@@ -26,13 +26,14 @@ Enterprise deployments with a requirement to archive history beyond the data ret
 Set up guide
 ------------
 
-Use the following guides to configure exports for CSV, Actiance XML, or Global Relay EML. \
-
-For self-hosted deployments, compliance exports are written to the ``exports`` subdirectory of the configured `Local Storage directory </configure/configuration-settings.html>`__ in the chosen format. If you've configured Mattermost to use S3 storage, the exports are written to the ``exports`` directory in the Mattermost bucket.
+Use the following guides to configure exports for CSV, Actiance XML, or Global Relay EML.
 
 .. note::
    
-   The compliance exports do not contain posts sent before the feature was enabled. For self-hosted deployments, you can export past history via the ``export`` :doc:`command line tool <../manage/command-line-tools>`. 
+   - For self-hosted deployments, compliance exports are written to the ``exports`` subdirectory of the configured `Local Storage directory </configure/environment-configuration-settings.html#file-storage>`__ in the chosen format.
+   - If you've configured Mattermost to use S3 storage, the exports are written to the ``exports`` directory in the Mattermost bucket.
+   - Alternatively, you can specify an alternate filestore target and generate an S3 presigned URL for compliance exports. See the `dedicated export filestore target </configure/experimental-configuration-settings.html#enable-dedicated-export-filestore-target>`__ configuration settings documentation for details.
+   - Compliance exports don't contain posts sent before the feature was enabled. For self-hosted deployments, you can export past history via the ``export`` :doc:`command line tool <../manage/command-line-tools>`. 
 
 CSV
 ~~~~

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -639,6 +639,40 @@ This setting disables re-fetching of channel and channel members on browser focu
 | This feature's ``config.json`` setting is ``"ExperimentalSettings.DisableRefetchingOnBrowserFocus": false`` with options ``true`` and ``false``. |
 +--------------------------------------------------------------------------------------------------------------------------------------------------+
 
+Enable dedicated export filestore target
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This setting enables you to specify an alternate filestore target for Mattermost `bulk exports </manage/bulk-export-tool.html>`__ and `compliance exports </comply/compliance-export.html>`__. 
+
+**True**: A new ``ExportFileBackend()`` is generated under ``FileSettings`` using new configuration values for the following configuration settings:
+
+- ``ExportDriverName``
+- ``ExportDirectory``
+- ``ExportAmazonS3AccessKeyId``
+- ``ExportAmazonS3SecretAccessKey``
+- ``ExportAmazonS3Bucket``
+- ``ExportAmazonS3PathPrefix``
+- ``ExportAmazonS3Region``
+- ``ExportAmazonS3Endpoint``
+- ``ExportAmazonS3SSL``
+- ``ExportAmazonS3SignV2``
+- ``ExportAmazonS3SSE``
+- ``ExportAmazonS3Trace``
+- ``ExportAmazonS3RequestTimeoutMilliseconds``
+- ``ExportAmazonS3PresignExpiresSeconds``
+
+**False**: Standard `file storage </configure/environment-configuration-settings.html#file-storage>`__ is used (or when the configuration setting is omitted).
+
+When an alternate filestore target is configured, Mattermost Cloud admins can generate an S3 presigned URL for exports using the ``/exportlink [job-id|zip file|latest]`` slash command. See the `Mattermost workspace migration </manage/cloud-data-export.html#create-the-export>`__ documentation for details. Alternatively, Cloud and self-hosted admins can use the `mmctl export generate-presigned-url </manage/mmctl-command-line-tool.html#mmctl-export-generate-presigned-url>`__ command to generate a presigned URL directly from mmctl.
+
+.. note::
+
+  Generating an S3 presigned URL requires the feature flag ``EnableExportDirectDownload`` to be set to ``true``,  the storage must be compatible with generating an S3 link, and this experimental configuration setting must be set to ``true``. Presigned URLs for exports aren't supported for systems with shared storage.
+
++-------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalSettings.DedicatedExportStore": false`` with options ``true`` and ``false``.     |
++-------------------------------------------------------------------------------------------------------------------------------------------+
+
 ----
 
 Experimental Bleve configuration settings


### PR DESCRIPTION
Documentation for:
- https://github.com/mattermost/enterprise/pull/1598

Also documented functionality via https://github.com/mattermost/mattermost/pull/23915 that was initially/intentionally omitted due to availability being behind a feature flag.