### PR TITLE
IS-7047: Incorrect `incoming webhook` link on Mattermost Performance Alerting Guide Page

### DIFF
--- a/source/scale/performance-alerting.rst
+++ b/source/scale/performance-alerting.rst
@@ -23,7 +23,7 @@ To get alerts, first set up a Notification Channel in Grafana. Here’s how you 
 1. In Mattermost:
 
   a. Create an Alerts channel.
-  b. Create an `incoming webhook <https://developers.mattermost.com/integrate/admin-guide/admin-webhooks-incoming/>`__ for the Alerts channel and copy the URL.
+  b. Create an `incoming webhook <https://developers.mattermost.com/integrate/webhooks/incoming/>`__ for the Alerts channel and copy the URL.
 
 2. In Grafana:
 


### PR DESCRIPTION
## Summary

The `incoming webhook` link available on https://docs.mattermost.com/scale/performance-alerting.html#prerequisites was giving `Page not found` error. This PR updates the link of `incoming webhook` to the correct one.

## Ticket Link

This PR fixes #7047

## Checklist

- [x] This PR follows the Mattermost Contributing Guidelines.
