### PR TITLE
Update mmctl-command-line-tool.rst

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -1929,6 +1929,13 @@ Migrate a file-based configuration to (or from) a database-based configuration. 
 
    To change the store type to use the database, a System Admin needs to set a ``MM_CONFIG`` `environment variable </configure/configuation-in-a-database.html#create-an-environment-file>`_ and restart the Mattermost server.
 
+.. note::
+
+   The `migrate` function requires local mode to be enabled.  To do this, add the following line to your Mattermost Environment file:
+   .. code-block:: sh
+
+      MM_SERVICESETTINGS_ENABLELOCALMODE=true
+
 **Format**
 
 .. code-block:: sh
@@ -1939,7 +1946,7 @@ Migrate a file-based configuration to (or from) a database-based configuration. 
 
 .. code-block:: sh
 
-   mmctl config migrate path/to/config.json "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+   mmctl config migrate path/to/config.json "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10" --local
 
 **Options**
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -1931,7 +1931,8 @@ Migrate a file-based configuration to (or from) a database-based configuration. 
 
 .. note::
 
-   The `migrate` function requires local mode to be enabled.  To do this, add the following line to your Mattermost Environment file:
+   The ``migrate`` function requires local mode to be enabled.  To do this, add the following line to your Mattermost Environment file:
+
    .. code-block:: sh
 
       MM_SERVICESETTINGS_ENABLELOCALMODE=true

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -1927,15 +1927,12 @@ Migrate a file-based configuration to (or from) a database-based configuration. 
 
 .. note::
 
-   To change the store type to use the database, a System Admin needs to set a ``MM_CONFIG`` `environment variable </configure/configuation-in-a-database.html#create-an-environment-file>`_ and restart the Mattermost server.
+   - To change the store type to use the database, a System Admin needs to set a ``MM_CONFIG`` `environment variable </configure/configuation-in-a-database.html#create-an-environment-file>`_ and restart the Mattermost server.
+   - The ``migrate`` function requires local mode to be enabled.  To do this, add the following line to your Mattermost Environment file:
 
-.. note::
+      .. code-block:: sh
 
-   The ``migrate`` function requires local mode to be enabled.  To do this, add the following line to your Mattermost Environment file:
-
-   .. code-block:: sh
-
-      MM_SERVICESETTINGS_ENABLELOCALMODE=true
+         MM_SERVICESETTINGS_ENABLELOCALMODE=true
 
 **Format**
 


### PR DESCRIPTION
Additional info needed in order to do an initial `mmctl config migrate`

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When initially setting up config in a database, we need to run `mmctl config migrate`, but the docs didn't include the need to run in local mode.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

