### PR TITLE
Adjust styles for yaml code block

### DIFF
--- a/source/_static/mytheme.css
+++ b/source/_static/mytheme.css
@@ -3263,3 +3263,24 @@ mark {
 		word-break: break-all;
 	}
 }
+
+/* YAML formatting for existing code-block class */
+
+.highlight-yaml {
+	background-color: #ECF0F9 !important;
+	border: none !important;
+	border-radius: 5px;
+}
+
+.highlight-yaml pre {
+	font-family: Fira Mono, monospace !important;
+    font-size: 13px !important;
+}
+
+.highlight-yaml pre span:not(.nt) {
+	color: #1C58D9 !important;
+}
+
+.highlight-yaml pre span.c1 {
+	color: #408090 !important;
+}

--- a/source/_static/mytheme.css
+++ b/source/_static/mytheme.css
@@ -3199,6 +3199,7 @@ mark {
 	padding: 18px 15px;
 	border: none !important;
 	display: inline-block;
+	max-width: 100%;
 }
 
 @media (max-width: 720px) {
@@ -3264,23 +3265,19 @@ mark {
 	}
 }
 
-/* YAML formatting for existing code-block class */
-
-.highlight-yaml {
-	background-color: #ECF0F9 !important;
-	border: none !important;
-	border-radius: 5px;
+/* YAML formatting for mm-code-block class */
+.mm-code-block.highlight-yaml pre {
+	white-space: pre !important;
 }
 
-.highlight-yaml pre {
-	font-family: Fira Mono, monospace !important;
-    font-size: 13px !important;
-}
-
-.highlight-yaml pre span:not(.nt) {
+.mm-code-block.highlight-yaml pre span:not(.nt) {
 	color: #1C58D9 !important;
 }
 
-.highlight-yaml pre span.c1 {
+.mm-code-block.highlight-yaml pre span.nt {
+	color: #062873 !important;
+}
+
+.mm-code-block.highlight-yaml pre span.c1 {
 	color: #408090 !important;
 }

--- a/source/conf.py
+++ b/source/conf.py
@@ -3453,7 +3453,7 @@ html_static_path = ["_static"]
 # A list of CSS files. The entry must be a filename string or a tuple containing the filename string and the attributes
 # dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like
 # https://example.org/style.css. The attributes is used for attributes of <link> tag. It defaults to an empty list.
-html_css_files = ["mytheme.css?version=v47", "css/compass-icons.css"]
+html_css_files = ["mytheme.css?version=v50", "css/compass-icons.css"]
 
 # A list of JavaScript filenames. The entry must be a filename string or a tuple containing the filename string and the
 # attributes dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like

--- a/source/conf.py
+++ b/source/conf.py
@@ -3453,7 +3453,7 @@ html_static_path = ["_static"]
 # A list of CSS files. The entry must be a filename string or a tuple containing the filename string and the attributes
 # dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like
 # https://example.org/style.css. The attributes is used for attributes of <link> tag. It defaults to an empty list.
-html_css_files = ["mytheme.css?version=v50", "css/compass-icons.css"]
+html_css_files = ["mytheme.css?version=v52", "css/compass-icons.css"]
 
 # A list of JavaScript filenames. The entry must be a filename string or a tuple containing the filename string and the
 # attributes dictionary. The filename must be relative to the html_static_path, or a full URI with scheme like

--- a/source/install/faq_kubernetes.rst
+++ b/source/install/faq_kubernetes.rst
@@ -43,6 +43,7 @@ This can be caused by the default ``proxy-buffer-size`` setting for NGINX Ingres
 To fix this issue, configure an appropriate buffer size (8k or 16k should be sufficient for most cases) with NGINX annotation by adding it to the Mattermost manifest under ``spec.ingressAnnotations``:
 
 .. code-block:: yaml
+  :class: mm-code-block 
 
   ...
   spec:

--- a/source/install/install-kubernetes.rst
+++ b/source/install/install-kubernetes.rst
@@ -44,6 +44,7 @@ Deploy Mattermost
 1. (Mattermost Enterprise only) Create a Mattermost license secret by opening a text editor and creating a secret manifest containing the Mattermost license. Replace ``[LICENSE_FILE_CONTENTS]`` below with the contents of your Mattermost license file. Save the file as ``mattermost-license-secret.yaml``.
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
     apiVersion: v1
     kind: Secret
@@ -56,6 +57,7 @@ Deploy Mattermost
 2. Create an installation manifest file locally in a text editor by copying and pasting contenst from the Mattermost installation manifest, and adjusting fields for your configuration and environment. 
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
       apiVersion: installation.mattermost.com/v1beta1
       kind: Mattermost
@@ -99,6 +101,7 @@ Deploy Mattermost
   Example secret for AWS Aurora compatible with PostgreSQL:
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
     apiVersion: v1
     data:
@@ -125,6 +128,7 @@ Deploy Mattermost
   Example secret for AWS S3:
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
     apiVersion: v1
     data:
@@ -140,6 +144,7 @@ Deploy Mattermost
   To instruct Mattermost Operator to use the external database, modify Mattermost manifest by adding the following fields:
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
     spec:
     ...
@@ -150,6 +155,7 @@ Deploy Mattermost
   To instruct Mattermost Operator to use the external filestore, modify Mattermost manifest by adding the following fields:
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
     spec:
     ...
@@ -162,6 +168,7 @@ Deploy Mattermost
   Additionally when using Amazon S3, set the ``MM_FILESETTINGS_AMAZONS3SSE`` and ``MM_FILESETTINGS_AMAZONS3SSL`` environment variables to ``true``:
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
     spec:
     ...
@@ -175,6 +182,7 @@ Deploy Mattermost
   Example Mattermost manifest configured with both external databases and filestore:
 
   .. code-block:: yaml
+    :class: mm-code-block 
 
     apiVersion: installation.mattermost.com/v1beta1
     kind: Mattermost


### PR DESCRIPTION
#### Summary
Flagged in https://github.com/mattermost/docs/pull/6782. This PR fixes the indentation bug when using `:class: mm-code-block` for YAML snippets. Changes in `source/install/install-kubernetes.rst`.

@cwarnermm for visibility. TY!

#### Ticket Link
https://app.asana.com/0/1201867728201087/1206097158557325/f

