### PR TITLE
Added new error codes docs page + safety limit code

### DIFF
--- a/source/guides/cloud-workspace-management.rst
+++ b/source/guides/cloud-workspace-management.rst
@@ -1,6 +1,12 @@
 Cloud workspace management
 ==========================
 
+This section of the guide is for system admins of Mattermost Cloud deployments.
+
+.. tip::
+    
+    If you're the admin for a Mattermost self-hosted workspace, see the `Self-hosted administration </guides/self-hosted-administration.html>`__ documentation.
+
 .. toctree::
     :maxdepth: 1
     :hidden:

--- a/source/guides/self-hosted-administration.rst
+++ b/source/guides/self-hosted-administration.rst
@@ -1,7 +1,11 @@
 Self-hosted administration
 ==========================
 
-This section of the guide is for system admins of self-hosted Mattermost servers. If you're the admin for a Mattermost Cloud workspace, please refer to the `Cloud workspace management </guides/administration.html#cloud-workspace-management>`__ section on this page.
+This section of the guide is for system admins of self-hosted Mattermost servers.
+
+.. tip::
+    
+    If you're the admin for a Mattermost Cloud workspace, see the `Cloud workspace management </guides/cloud-workspace-management.html>`__ documentation.
 
 .. toctree::
     :maxdepth: 1
@@ -9,6 +13,7 @@ This section of the guide is for system admins of self-hosted Mattermost servers
     :titlesonly:
 
     Mattermost self-hosted billing </manage/self-hosted-billing>
+    Mattermost error codes </manage/error-codes>
     Store configuration in the database </configure/configuation-in-a-database>
     Bulk loading data </onboard/bulk-loading-data>
     SMTP email setup </configure/smtp-email>
@@ -28,6 +33,7 @@ This section of the guide is for system admins of self-hosted Mattermost servers
     Manage telemetry </manage/telemetry>
 
 * :doc:`Mattermost self-hosted billing </manage/self-hosted-billing>` - Manage your Mattermost subscription.
+* :doc:`Mattermost error codes </manage/error-codes>` - Learn more about the error code you're encountering in Mattermost.
 * :doc:`Include configuration in the Mattermost database </configure/configuation-in-a-database>` - Store Mattermost configuration information in your database rather than as a JSON file. We recommend this for High Availability environments.
 * :doc:`Bulk loading data </onboard/bulk-loading-data>` - Import bulk data into Mattermost for teams, channels, users, post content, and more.
 * :doc:`SMTP email setup </configure/smtp-email>` - Connect to an email server to send emails for password resets and system notifications.

--- a/source/manage/error-codes.rst
+++ b/source/manage/error-codes.rst
@@ -1,0 +1,26 @@
+Mattermost error codes
+======================
+
+.. include:: ../_static/badges/allplans-selfhosted.rst
+  :start-after: :nosearch:
+
+Mattermost is designed to deploy in private networks which may be disconnected or “air-gapped” from the internet. In these deployments, links to Mattermost’s online documentation may be unavailable. 
+
+Therefore, Mattermost error codes are provided to enable administrators to use internet connected machines to look up error messages and resolutions in online resources, including Mattermost documentation and user forums, as well as providing Mattermost support teams a concise way to identify issues.
+
+Mattermost error codes are used in logs, administrative tools, as well as on-screen messages to concisely identify issues and connect them with additional resources. 
+
+In advanced deployments, error codes can be overwritten by administrators to reference internal documentation and guides.
+
+ERROR_SAFETY_LIMITS_EXCEEDED
+----------------------------
+
+This error happens in the free version of Mattermost when more than 10,000 users are registered on the server.
+
+The free version of Mattermost is intended for approximately 50 users, and should a deployment materially exceed this recommended size, administrators should seek to either `purchase a commercial license <https://mattermost.com/pricing/>`__ or apply for a `nonprofit license <https://mattermost.com/nonprofit/>`__.
+
+When usage grossly exceeds the recommended limit for users in a safe deployment, an error message is displayed and certain functionality may be limited.
+
+10,000 users represents a “high upper limit” for deployments that are approximately 200 times the recommended size, which is far beyond the intended design of the product. 
+
+To remove the error message, deactivate users until your user count is below the high upper limit.


### PR DESCRIPTION
Documentation for: https://github.com/mattermost/mattermost/pull/25797

New page preview: http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/6908/manage/error-codes.html

Page content driven by: https://docs.google.com/document/d/1Umab1BZc1CPqd0LOZWmrxJxs6__QlYmMF8_MzyfISWA/edit#heading=h.37oitzqj4thz

PL link requested via https://docs.google.com/spreadsheets/d/1O601H_A0IM8pR3FOfue29_C8flGV7xK3ts-tJUVDHHg/edit#gid=607040777