### PR TITLE
Audit and improve community onboarding experience

### DIFF
--- a/source/guides/community-chat.rst
+++ b/source/guides/community-chat.rst
@@ -1,26 +1,44 @@
-Mattermost community collaboration server
-=========================================
+Join Our Community
+==================
 
-Mattermost hosts a collaboration and chat server at `community.mattermost.com <https://community.mattermost.com/login>`__ to connect our team with our larger contributor and user community. This server is open to everyone, and we welcome anyone who wants to participate in our community to sign up.
+Connect with thousands of contributors, customers, and users to build, share, and learn together at `community.mattermost.com <https://community.mattermost.com>`__. This server is our virtual office and is open to everyone. Please review our `Code of Conduct <https://handbook.mattermost.com/contributors/contributors/guidelines/contribution-guidelines>`__ before participating.
 
-We have many channels on our community server you can join. Here are some of the more popular channels.
+General Channels
+----------------
 
-**General purpose channels**
+- `~Contributors <https://community.mattermost.com/core/chann0els/tickets>`__
+- `~Community Team <https://community.mattermost.com/core/channels/community-team>`__
+- `~Developers <https://community.mattermost.com/core/channels/developers>`__
+- `~New Channel Notifications <https://community.mattermost.com/core/channels/new-channel-notifications>`__
+- `~Off-Topic <https://community.mattermost.com/core/channels/off-topic-pub>`__
+- `~Reception <https://community.mattermost.com/core/channels/town-square>`__
 
-- `Peer-to-peer Help: <https://community.mattermost.com/core/channels/peer-to-peer-help>`__ Get help from other community members on using, deploying, or contributing to Mattermost.
-- `Ask Anything: <https://community.mattermost.com/core/channels/ask-anything>`__ Ask general questions about Mattermost.
+Technical Support Channels
+--------------------------
 
-**Contributor discussions**
+To familiarize yourself with our community support process, start by reading the `Get Help <https://docs.mattermost.com/guides/get-help.html>`__ documentation page.
 
-- `Developers: <https://community.mattermost.com/core/channels/developers>`__ Get help with development issues from our team and other developers in our community.
-- `Developers Meeting: <https://community.mattermost.com/core/channels/developers-meeting>`__ Join the weekly developers meeting to find out what Mattermost developers are working on.
-- `Contributors: <https://community.mattermost.com/core/channels/tickets>`__ Connect with other people who are working to make Mattermost better.
-- `Contributor Guilds: <https://developers.mattermost.com/contribute/getting-started/guilds/>`__ Find focused groups within our community that work on specific portions of the Mattermost ecosystem.
-- `Documentation Working Group: <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`__ Provide feedback about Mattermost documentation and ask questions to the Mattermost Technical Writing team.
-- `Content: <https://community.mattermost.com/core/channels/mattermost-blog>`__ Discuss blog, video, podcast, and other content publication with the Mattermost Content team.
+- `~Ask Anything <https://community.mattermost.com/core/channels/ask-anything>`__
+- `~Bugs <https://community.mattermost.com/core/channels/bugs>`__
+- `~Peer-to-peer Help <https://community.mattermost.com/core/channels/peer-to-peer-help>`__
 
-**Social channels**
+We also recommend using the `Troubleshooting forum <https://forum.mattermost.com/c/trouble-shoot/16>`__ for technical support.
 
-- `Off-Topic: <https://community.mattermost.com/core/channels/off-topic-pub>`__ Talk about anything that’s not directly related to Mattermost
-- `Open Source Fridays: <https://community.mattermost.com/core/channels/open-source-fridays>`__ Share what you’re working on during your own Open Source Fridays.
-- `Social: <https://community.mattermost.com/core/channels/social>`__ Join the conversation on our channel for casual chats. 
+Contributor Community Channels
+------------------------------
+
+To familiarize yourself with our community contribution process, start by exploring the `Contribute to Mattermost <https://mattermost.com/contribute/>`__ documentation.
+
+- `~AI Exchange <https://community.mattermost.com/core/channels/ai-exchange>`__
+- `~Developers: Meeting <https://community.mattermost.com/core/channels/developers-meeting>`__
+- `~DWG: Documentation Working Group <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`__
+- `~Feature Proposals <https://community.mattermost.com/core/channels/feature-ideas>`__
+- `~i18n - Localization <https://community.mattermost.com/core/channels/localization>`__
+- `~Open Source Fridays (OSF) <https://community.mattermost.com/core/channels/open-source-fridays>`__
+- `~Public Speakers <https://community.mattermost.com/core/channels/public-speakers>`__
+- `~QA: Contributors <https://community.mattermost.com/core/channels/qa-contributors>`__
+- `~Thank you! <https://community.mattermost.com/core/channels/thank-you>`__
+
+There are many channels that specialize in different areas of the Mattermost platform. To find and join them, search “**Developers:**” in the `LHS <https://handbook.mattermost.com/company/about-mattermost/list-of-terms#lhs>`__ “🔍 Find channel” search bar on the community server.
+
+We hold a public developer community meeting every Wednesday at 8:30 AM PT. ☎️ The meeting is held via an audio call in `Developers: Meeting <https://community.mattermost.com/core/channels/developers-meeting>`__ and everyone is welcome. This weekly meeting is a great opportunity to ask questions about the project and get involved.

