### PR TITLE
Clarified format of postgres_dsn

### DIFF
--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -459,7 +459,7 @@ Compare the plugin data
 
 .. code:: sh
 
-   dbcmp --source "${MYSQL_DSN}" --target "postgres://${POSTGRES_DSN}" --exclude="db_migrations,systems"
+   dbcmp --source "${MYSQL_DSN}" --target "${POSTGRES_DSN}" --exclude="db_migrations,systems"
 
 Iterative migrations
 --------------------

--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -275,9 +275,13 @@ For our case, we can simply run the following command:
 
 .. code:: sh
 
-   dbcmp --source "${MYSQL_DSN}" --target "${POSTGRES_DSN}" --exclude="db_migrations,ir_,focalboard,systems"
+   dbcmp --source "${MYSQL_DSN}" --target "postgres://${POSTGRES_DSN} " --exclude="db_migrations,ir_,focalboard,systems"
 
-Note that this migration guide only covers the tables for Mattermost products.
+For example: ``dbcmp --source "user:password@tcp(address:3306)/db_name --target "postgres://user:password@address:5432/db_name``
+
+.. note::
+   
+   This migration guide only covers the tables for Mattermost products.
 
 Another exclusion we are making is in the ``db_migrations`` table which has a small difference (a typo in a single migration name) and creates a diff. Since we created the PostgreSQL schema with morph, and the official ``mattermost`` source, we can skip it safely without concerns. On the other hand, ``systems`` table may contain additional diffs if there were extra keys added during some of the migrations. Consider excluding the ``systems`` table if you run into issues, and perform a manual comparison as the data in the ``systems`` table is relatively smaller in size.
 
@@ -455,7 +459,7 @@ Compare the plugin data
 
 .. code:: sh
 
-   dbcmp --source "${MYSQL_DSN}" --target "${POSTGRES_DSN}" --exclude="db_migrations,systems"
+   dbcmp --source "${MYSQL_DSN}" --target "postgres://${POSTGRES_DSN}" --exclude="db_migrations,systems"
 
 Iterative migrations
 --------------------

--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -277,11 +277,11 @@ For our case, we can simply run the following command:
 
    dbcmp --source "${MYSQL_DSN}" --target "postgres://${POSTGRES_DSN} " --exclude="db_migrations,ir_,focalboard,systems"
 
-For example: ``dbcmp --source "user:password@tcp(address:3306)/db_name --target "postgres://user:password@address:5432/db_name``
+An example command would look like: ``dbcmp --source "user:password@tcp(address:3306)/db_name --target "postgres://user:password@address:5432/db_name``
 
 .. note::
    
-   This migration guide only covers the tables for Mattermost products.
+   ``POSTGRES_DSN`` should start with a ``postgres://`` prefix. This way ``dbcmp`` decides which driver to use while connecting to a database.
 
 Another exclusion we are making is in the ``db_migrations`` table which has a small difference (a typo in a single migration name) and creates a diff. Since we created the PostgreSQL schema with morph, and the official ``mattermost`` source, we can skip it safely without concerns. On the other hand, ``systems`` table may contain additional diffs if there were extra keys added during some of the migrations. Consider excluding the ``systems`` table if you run into issues, and perform a manual comparison as the data in the ``systems`` table is relatively smaller in size.
 

--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -275,7 +275,7 @@ For our case, we can simply run the following command:
 
 .. code:: sh
 
-   dbcmp --source "${MYSQL_DSN}" --target "postgres://${POSTGRES_DSN} " --exclude="db_migrations,ir_,focalboard,systems"
+   dbcmp --source "${MYSQL_DSN}" --target "${POSTGRES_DSN} " --exclude="db_migrations,ir_,focalboard,systems"
 
 An example command would look like: ``dbcmp --source "user:password@tcp(address:3306)/db_name --target "postgres://user:password@address:5432/db_name``
 

--- a/source/images/creation-outline_F1C2B copy.svg
+++ b/source/images/creation-outline_F1C2B copy.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"> 
+    <path d="M12,7.534l0.84,2.519l0.277,0.83l0.83,0.277L16.466,12l-2.519,0.84l-0.83,0.277l-0.277,0.83L12,16.466l-0.84-2.519
+		l-0.277-0.83l-0.83-0.277L7.534,12l2.519-0.84l0.83-0.277l0.277-0.83L12,7.534 M12,2L9.5,9.5L2,12l7.5,2.5L12,22l2.5-7.5L22,12
+		l-7.5-2.5L12,2L12,2z M5,2L4.34,4.34L2,5l2.34,0.66L5,8l0.66-2.34L8,5L5.66,4.34L5,2L5,2z M19,16l-0.66,2.34L16,19l2.34,0.66L19,22
+		l0.66-2.34L22,19l-2.34-0.66L19,16L19,16z"/>
+</svg>


### PR DESCRIPTION
Based on customer feedback that ``--target "${POSTGRES_DSN}"`` wasn't sufficient, and ``postgres://${POSTGRES_DSN}`` would be clearer instruction in the docs that leads admins to successful outcomes.