### PR TITLE
Update reporting-configuration-settings.rst

### DIFF
--- a/source/configure/reporting-configuration-settings.rst
+++ b/source/configure/reporting-configuration-settings.rst
@@ -22,7 +22,7 @@ Site statistics
 | sessions, commands, webhooks, active users, connections,      | - ``config.json setting``: N/A                              |
 | and playbooks.                                                | - Environment variable: N/A                                 |
 +---------------------------------------------------------------+-------------------------------------------------------------+
-| **Note**: Inactive and deactivated users, as well as remote users in                                                        |
+| **Note**: Deactivated users as well as synthetic users in                                                        |
 | `Microsoft Teams integrations </collaborate/collaborate-using-mattermost-for-microsoft-teams.html>`__                       |
 | and `shared channels users </onboard/shared-channels.html>`__, aren't counted towards the total number of active users.     |
 +---------------------------------------------------------------+-------------------------------------------------------------+
@@ -39,7 +39,7 @@ Team statistics
 | number of public and private channels, total post count, and  | - ``config.json`` setting: N/A                                |
 | count of paid users (self-hosted only).                       | - Environment variable: N/A                                   |
 +---------------------------------------------------------------+---------------------------------------------------------------+
-| **Note**: Inactive and deactivated users are not counted towards the total number of active users.                            |
+| **Note**: Deactivated users are not counted towards the total number of active users.                            |
 +---------------------------------------------------------------+---------------------------------------------------------------+
 
 ----

--- a/source/configure/reporting-configuration-settings.rst
+++ b/source/configure/reporting-configuration-settings.rst
@@ -22,7 +22,7 @@ Site statistics
 | sessions, commands, webhooks, active users, connections,      | - ``config.json setting``: N/A                              |
 | and playbooks.                                                | - Environment variable: N/A                                 |
 +---------------------------------------------------------------+-------------------------------------------------------------+
-| **Note**: Deactivated users as well as synthetic users in                                                                  |
+| **Note**: Deactivated users as well as synthetic users in                                                                   |
 | `Microsoft Teams integrations </collaborate/collaborate-using-mattermost-for-microsoft-teams.html>`__                       |
 | and `shared channels users </onboard/shared-channels.html>`__, aren't counted towards the total number of active users.     |
 +---------------------------------------------------------------+-------------------------------------------------------------+

--- a/source/configure/reporting-configuration-settings.rst
+++ b/source/configure/reporting-configuration-settings.rst
@@ -22,7 +22,7 @@ Site statistics
 | sessions, commands, webhooks, active users, connections,      | - ``config.json setting``: N/A                              |
 | and playbooks.                                                | - Environment variable: N/A                                 |
 +---------------------------------------------------------------+-------------------------------------------------------------+
-| **Note**: Deactivated users as well as synthetic users in                                                        |
+| **Note**: Deactivated users as well as synthetic users in                                                                  |
 | `Microsoft Teams integrations </collaborate/collaborate-using-mattermost-for-microsoft-teams.html>`__                       |
 | and `shared channels users </onboard/shared-channels.html>`__, aren't counted towards the total number of active users.     |
 +---------------------------------------------------------------+-------------------------------------------------------------+

--- a/source/configure/reporting-configuration-settings.rst
+++ b/source/configure/reporting-configuration-settings.rst
@@ -39,7 +39,7 @@ Team statistics
 | number of public and private channels, total post count, and  | - ``config.json`` setting: N/A                                |
 | count of paid users (self-hosted only).                       | - Environment variable: N/A                                   |
 +---------------------------------------------------------------+---------------------------------------------------------------+
-| **Note**: Deactivated users are not counted towards the total number of active users.                                          |
+| **Note**: Deactivated users are not counted towards the total number of active users.                                         |
 +---------------------------------------------------------------+---------------------------------------------------------------+
 
 ----

--- a/source/configure/reporting-configuration-settings.rst
+++ b/source/configure/reporting-configuration-settings.rst
@@ -39,7 +39,7 @@ Team statistics
 | number of public and private channels, total post count, and  | - ``config.json`` setting: N/A                                |
 | count of paid users (self-hosted only).                       | - Environment variable: N/A                                   |
 +---------------------------------------------------------------+---------------------------------------------------------------+
-| **Note**: Deactivated users are not counted towards the total number of active users.                            |
+| **Note**: Deactivated users are not counted towards the total number of active users.                                      |
 +---------------------------------------------------------------+---------------------------------------------------------------+
 
 ----

--- a/source/configure/reporting-configuration-settings.rst
+++ b/source/configure/reporting-configuration-settings.rst
@@ -39,7 +39,7 @@ Team statistics
 | number of public and private channels, total post count, and  | - ``config.json`` setting: N/A                                |
 | count of paid users (self-hosted only).                       | - Environment variable: N/A                                   |
 +---------------------------------------------------------------+---------------------------------------------------------------+
-| **Note**: Deactivated users are not counted towards the total number of active users.                                      |
+| **Note**: Deactivated users are not counted towards the total number of active users.                                          |
 +---------------------------------------------------------------+---------------------------------------------------------------+
 
 ----


### PR DESCRIPTION
Remove incorrect usage of "inactive" in this page.

Inactive users are still counted as an activated users.

An "inactive user" are not the same as a "deactivated user".

Also updated the "remote users" usage relating to MS Teams and used the correct "synthetic users" terminology

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

