### PR TITLE
IS-7052: Prefixing channel names with tilde (~) in product docs not clear

### DIFF
--- a/source/guides/community-chat.rst
+++ b/source/guides/community-chat.rst
@@ -6,21 +6,21 @@ Connect with thousands of contributors, customers, partners, and users to build,
 General channels
 ----------------
 
-- `~Contributors <https://community.mattermost.com/core/channels/tickets>`__
-- `~Community Team <https://community.mattermost.com/core/channels/community-team>`__
-- `~Developers <https://community.mattermost.com/core/channels/developers>`__
-- `~New Channel Notifications <https://community.mattermost.com/core/channels/new-channel-notifications>`__
-- `~Off-Topic <https://community.mattermost.com/core/channels/off-topic-pub>`__
-- `~Reception <https://community.mattermost.com/core/channels/town-square>`__
+- `Contributors <https://community.mattermost.com/core/channels/tickets>`__
+- `Community Team <https://community.mattermost.com/core/channels/community-team>`__
+- `Developers <https://community.mattermost.com/core/channels/developers>`__
+- `New Channel Notifications <https://community.mattermost.com/core/channels/new-channel-notifications>`__
+- `Off-Topic <https://community.mattermost.com/core/channels/off-topic-pub>`__
+- `Reception <https://community.mattermost.com/core/channels/town-square>`__
 
 Technical support channels
 --------------------------
 
 To familiarize yourself with our community support process, start by reading the :doc:`Get Help </guides/get-help>` documentation page.
 
-- `~Ask Anything <https://community.mattermost.com/core/channels/ask-anything>`__
-- `~Bugs <https://community.mattermost.com/core/channels/bugs>`__
-- `~Peer-to-peer Help <https://community.mattermost.com/core/channels/peer-to-peer-help>`__
+- `Ask Anything <https://community.mattermost.com/core/channels/ask-anything>`__
+- `Bugs <https://community.mattermost.com/core/channels/bugs>`__
+- `Peer-to-peer Help <https://community.mattermost.com/core/channels/peer-to-peer-help>`__
 
 We also recommend using the `Troubleshooting forum <https://forum.mattermost.com/c/trouble-shoot/16>`__ for technical support.
 
@@ -29,15 +29,15 @@ Contributor community channels
 
 To familiarize yourself with our community contribution process, start by exploring the `Contribute to Mattermost <https://mattermost.com/contribute/>`__ documentation.
 
-- `~AI Exchange <https://community.mattermost.com/core/channels/ai-exchange>`__
-- `~Developers: Meeting <https://community.mattermost.com/core/channels/developers-meeting>`__
-- `~DWG: Documentation Working Group <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`__
-- `~Feature Proposals <https://community.mattermost.com/core/channels/feature-ideas>`__
-- `~i18n - Localization <https://community.mattermost.com/core/channels/localization>`__
-- `~Open Source Fridays (OSF) <https://community.mattermost.com/core/channels/open-source-fridays>`__
-- `~Public Speakers <https://community.mattermost.com/core/channels/public-speakers>`__
-- `~QA: Contributors <https://community.mattermost.com/core/channels/qa-contributors>`__
-- `~Thank you! <https://community.mattermost.com/core/channels/thank-you>`__
+- `AI Exchange <https://community.mattermost.com/core/channels/ai-exchange>`__
+- `Developers: Meeting <https://community.mattermost.com/core/channels/developers-meeting>`__
+- `DWG: Documentation Working Group <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`__
+- `Feature Proposals <https://community.mattermost.com/core/channels/feature-ideas>`__
+- `i18n - Localization <https://community.mattermost.com/core/channels/localization>`__
+- `Open Source Fridays (OSF) <https://community.mattermost.com/core/channels/open-source-fridays>`__
+- `Public Speakers <https://community.mattermost.com/core/channels/public-speakers>`__
+- `QA: Contributors <https://community.mattermost.com/core/channels/qa-contributors>`__
+- `Thank you! <https://community.mattermost.com/core/channels/thank-you>`__
 
 There are many channels that specialize in different areas of the Mattermost platform. To find and join them, search “**Developers:**” in the `LHS <https://handbook.mattermost.com/company/about-mattermost/list-of-terms#lhs>`__ “🔍 Find channel” search bar on the community server.
 

--- a/source/guides/contribute-to-documentation.rst
+++ b/source/guides/contribute-to-documentation.rst
@@ -1,7 +1,7 @@
 Contribute to this documentation
 ================================
 
-Mattermost has a diverse community that extends well beyond code contributions. If you're interested in contributing to Mattermost, why not help improve the documentation? Be sure to join the documentation community in `~DWG: Documentation Working Group <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`_ so we can support and celebrate you!
+Mattermost has a diverse community that extends well beyond code contributions. If you're interested in contributing to Mattermost, why not help improve the documentation? Be sure to join the documentation community in `DWG: Documentation Working Group <https://community.mattermost.com/core/channels/dwg-documentation-working-group>`_ so we can support and celebrate you!
 
 How to get started
 ------------------


### PR DESCRIPTION
## Summary

The Mattermost Community Channel names were prefixed with tilde (~) symbols which was unclear to the users. This PR aims to remove those symbols from channel names throughout the documentation site to make it look more relevant to the users.

## Ticket Link

This PR fixes #7052.

## Checklist
- [x] This PR follows the Contributing Guidelines of Mattermost.

