### PR TITLE
Correct typograph `member` in the disable-apps-bar item on configure disable-data-refetching-on-browser-refocus page

### DIFF
--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -634,7 +634,7 @@ This setting disables re-fetching of channel and channel members on browser focu
 
 **True**: Mattermost won't refetch channels and channel members when the browser regains focus. This may result in improved performance for users with many channels and channel members.
 
-**False**: (Default) Mattermost will refetch channels and channel emmbers when the browser regains focus.
+**False**: (Default) Mattermost will refetch channels and channel members when the browser regains focus.
 
 +--------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"ExperimentalSettings.DisableRefetchingOnBrowserFocus": false`` with options ``true`` and ``false``. |


### PR DESCRIPTION
#### Summary
Correcting a typographical error `member` in [docs page of configure/experimental-configuration-settings](https://docs.mattermost.com/configure/experimental-configuration-settings.html#disable-data-refetching-on-browser-refocus)


This is my first time contributing！