### PR TITLE
Update SqlSettings.MaxIdleConns default setting

### DIFF
--- a/source/configure/database-configuration-settings.rst
+++ b/source/configure/database-configuration-settings.rst
@@ -153,7 +153,7 @@ Data source
   :systemconsole: Environment > Database
   :configjson: SqlSettings.MaxIdleConns
   :environment: MM_SQLSETTINGS_MAXIDLECONNS
-  :description: The maximum number of idle connections held open to the database. Default is **10**.
+  :description: The maximum number of idle connections held open to the database. Default is **20**.
 
 Maximum idle database connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
Per https://github.com/mattermost/mattermost/blob/98712737e600e8b11e7d72ea90faa266227aa855/server/public/model/config.go#L1236-L1238.

It seems like the default setting was always at 20, and the docs were always incorrect.

#### Ticket Link
None

