### PR TITLE
Fix typo in Slack migration docs

### DIFF
--- a/source/onboard/migrate-from-slack.rst
+++ b/source/onboard/migrate-from-slack.rst
@@ -6,7 +6,7 @@ Migrate from Slack
 
 .. note::
 
-  `Slack's data control policies may change at any time <https://twitter.com/Austen/status/1752064934970896626>`_. Also, Slack may choose to changes its export capabilities, and/or charge fees to customers for exporting data stored in Slack. Support for negotiating export of customer IP from Slack Enterprise can be requested by `contacting Mattermost sales team <https://mattermost.com/contact-sales/>`_.
+  `Slack's data control policies may change at any time <https://twitter.com/Austen/status/1752064934970896626>`_. Also, Slack may choose to change its export capabilities, and/or charge fees to customers for exporting data stored in Slack. Support for negotiating export of customer IP from Slack Enterprise can be requested by `contacting Mattermost sales team <https://mattermost.com/contact-sales/>`_.
 
 Migrating from Slack to Mattermost involves the following steps:
 


### PR DESCRIPTION
#### Summary
Fix typo in Slack migration docs.

#### Ticket Link
NONE