### PR TITLE
Correct a unit conversion for the FileSettings.MaxFileSize config setting, make clear that IEC units are used

### DIFF
--- a/source/configure/file-storage-configuration-settings.rst
+++ b/source/configure/file-storage-configuration-settings.rst
@@ -70,7 +70,7 @@ Local storage directory
   :systemconsole: Environment > File Storage
   :configjson: .FileSettings.MaxFileSize
   :environment: MM_FILESETTINGS_MAXFILESIZE
-  :description: The maximum file size, in bytes, for message attachments and plugin uploads. Default value is **104857600** bytes (1 megabyte).
+  :description: The maximum file size, in bytes, for message attachments and plugin uploads. Default value is **104857600** bytes (100 mebibytes).
 
 Maximum file size
 ~~~~~~~~~~~~~~~~~
@@ -79,26 +79,26 @@ Maximum file size
 
  <p class="mm-label-note">Also available in legacy Mattermost Enterprise Edition E10 or E20</p>
 
-+---------------------------------------------------------------+--------------------------------------------------------------------------+
-| The maximum file size for message attachments and plugin      | - System Config path: **Environment > File Storage**                     |
-| uploads. This value must be specified in megabytes in the     | - ``config.json`` setting: ``".FileSettings.MaxFileSize: 104857600",``   |
-| System Console, and in bytes in the ``config.json`` file.     | - Environment variable: ``MM_FILESETTINGS_MAXFILESIZE``                  |
-|                                                               |                                                                          |
-| The default is ``104857600`` bytes (**1** megabyte).          |                                                                          |
-+---------------------------------------------------------------+--------------------------------------------------------------------------+
-| **Warning**: Verify server memory can support your setting choice. Large file sizes increase the risk of server crashes and failed       |
-| uploads due to network disruptions.                                                                                                      |
-+---------------------------------------------------------------+--------------------------------------------------------------------------+
-| **Notes**:                                                                                                                               |
-|                                                                                                                                          |
-| - When `uploading plugin files </configure/plugins-configuration-settings.html#upload-plugin>`__, a ``Received invlaid response from     |
-|   the server`` error typically indicates that ``MaxFileSize`` isn't large enough to support the plugin file upload, and/or that proxy    |
-|   settings may not be sufficient.                                                                                                        |
-| - If you use a proxy or load balancer in front of Mattermost, the following proxy settings must be adjusted accordingly:                 |
-|                                                                                                                                          |
-|  - For NGINX, use ``client_max_body_size``.                                                                                              |
-|  - For Apache use ``LimitRequestBody``.                                                                                                  |
-+---------------------------------------------------------------+--------------------------------------------------------------------------+
++-------------------------------------------------------------------+--------------------------------------------------------------------------+
+| The maximum file size for message attachments and plugin          | - System Config path: **Environment > File Storage**                     |
+| uploads. This value must be specified in mebibytes in the         | - ``config.json`` setting: ``".FileSettings.MaxFileSize: 104857600",``   |
+| System Console, and in bytes in the ``config.json`` file.         | - Environment variable: ``MM_FILESETTINGS_MAXFILESIZE``                  |
+|                                                                   |                                                                          |
+| The default is ``104857600`` bytes (**100** mebibytes).           |                                                                          |
++-------------------------------------------------------------------+--------------------------------------------------------------------------+
+| **Warning**: Verify server memory can support your setting choice. Large file sizes increase the risk of server crashes and failed           |
+| uploads due to network disruptions.                                                                                                          |
++-------------------------------------------------------------------+--------------------------------------------------------------------------+
+| **Notes**:                                                                                                                                   |
+|                                                                                                                                              |
+| - When `uploading plugin files </configure/plugins-configuration-settings.html#upload-plugin>`__, a ``Received invlaid response from         |
+|   the server`` error typically indicates that ``MaxFileSize`` isn't large enough to support the plugin file upload, and/or that proxy        |
+|   settings may not be sufficient.                                                                                                            |
+| - If you use a proxy or load balancer in front of Mattermost, the following proxy settings must be adjusted accordingly:                     |
+|                                                                                                                                              |
+|  - For NGINX, use ``client_max_body_size``.                                                                                                  |
+|  - For Apache use ``LimitRequestBody``.                                                                                                      |
++-------------------------------------------------------------------+--------------------------------------------------------------------------+
 
 .. config:setting:: file-enabledocsearchbycontent
   :displayname: Enable document search by content (File Storage)

