### PR TITLE
[GH-7075] Use the correct config object for EnableSecurityFixAlert

### DIFF
--- a/source/configure/smtp-configuration-settings.rst
+++ b/source/configure/smtp-configuration-settings.rst
@@ -164,8 +164,8 @@ Skip server certificate verification
 .. config:setting:: smtp-enablesecurityalerts
   :displayname: Enable security alerts (SMTP)
   :systemconsole: Environment > SMTP
-  :configjson: .EmailSettings.EnableSecurityFixAlert
-  :environment: MM_EMAILSETTINGS_ENABLESECURITYFIXALERT
+  :configjson: .ServiceSettings.EnableSecurityFixAlert
+  :environment: MM_SERVICESETTINGS_ENABLESECURITYFIXALERT
 
   - **true**: **(Default)** System Admins are notified by email if a relevant security fix alert is announced. Requires email to be enabled.
   - **false**: Security alerts are disabled.
@@ -177,16 +177,16 @@ Enable security alerts
 
  <p class="mm-label-note">Also available in legacy Mattermost Enterprise Edition E10 or E20</p>
 
-+-----------------------------------------------------------------+----------------------------------------------------------------------------------+
-| Enable or disable security alerts.                              | - System Config path: **Environment > SMTP**                                     |
-|                                                                 | - ``config.json setting``: ``".EmailSettings.EnableSecurityFixAlert": true",``   |
-| - **true**: **(Default)** System Admins are notified by email   | - Environment variable: ``MM_EMAILSETTINGS_ENABLESECURITYFIXALERT``              |
-|   if a relevant security fix alert is announced. Requires email |                                                                                  |
-|   to be enabled.                                                |                                                                                  |
-| - **false**: Security alerts are disabled.                      |                                                                                  |
-+-----------------------------------------------------------------+----------------------------------------------------------------------------------+
-| See the :ref:`Telemetry <manage/telemetry:security update check feature>` documentation to learn more.                                             |
-+-----------------------------------------------------------------+----------------------------------------------------------------------------------+
++-----------------------------------------------------------------+------------------------------------------------------------------------------------+
+| Enable or disable security alerts.                              | - System Config path: **Environment > SMTP**                                       |
+|                                                                 | - ``config.json setting``: ``".ServiceSettings.EnableSecurityFixAlert": true",``   |
+| - **true**: **(Default)** System Admins are notified by email   | - Environment variable: ``MM_SERVICESETTINGS_ENABLESECURITYFIXALERT``              |
+|   if a relevant security fix alert is announced. Requires email |                                                                                    |
+|   to be enabled.                                                |                                                                                    |
+| - **false**: Security alerts are disabled.                      |                                                                                    |
++-----------------------------------------------------------------+------------------------------------------------------------------------------------+
+| See the :ref:`Telemetry <manage/telemetry:security update check feature>` documentation to learn more.                                               |
++-----------------------------------------------------------------+------------------------------------------------------------------------------------+
 
 .. config:setting:: smtp-servertimeout
   :displayname: SMTP server timeout (SMTP)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR updates the documentation for the *EnableSecurityFixAlert* configuration setting to indicate that the setting is actually stored in the *ServiceSettings* config object in `config.json` rather than the *EmailSettings* object.

Definition in the mattermost project: https://github.com/mattermost/mattermost/blob/603c26a5bcda365917285b8f32c6982e170c5cd3/server/public/model/config.go#L331

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/docs/issues/7075