--- a/source/guides/community-chat.rst
+++ b/source/guides/community-chat.rst
@@ -1,7 +1,7 @@
 Join our community
 ==================
 
-Connect with thousands of contributors, customers, and users to build, share, and learn together at `community.mattermost.com <https://community.mattermost.com>`__. This server is our virtual office and is open to everyone. Please review our `Code of Conduct <https://handbook.mattermost.com/contributors/contributors/guidelines/contribution-guidelines>`__ before participating.
+Connect with thousands of contributors, customers, partners, and users to build, share, and learn together at `community.mattermost.com <https://community.mattermost.com>`__. This server is our virtual office and is open to everyone. Please review our `Code of Conduct <https://handbook.mattermost.com/contributors/contributors/guidelines/contribution-guidelines>`__ before participating.
 
 General channels
 ----------------

--- a/source/guides/community-chat.rst
+++ b/source/guides/community-chat.rst
@@ -1,9 +1,9 @@
-Join Our Community
+Join our community
 ==================
 
 Connect with thousands of contributors, customers, and users to build, share, and learn together at `community.mattermost.com <https://community.mattermost.com>`__. This server is our virtual office and is open to everyone. Please review our `Code of Conduct <https://handbook.mattermost.com/contributors/contributors/guidelines/contribution-guidelines>`__ before participating.
 
-General Channels
+General channels
 ----------------
 
 - `~Contributors <https://community.mattermost.com/core/chann0els/tickets>`__
@@ -13,7 +13,7 @@ General Channels
 - `~Off-Topic <https://community.mattermost.com/core/channels/off-topic-pub>`__
 - `~Reception <https://community.mattermost.com/core/channels/town-square>`__
 
-Technical Support Channels
+Technical support channels
 --------------------------
 
 To familiarize yourself with our community support process, start by reading the `Get Help <https://docs.mattermost.com/guides/get-help.html>`__ documentation page.
@@ -24,7 +24,7 @@ To familiarize yourself with our community support process, start by reading the
 
 We also recommend using the `Troubleshooting forum <https://forum.mattermost.com/c/trouble-shoot/16>`__ for technical support.
 
-Contributor Community Channels
+Contributor community channels
 ------------------------------
 
 To familiarize yourself with our community contribution process, start by exploring the `Contribute to Mattermost <https://mattermost.com/contribute/>`__ documentation.

--- a/source/guides/community-chat.rst
+++ b/source/guides/community-chat.rst
@@ -41,4 +41,4 @@ To familiarize yourself with our community contribution process, start by explor
 
 There are many channels that specialize in different areas of the Mattermost platform. To find and join them, search “**Developers:**” in the `LHS <https://handbook.mattermost.com/company/about-mattermost/list-of-terms#lhs>`__ “🔍 Find channel” search bar on the community server.
 
-We hold a public developer community meeting every Wednesday at 8:30 AM PT. ☎️ The meeting is held via an audio call in `Developers: Meeting <https://community.mattermost.com/core/channels/developers-meeting>`__ and everyone is welcome. This weekly meeting is a great opportunity to ask questions about the project and get involved.
+We hold a public developer community meeting every Wednesday at 8:30 AM Palo Alto time. ☎️ The meeting is held via an audio call in `Developers: Meeting <https://community.mattermost.com/core/channels/developers-meeting>`__ and everyone is welcome. This weekly meeting is a great opportunity to ask questions about the project and get involved.

--- a/source/guides/contribute-to-documentation.rst
+++ b/source/guides/contribute-to-documentation.rst
@@ -1,23 +1,23 @@
-Contribute to this site
-========================
+Contribute to this documentation
+================================
 
