### PR TITLE
Update editions-and-offerings to match pricing page changes

### DIFF
--- a/source/about/editions-and-offerings.rst
+++ b/source/about/editions-and-offerings.rst
@@ -64,8 +64,7 @@ Mattermost Free is available to our self-hosted community through both our open 
 
 Features include:
 
-- Unlimited teams and channels for one-to-one and group messaging, file sharing, and unlimited search history with threaded messaging, emoji, and custom emoji.
-- Unlimited playbooks with ad hoc add/remove tasks, automated triggers, and stakeholders dashboard.
+- Teams and channels for one-to-one and group messaging, file sharing, and unlimited search history with threaded messaging, emoji, and custom emoji.
 - Native apps for iOS, Android, Windows, macOS, and Linux.
 - Pre-packaged integrations with most common developer tools, including Jira, Confluence, GitHub, GitLab, CircleCI, Zoom, Jitsi, and more.
 - Tools for `custom branding </configure/custom-branding-tools.html>`__ and `themes </messaging/customizing-theme-colors.html>`__.
@@ -118,6 +117,7 @@ This offering includes all the features of Mattermost Professional, plus:
 - `Advanced legal controls with customizable end-user terms of service and re-acceptance duration </comply/custom-terms-of-service.html>`__.
 - `Private mobility with ID-only push notifications </configure/site-configuration-settings.html#notification-pushnotificationcontents>`__.
 - `Enhanced compliance with global and custom retention policies for messages and files </comply/data-retention-policy.html>`__.
+- `Playbooks with ad hoc add/remove tasks, automated triggers, and stakeholders dashboard <https://docs.mattermost.com/playbooks/get-started-with-playbooks.html>`__.
 - `Granular administrative control with custom system admin roles </onboard/system-admin-roles.html>`__.
 - `Advanced configuration of playbook permissions, analytics dashboards, and channel exports </repeatable-processes/share-and-collaborate.html>`__.
 - `Enhanced compliance controls and granular audit logs with data export </manage/logging.html#audit-logging-experimental-beta>`__.

--- a/source/about/editions-and-offerings.rst
+++ b/source/about/editions-and-offerings.rst
@@ -117,7 +117,7 @@ This offering includes all the features of Mattermost Professional, plus:
 - `Advanced legal controls with customizable end-user terms of service and re-acceptance duration </comply/custom-terms-of-service.html>`__.
 - `Private mobility with ID-only push notifications </configure/site-configuration-settings.html#notification-pushnotificationcontents>`__.
 - `Enhanced compliance with global and custom retention policies for messages and files </comply/data-retention-policy.html>`__.
-- `Playbooks with ad hoc add/remove tasks, automated triggers, and stakeholders dashboard <https://docs.mattermost.com/playbooks/get-started-with-playbooks.html>`__.
+- `Playbooks with ad hoc add/remove tasks, automated triggers, and stakeholders dashboard </repeatable-processes/learn-about-playbooks.html>`__.
 - `Granular administrative control with custom system admin roles </onboard/system-admin-roles.html>`__.
 - `Advanced configuration of playbook permissions, analytics dashboards, and channel exports </repeatable-processes/share-and-collaborate.html>`__.
 - `Enhanced compliance controls and granular audit logs with data export </manage/logging.html#audit-logging-experimental-beta>`__.


### PR DESCRIPTION
Removing "unlimited" moving Playbooks to enterprise per agreement with CIL on new packaging--Playbooks code base continues to be available, just not automatically compiled in outside of Enterprise, so we can support it more easily. 

Probably other updates coming here, but at least we can knock out two.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

