### PR TITLE
fix: synced s3 files to remove outdated pages and corrected typo error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,4 +27,4 @@ jobs:
         path: build/html
     - name: cd/Upload artifacts to S3
       run: |
-        aws s3 cp build/html s3://docs.mattermost.com/ --recursive --cache-control no-cache --acl public-read --no-progress
+        aws s3 sync build/html s3://docs.mattermost.com/ --delete --cache-control no-cache --acl public-read --no-progress

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -201,7 +201,7 @@ The following additional documentation resources are also available for the Matt
 Troubleshooting your Desktop App installation
 ----------------------------------------------
 
-Where is configuation stored locally?
+Where is configuration stored locally?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The location of the Mattermost desktop app configuration file depends on the platform where you're running Mattermost (and, in the case of macOS, how you've chosen to install the app):

--- a/source/conf.py
+++ b/source/conf.py
@@ -139,11 +139,11 @@ redirects = {
 "administration/compliance-export.html":
         "https://docs.mattermost.com/comply/compliance-export.html",
 "administration/config-in-database.html":
-        "https://docs.mattermost.com/configure/configuation-in-a-database.html",
+        "https://docs.mattermost.com/configure/configuration-in-a-database.html",
 "administration/config-in-database.html#configuration-in-a-database.html":
-        "https://docs.mattermost.com/configure/configuation-in-a-database.html",
+        "https://docs.mattermost.com/configure/configuration-in-a-database.html",
 "administration/config-in-database.html#configuration-in-the-mattermost-database":
-        "https://docs.mattermost.com/configure/configuation-in-a-database.html",
+        "https://docs.mattermost.com/configure/configuration-in-a-database.html",
 "administration/config-settings.html#enable-hardened-mode-experimental":
 	"https://docs.mattermost.com/configure/experimental-configuration-settings.html#enable-hardened-mode",
 "administration/data-retention.html":
@@ -245,7 +245,7 @@ redirects = {
 "administration/config-settings.html#ad-ldap":
         "https://docs.mattermost.com/configure/configuration-settings.html#ad-ldap",
 "administration/config-in-database.html":
-	"https://docs.mattermost.com/configure/configuation-in-a-database.html",
+	"https://docs.mattermost.com/configure/configuration-in-a-database.html",
 "administration/config-settings.html#customization":
         "https://docs.mattermost.com/configure/configuration-settings.html#customization",
 "administration/config-settings.html#default-channels-experimental":
@@ -815,7 +815,7 @@ redirects = {
 
 # Configuration settings redirects
 "configure/configuration-in-mattermost-database.html":
-        "https://docs.mattermost.com/configure/configuation-in-a-database.html",
+        "https://docs.mattermost.com/configure/configuration-in-a-database.html",
 "configure/configuration-settings.html#channels":
         "https://docs.mattermost.com/configure/user-management-configuration-settings.html#channels",
 "configure/configuration-settings.html#allow-use-of-api-v3-endpoints":
@@ -1768,8 +1768,8 @@ redirects = {
         "https://docs.mattermost.com/manage/logging.html#syslog-target-configuration-options",
 "configure/experimental-configuration-settings.html#syslog-max-queue-size":
         "https://docs.mattermost.com/manage/logging.html#syslog-target-configuration-options",
-"configure/configuation-in-mattermost-database.html":
-        "https://docs.mattermost.com/configure/configuation-in-a-database.html",
+"configure/configuration-in-mattermost-database.html":
+        "https://docs.mattermost.com/configure/configuration-in-a-database.html",
 
 # Deploy redirects
 "deploy/mobile-apps-faq.html":

--- a/source/configure/configuration-settings.rst
+++ b/source/configure/configuration-settings.rst
@@ -24,7 +24,7 @@ Mattermost configuration settings are organized into the following categories wi
 - :doc:`Compliance configuration settings </configure/compliance-configuration-settings>`
 - :doc:`Experimental configuration settings </configure/experimental-configuration-settings>`
 
-In self-hosted Mattermost deployments, configuration settings are maintained in the ``config.json`` configuration file, located in the ``mattermost/config`` directory, or `stored in the database <https://docs.mattermost.com/configure/configuation-in-a-database.html>`__. System Admins managing self-hosted workspaces can also modify the ``config.json`` file directly using a text editor.
+In self-hosted Mattermost deployments, configuration settings are maintained in the ``config.json`` configuration file, located in the ``mattermost/config`` directory, or `stored in the database <https://docs.mattermost.com/configure/configuration-in-a-database.html>`__. System Admins managing self-hosted workspaces can also modify the ``config.json`` file directly using a text editor.
 
 Configuration in database
 --------------------------
@@ -32,7 +32,7 @@ Configuration in database
 .. include:: ../_static/badges/selfhosted-only.rst
   :start-after: :nosearch:
 
-Self-hosted system configuration can be stored in the database. This changes the Mattermost binary from reading the default ``config.json`` file to reading the configuration settings stored within a configuration table in the database. See the `Mattermost database configuration </configure/configuation-in-a-database.html>`__ documentation for migration details.
+Self-hosted system configuration can be stored in the database. This changes the Mattermost binary from reading the default ``config.json`` file to reading the configuration settings stored within a configuration table in the database. See the `Mattermost database configuration </configure/configuration-in-a-database.html>`__ documentation for migration details.
 
 Environment variables
 ---------------------

--- a/source/configure/environment-variables.rst
+++ b/source/configure/environment-variables.rst
@@ -21,7 +21,7 @@ The name of the environment variable for any setting can be derived from the nam
 
 .. warning::
    
-   - Environment variables for Mattermost settings that are set within the active shell will take effect when migrating configuration. For more information, see the `configuration in a database </configure/configuation-in-a-database.html>`__ documentation.
+   - Environment variables for Mattermost settings that are set within the active shell will take effect when migrating configuration. For more information, see the `configuration in a database </configure/configuration-in-a-database.html>`__ documentation.
    - Database connection strings for the database read and search replicas need to be formatted using `URL encoding <https://www.w3schools.com/tags/ref_urlencode.asp>`__. Incorrectly formatted strings may cause some characters to terminate the string early, resulting in issues when the connection string is parsed.
    
 Override Mattermost license file

--- a/source/getting-started/enterprise-roll-out-checklist.rst
+++ b/source/getting-started/enterprise-roll-out-checklist.rst
@@ -140,7 +140,7 @@ Much of the preparation work is focused on ensuring the environment is deployed 
 
   - (Optional) Set up configuration management via the database instead of a config file for high available environments
 
-   - Resource: https://docs.mattermost.com/configure/configuation-in-a-database.html
+   - Resource: https://docs.mattermost.com/configure/configuration-in-a-database.html
 
  - Install and configure File Storage
 

--- a/source/guides/self-hosted-administration.rst
+++ b/source/guides/self-hosted-administration.rst
@@ -14,7 +14,7 @@ This section of the guide is for system admins of self-hosted Mattermost servers
 
     Mattermost self-hosted billing </manage/self-hosted-billing>
     Mattermost error codes </manage/error-codes>
-    Store configuration in the database </configure/configuation-in-a-database>
+    Store configuration in the database </configure/configuration-in-a-database>
     Bulk loading data </onboard/bulk-loading-data>
     SMTP email setup </configure/smtp-email>
     Email templates </configure/email-templates>
@@ -34,7 +34,7 @@ This section of the guide is for system admins of self-hosted Mattermost servers
 
 * :doc:`Mattermost self-hosted billing </manage/self-hosted-billing>` - Manage your Mattermost subscription.
 * :doc:`Mattermost error codes </manage/error-codes>` - Learn more about the error code you're encountering in Mattermost.
-* :doc:`Include configuration in the Mattermost database </configure/configuation-in-a-database>` - Store Mattermost configuration information in your database rather than as a JSON file. We recommend this for High Availability environments.
+* :doc:`Include configuration in the Mattermost database </configure/configuration-in-a-database>` - Store Mattermost configuration information in your database rather than as a JSON file. We recommend this for High Availability environments.
 * :doc:`Bulk loading data </onboard/bulk-loading-data>` - Import bulk data into Mattermost for teams, channels, users, post content, and more.
 * :doc:`SMTP email setup </configure/smtp-email>` - Connect to an email server to send emails for password resets and system notifications.
 * :doc:`Email templates </configure/email-templates>` - Alter the transactional emails Mattermost sends to your users.

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -1927,7 +1927,7 @@ Migrate a file-based configuration to (or from) a database-based configuration. 
 
 .. note::
 
-   - To change the store type to use the database, a System Admin needs to set a ``MM_CONFIG`` `environment variable </configure/configuation-in-a-database.html#create-an-environment-file>`_ and restart the Mattermost server.
+   - To change the store type to use the database, a System Admin needs to set a ``MM_CONFIG`` `environment variable </configure/configuration-in-a-database.html#create-an-environment-file>`_ and restart the Mattermost server.
    - The ``migrate`` function requires local mode to be enabled.  To do this, add the following line to your Mattermost Environment file:
 
       .. code-block:: sh


### PR DESCRIPTION
#### Summary
Use `aws s3 sync <bucket> --delete` instead of `cp` to sync all files in a directory and delete if file/s exist at destination but not from source.

Other: Fixed typo error from `configuation` to `configuration`.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7192