-Mattermost has a diverse community that extends well beyond those who write code for our core projects. We value every contributor who helps make Mattermost better for everyone, from the community members who translate the Mattermost platform into languages beyond English, to those who write documentation and beyond. 
-
-If you’re interested in contributing to Mattermost, why not help improve the product documentation?
+Mattermost has a diverse community that extends well beyond code contributions. If you're interested in contributing to Mattermost, why not help improve the documentation? Be sure to join the documentation community in `~DWG: Documentation Working Group <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`__ so we can support and celebrate you!
 
 How to get started
 ------------------
 
-The fastest way to get started with a documentation contribution is to find something you want to change in the documentation, such as a typo or link fix, or updating content for clarity. Once you've found a page you want to update, select **Edit** in the top-right corner of that page. 
+The fastest way to get started with a documentation contribution is to find something you want to change in the documentation. This might be a typo or broken link, or something more extensive like revising or expanding content. Once you've found a page you want to update, select **Edit** in the top right corner of that page. 
 
 .. image:: ../images/edit-on-github.png
     :height: 50
-    :alt: Contribute to Mattermost documentation by selecting the Edit option located in the top right corner of every documentation page.
+    :alt: Contribute to Mattermost documentation by selecting the Edit option located in the top right corner of any documentation page.
 
-First time contributor?
+First-time contributor?
 -----------------------
 
-In a GitHub pull request, you can make changes as if you were fixing any other Mattermost product issue or bug. If you're new to contributing to documentation using pull requests in GitHub, the following `video <https://www.youtube.com/watch?v=V8ROl9wiHr8>`__ will help you get started:
+Start by exploring the `Contribute to Mattermost <https://mattermost.com/contribute/>`__ documentation, specifically the `"You want to help with content" <https://developers.mattermost.com/contribute/why-contribute/#you-want-to-help-with-content>`__ section.
+
+In a GitHub pull request, you can make changes as if you were editing code. If you're new to contributing to documentation using pull requests in GitHub, the following `video <https://www.youtube.com/watch?v=V8ROl9wiHr8>`__ will help you get started:
 
 .. raw:: html
 
@@ -25,16 +25,14 @@ In a GitHub pull request, you can make changes as if you were fixing any other M
       <iframe src="https://www.youtube.com/embed/V8ROl9wiHr8" alt="Video on creating pull requests in GitHub" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 95%;"></iframe>
    </div>
 
-See our `contribution <https://developers.mattermost.com/contribute/why-contribute/#you-want-to-help-with-content>`__ documentation to learn more about the contribution opportunities available.
-
 Where to find more information
 ------------------------------
 
-If you'd like to take on a project with larger scope across multiple pages at a time, you'll want to be able to generate the documentation locally on demand to review your changes. See the product documentation `README <https://github.com/mattermost/docs#readme>`__ documentation to learn how to build the product documentation locally on your own system. 
+Explore the README links below for details on building and previewing documentation locally for our different documentation repositories:
 
-Are you interested in contributing to the Mattermost developer or API reference documentation? See the additional README links below for details on generating documentation locally:
+- `docs.mattermost.com documentation README <https://github.com/mattermost/docs#readme>`__
+- `developers.mattermost.com documentation README <https://github.com/mattermost/mattermost-developer-documentation/blob/master/README.md>`__
+- `api.mattermost.com documentation README <https://github.com/mattermost/mattermost/blob/master/api/README.md>`__
+- `handbook.mattermost.com documentation README <https://github.com/mattermost/mattermost-handbook/blob/0.2.1/README.md>`__
 
-- `Mattermost Developer README <https://github.com/mattermost/mattermost-developer-documentation#readme>`__
-- `API reference README <https://github.com/mattermost/mattermost-api-reference#readme>`__
-
-Thank you again for your support. If you have any questions, reach out to us in the `Documentation Working Group channel <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`__ on the Community Mattermost workspace.
+Thank you for your support! 💙 If you have any questions, reach out to us in `~DWG: Documentation Working Group <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`__.

--- a/source/guides/get-help.rst
+++ b/source/guides/get-help.rst
@@ -1,47 +1,42 @@
 Get help with Mattermost
 =========================
 
-Get the help you need with Mattermost via robust documentation, extensive community support, and professional support services. We have a diverse community spread across the internet, and web searches via your favorite search engine are often the quickest way to get answers. 
+Get the help you need with Mattermost via robust documentation, extensive community support, and professional support services. If you're struggling with something on your Mattermost journey, take a look at the following learning resources:
 
-If you’re struggling with something on your Mattermost journey, take a look at the following learning resources:
+Training
+--------
 
