### PR TITLE
fix a typo in the migration doc

### DIFF
--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -48,7 +48,7 @@ Before the migration
    - See the `schema-diffs <#schema-diffs>`__ section to ensure data compatibility between schemas.
    - Prepare your PostgreSQL environment by creating a database and user. See the `database </install/prepare-mattermost-database.html>`__ documentation for details.
    - If you are planning to run an iterative migration (running the pgloader several times), please see the `iterative-migrations <#iterative-migrations>`_ section.
-   - On `newer versions <https://www.postgresql.org/docs/release/15.0/>`__ of PostgreSQL, newly created users do not have access to ``public`` schema. The access should be explicitly granted by running ``GRANT ALL ON SCHEMA public to mmuser'``.
+   - On `newer versions <https://www.postgresql.org/docs/release/15.0/>`__ of PostgreSQL, newly created users do not have access to ``public`` schema. The access should be explicitly granted by running ``GRANT ALL ON SCHEMA public to mmuser``.
 
 Prepare target database
 -----------------------


### PR DESCRIPTION

#### Summary
Just a small typo in the MySQL->Postgres migration documentation.