--- a/source/configure/plugins-configuration-settings.rst
+++ b/source/configure/plugins-configuration-settings.rst
@@ -1278,35 +1278,35 @@ Prompt interval for DMs and GMs
   :systemconsole: Plugins > MS Teams
   :configjson: N/A
   :environment: N/A
-  :description: Specify the maximum file size, in megabytes (MB), of attachments that can be loaded into memory. Attachment files larger than this value will be streamed from Microsoft Teams to Mattermost.
+  :description: Specify the maximum file size, in mebibytes (MiB), of attachments that can be loaded into memory. Attachment files larger than this value will be streamed from Microsoft Teams to Mattermost.
 
 Maximum size of attachments to support complete one time download
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+--------------------------------------------------------------------+----------------------------------------------------------+
-| Specify the maximum file size, in megabytes (MB), of attachments   | - System Config path: **Plugins > MS Teams**             |
-| that can be loaded into memory. Attachment files larger than       | - ``config.json`` setting: N/A                           |
-| this value will be streamed from Microsoft Teams to Mattermost.    | - Environment variable: N/A                              |
-|                                                                    |                                                          |
-| Numerical value. Default is **20** MB.                             |                                                          |
-+--------------------------------------------------------------------+----------------------------------------------------------+
++---------------------------------------------------------------------+----------------------------------------------------------+
+| Specify the maximum file size, in mebibytes (MiB), of attachments   | - System Config path: **Plugins > MS Teams**             |
+| that can be loaded into memory. Attachment files larger than        | - ``config.json`` setting: N/A                           |
+| this value will be streamed from Microsoft Teams to Mattermost.     | - Environment variable: N/A                              |
+|                                                                     |                                                          |
+| Numerical value. Default is **20** MiB.                             |                                                          |
++---------------------------------------------------------------------+----------------------------------------------------------+
 
 .. config:setting:: plugins-msteamsbuffer
   :displayname: Buffer size for streaming files (Plugins - MS Teams)
   :systemconsole: Plugins > MS Teams
   :configjson: N/A
   :environment: N/A
-  :description: Specify the buffer size, in megabytes (MB), for streaming attachment files from Microsoft Teams to Mattermost.
+  :description: Specify the buffer size, in mebibytes (MiB), for streaming attachment files from Microsoft Teams to Mattermost.
 
 Buffer size for streaming files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+--------------------------------------------------------------------+----------------------------------------------------------+
-| Specify the buffer size, in megabytes (MB), for streaming          | - System Config path: **Plugins > MS Teams**             |
-| attachment files from Microsoft Teams to Mattermost.               | - ``config.json`` setting: N/A                           |
-|                                                                    | - Environment variable: N/A                              |
-| Numerical value. Default is **20** MB.                             |                                                          |
-+--------------------------------------------------------------------+----------------------------------------------------------+
++---------------------------------------------------------------------+----------------------------------------------------------+
+| Specify the buffer size, in mebibytes (MiB), for streaming          | - System Config path: **Plugins > MS Teams**             |
+| attachment files from Microsoft Teams to Mattermost.                | - ``config.json`` setting: N/A                           |
+|                                                                     | - Environment variable: N/A                              |
+| Numerical value. Default is **20** MiB.                             |                                                          |
++---------------------------------------------------------------------+----------------------------------------------------------+
 
 ----
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR corrects a unit conversion for the *FileSettings.MaxFileSize* configuration setting (104857600 bytes is 100 mebibytes), and uses IEC prefix names instead of SI prefix names to make clear how values entered in the System Console will be interpreted.

A code comment [here](https://github.com/mattermost/mattermost/blob/a40550136f45ebd1bde2be3b75ab6acf7eaa8a92/server/public/model/config.go#L1613) indicates that IEC units should be used.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

None