-Free online training
---------------------
-
-.. image:: ../_static/images/badges/academy-qrcode.png
-    :alt: Mattermost Academy QR Code. Scan to enrol in available courses.
-
-Scan this QR Code to enrol in `Mattermost Academy <https://academy.mattermost.com/>`__ end user and system admin courses for self-hosted deployments. Get the most out of your Mattermost deployment!
+- `Mattermost Academy <https://academy.mattermost.com/>`__ - Enroll in the free online end user and system admin courses for self-hosted deployments. Get the most out of your Mattermost experience with this in-depth training!
 
 Documentation
---------------
+-------------
 
-- `Mattermost Product Documentation: </>`__ This comprehensive documentation site features information about deploying, managing, and using Mattermost.
-- `Mattermost Developer Documentation: <https://developers.mattermost.com/>`__ This site features information for developers, integrators, and community contributors integrating, extending, customizing, and contributing to Mattermost.
-- `Mattermost API Reference: <https://api.mattermost.com/>`__ This site features information about the Mattermost Web Services API used by Mattermost clients and third-party applications to interact with the Mattermost server.
+- `Mattermost product documentation (here) <https://docs.mattermost.com/>`__ - read information for end users and administrators about deploying, managing, and using Mattermost.
+- `Mattermost developer documentation <https://developers.mattermost.com/>`__ - read information for developer community members about integrating, extending, customizing, and contributing to Mattermost.
+- `Mattermost API reference <https://api.mattermost.com/>`__ - read information for developer community members about the Mattermost API used by Mattermost clients and third-party applications.
 
-Support knowledge base
-----------------------
+Help Center
+-----------
 
-`Support Knowledge Base: <http://support.mattermost.com>`__ Get answers to frequently asked questions and common problems.
+- `Mattermost Help Center <http://support.mattermost.com>`__ - access frequently asked questions and common troubleshooting tips.
 
-Mattermost Community server
----------------------------
+Community server
+----------------
 
-`Community chat server: <https://community.mattermost.com/login>`__ Chat directly with the Mattermost community in chat channels tailored to share knowledge and expertise.
+- `Mattermost Community server <https://community.mattermost.com>`__ - connect with thousands of contributors, customers, and users to build, share, and learn together. This server is our virtual office and is open to everyone. Please review our `Code of Conduct <https://handbook.mattermost.com/contributors/contributors/guidelines/contribution-guidelines>`__ before participating.
 
 Mattermost user forums
 ----------------------
 
-`Forums: <https://forum.mattermost.org/>`__ Search past discussions for helpful information, or start your own thread.
+- `Troubleshooting forum <https://forum.mattermost.com/c/trouble-shoot/16>`__ - join our community forum for technical support. Please review our `Code of Conduct <https://handbook.mattermost.com/contributors/contributors/guidelines/contribution-guidelines>`__ before participating.
 
 Feedback
 --------
 
-- `Report an issue: <https://handbook.mattermost.com/contributors/contributors/ways-to-contribute#report-a-bug>`__ Report bugs or other issues you encounter when using Mattermost to our development team.
-- `Propose a feature: <https://mattermost.com/suggestions/>`__ Vote for feature proposals or submit your feature ideas.
+- `Report a bug <https://developers.mattermost.com/contribute/why-contribute/#youve-found-a-bug>`__ - report bugs or other issues you encounter when using Mattermost to our development team.
+- `Propose a feature <https://mattermost.com/suggestions/>`__ - vote for feature proposals or submit your own.
 
-Enterprise support
-------------------
+Professional and enterprise support
+-----------------------------------
 
-Mattermost offers `support services <https://mattermost.com/support/>`__ to our Enterprise customers, where Mattermost customers can make a `support request <https://support.mattermost.com/hc/en-us/requests/new>`__ to get help from our team.
+- `Mattermost Support <https://mattermost.com/support/>`__ - Submit a `support request <https://support.mattermost.com/hc/en-us/requests/new>`__ to get help from our team. Available to enrolled Professional and Enterprise customers.


### PR DESCRIPTION
To complement the [upcoming Welcome Bot changes to the community server](https://community.mattermost.com/core/pl/m5ya9t38pinb7pnxb1ydgkag7w), I've revised the ["Get help with Mattermost"](https://docs.mattermost.com/guides/get-help.html) and ["Join our community"](https://docs.mattermost.com/guides/community-chat.html) documentation pages to be more readable and concise.

The "Join our community" page now has revised channel recommendations that mirror the new recommendations from the Welcome Bot. The goal is to keep the community concentrated in areas of focus and prevent fracturing. By making it easy to reference which channels are universally recommended to new users, staff can also pay closer attention to community ingress and health.

