### PR TITLE
Corrected logs CLI command

### DIFF
--- a/source/guides/prepare-for-your-mattermost-deployment.rst
+++ b/source/guides/prepare-for-your-mattermost-deployment.rst
@@ -8,6 +8,7 @@ Prepare for your Mattermost deployment
 
     Software and hardware requirements </install/software-hardware-requirements>
     About the Mattermost Kubernetes Operator </install/mattermost-kubernetes-operator>
+    Manage the Mattermost Kubernetes Operator </install/manage_kubernetes>
     Administrator tasks </getting-started/admin-onboarding-tasks>
     Architecture overview </getting-started/architecture-overview>
     Plan your Mattermost implementation </getting-started/implementation-plan>
@@ -18,6 +19,7 @@ These guides will help you prepare for your Mattermost deployment.
 
 * :doc:`Software and hardware requirements </install/software-hardware-requirements>` - Confirm software and hardware requirements for your Mattermost deployment.
 * :doc:`About the Mattermost Kubernetes Operator </install/mattermost-kubernetes-operator>` - Learn more about the Mattermost Kubernetes Operator.
+* :doc:`Manage the Mattermost Kubernetes Operator </install/manage_kubernetes>` - Learn how to manage and monitor your Mattermost installation and deployment process in the CLI.
 * :doc:`Administrator tasks </getting-started/admin-onboarding-tasks>` - Learn about the standard configurations and settings you’ll encounter.
 * :doc:`Architecture overview </getting-started/architecture-overview>` - Learn the basics of user authentication, notifications, data management services, network connectivity, and high availability.
 * :doc:`Plan your Mattermost implementation </getting-started/implementation-plan>` - Get a detailed breakdown of the technical requirements to deploy Mattermost for your team or organization.

--- a/source/install/manage_kubernetes.rst
+++ b/source/install/manage_kubernetes.rst
@@ -1,29 +1,27 @@
-:orphan:
-:nosearch:
-
-.. _manage_kubernetes:
-
-Managing the Mattermost Kubernetes operator
-============================================
-
-.. This page is intentionally not accessible via the LHS navigation pane because it's common content included on other docs pages.
+Manage the Mattermost Kubernetes Operator
+=========================================
 
 CLI commands
 ------------
 
-You can manage and monitor your Mattermost installation's installation and deployment process in the CLI, using the commands listed below.
+You can manage and monitor your Mattermost installation and deployment process in the CLI, using the commands listed below.
 
 .. code-block:: sh
 
-    $ kubectl -n mattermost get jobs
+  kubectl -n mattermost get jobs
 
 .. code-block:: sh
 
-    $ kubectl -n mattermost get all
+  kubectl -n mattermost get all
 
 Logs
 ----
 
+The following command can be used for operator or mattermost pod/container logs:
+
 .. code-block:: sh
 
-    $ mattermost logs -f [pod name]
+  kubectl -n [namespace] logs -f [pod name]
+
+If the ``-n [namespace]`` is omitted, then the default namespace of the current context is used. We recommend specifying the namespace based on your deployment.
+


### PR DESCRIPTION
Implemented documentation feedback re: Incorrect Mattermost Kubernetes Operator logs CLI command syntax.

Docs feedback: "The 'Logs' section is not explained at all. Where/how do i execute the command? what is expected after the -f flag? The operators pod name?"