### PR TITLE
[MM-57086] Remove UseGossip setting

### DIFF
--- a/source/configure/deprecated-configuration-settings.rst
+++ b/source/configure/deprecated-configuration-settings.rst
@@ -564,6 +564,20 @@ A list of all the machines in the cluster, such as ``["http://10.10.10.2", "http
 | This feature's ``config.json`` setting is ``"InterNodeUrls": []`` with string array input consisting of the machines in the cluster. |
 +--------------------------------------------------------------------------------------------------------------------------------------+
 
+Use gossip
+~~~~~~~~~~~~~~~
+
+*Removed in Mattermost v6.0*
+
+**True**: The server attempts to communicate via the gossip protocol over the gossip port specified.
+
+**False**: The server attempts to communicate over the streaming port.
+
++--------------------------------------------------------------------------------------------------------------------------------------+
+| This feature’s config.json setting is ``"UseExperimentalGossip": true`` with options ``true`` and ``false``.                         |
++--------------------------------------------------------------------------------------------------------------------------------------+
+
+
 ----
 
 REST API V3 settings

--- a/source/configure/high-availability-configuration-settings.rst
+++ b/source/configure/high-availability-configuration-settings.rst
@@ -117,36 +117,6 @@ Use IP address
   - **true**: **(Default)** The server attempts to communicate via the gossip protocol over the gossip port specified.
   - **false**: The server attempts to communicate over the streaming port.
 
-Use gossip
-~~~~~~~~~~
-
-.. raw:: html
-
- <p class="mm-label-note">Also available in legacy Mattermost Enterprise Edition E20</p>
-
-+-----------------------------------------------------------------+--------------------------------------------------------------------------------+
-| All cluster traffic uses the gossip protocol.                   | - System Config path: **Environment > High Availability**                      |
-|                                                                 | - ``config.json`` setting: ``".ClusterSettings.UseExperimentalGossip: true",`` |
-| - **true**: **(Default)** The server attempts to communicate    | - Environment variable: ``MM_CLUSTERSETTINGS_USEEXPERIMENTALGOSSIP``           |
-|   via the gossip protocol over the gossip port specified.       |                                                                                |
-| - **false**: The server attempts to communicate over the        |                                                                                |
-|   streaming port.                                               |                                                                                |
-+-----------------------------------------------------------------+--------------------------------------------------------------------------------+
-| **Notes**:                                                                                                                                       |
-|                                                                                                                                                  |
-| - Gossip clustering can no longer be disabled.                                                                                                   |
-| - The gossip port and gossip protocol are used to determine cluster health even when this setting is set to **false**.                           |
-+-----------------------------------------------------------------+--------------------------------------------------------------------------------+
-
-.. config:setting:: ha-gossipencryption
-  :displayname: Enable experimental gossip encryption (High Availability)
-  :systemconsole: Environment > High Availability
-  :configjson: .ClusterSettings.EnableExperimentalGossipEncryption
-  :environment: MM_CLUSTERSETTINGS_ENABLEEXPERIMENTALGOSSIPENCRYPTION
-
-  - **true**: All communication through the cluster using the gossip protocol will be encrypted.
-  - **false**: **(Default)** All communication using gossip protocol remains unencrypted.
-
 Enable experimental gossip encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/scale/high-availability-cluster.rst
+++ b/source/scale/high-availability-cluster.rst
@@ -85,7 +85,6 @@ Configuration settings
             "ClusterName": "production",
             "OverrideHostname": "",
             "UseIpAddress": true,
-            "UseGossip": true,
             "ReadOnlyConfig": true,
             "GossipPort": 8074,
             "StreamingPort": 8075
@@ -477,7 +476,6 @@ When a server starts up, it can automatically discover other servers in the same
         "ClusterName": "production",
         "OverrideHostname": "",
         "UseIpAddress": true,
-        "UseGossip": true,
         "ReadOnlyConfig": true,
         "GossipPort": 8074,
         "StreamingPort": 8075


### PR DESCRIPTION
#### Summary
`ClusterSettings.UseGossip` was removed via https://github.com/mattermost/mattermost/pull/18035 in `v6.0.0`. The docs should reflect that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57086
