### PR TITLE
Patch 1

### DIFF
--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -40,6 +40,7 @@ SSL and HTTP/2 with server push are enabled in the provided configuration exampl
 
     server {
        listen 443 ssl http2;
+       listen [::]:443 ssl http2;
        server_name    mattermost.example.com;
 
        http2_push_preload on; # Enable HTTP/2 Server Push

--- a/source/install/config-proxy-nginx.rst
+++ b/source/install/config-proxy-nginx.rst
@@ -45,7 +45,6 @@ SSL and HTTP/2 with server push are enabled in the provided configuration exampl
 
        http2_push_preload on; # Enable HTTP/2 Server Push
 
-       ssl on;
        ssl_certificate /etc/letsencrypt/live/{domain-name}/fullchain.pem;
        ssl_certificate_key /etc/letsencrypt/live/{domain-name}/privkey.pem;
        ssl_session_timeout 1d;


### PR DESCRIPTION
#### Summary
<!--
added two lines to the nginx config: One to listen on IPv6 by default, and one to remove the "ssl on;" statement, which is deprecated and no longer necessary, because it's already enabled by "listen ... ssl".
-->

