### PR TITLE
postgres-migration: add remove-null-characters to prevent errors

### DIFF
--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -171,6 +171,8 @@ There is a specific unicode sequence that is `disallowed <https://www.postgresql
 
    DROP PROCEDURE IF EXISTS SanitizeUnsupportedUnicode;
 
+There is also a specific byte sequence value that is not allowed and will cause an ``invalid byte sequence for encoding 'UTF8': 0x00"`` error during the migration. To prevent this error, you can add the ``remove-null-characters`` clause to the text casting rules. However, since pgloader will modify the data on the fly, there may be differences between the tables (if any are affected) during the comparison phase.
+
 Artifacts may remain from previous configurations/versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -255,9 +257,9 @@ Once we set the schema to a desired state, we can start migrating the **data** b
         column Drafts.Priority to text,
         type int when (= precision 11) to integer drop typemod,
         type bigint when (= precision 20) to bigint drop typemod,
-        type text to varchar drop typemod,
+        type text to varchar drop typemod using remove-null-characters,
         type tinyint when (<= precision 4) to boolean using tinyint-to-boolean,
-        type json to jsonb drop typemod
+        type json to jsonb drop typemod using remove-null-characters
 
    EXCLUDING TABLE NAMES MATCHING ~<IR_>, ~<focalboard>, 'schema_migrations', 'db_migrations', 'db_lock',
         'Configurations', 'ConfigurationFiles', 'db_config_migrations'
@@ -334,6 +336,10 @@ An example command would look like: ``dbcmp --source "user:password@tcp(address:
    ``POSTGRES_DSN`` should start with a ``postgres://`` prefix. This way ``dbcmp`` decides which driver to use while connecting to a database.
 
 Another exclusion we are making is in the ``db_migrations`` table which has a small difference (a typo in a single migration name) and creates a diff. Since we created the PostgreSQL schema with morph, and the official ``mattermost`` source, we can skip it safely without concerns. On the other hand, ``systems`` table may contain additional diffs if there were extra keys added during some of the migrations. Consider excluding the ``systems`` table if you run into issues, and perform a manual comparison as the data in the ``systems`` table is relatively smaller in size.
+
+.. note::
+
+   If the ``remove-null-characters`` transform function is utilized during the migration and there were ``0x00`` byte sequences in the MySQL database, those tables will have differences during the comparison phase.
 
 Plugin migrations
 -----------------

--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -171,7 +171,9 @@ There is a specific unicode sequence that is `disallowed <https://www.postgresql
 
    DROP PROCEDURE IF EXISTS SanitizeUnsupportedUnicode;
 
-There is also a specific byte sequence value that is not allowed and will cause an ``invalid byte sequence for encoding 'UTF8': 0x00"`` error during the migration. To prevent this error, you can add the ``remove-null-characters`` clause to the text casting rules. However, since pgloader will modify the data on the fly, there may be differences between the tables (if any are affected) during the comparison phase.
+.. note::
+
+     There is also a specific byte sequence value that is not allowed and will cause an ``invalid byte sequence for encoding 'UTF8': 0x00"`` error during the migration. To prevent this error, you can add the ``remove-null-characters`` clause to the text casting rules. However, since pgloader will modify the data on the fly, there may be differences between the tables (if any are affected) during the comparison phase.
 
 Artifacts may remain from previous configurations/versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
Usual documentation update :)

In short, we are recommending a transform function as `remove-null-characters`  to prevent some errors happening during migration. We have received an error (one occurrence 9 million sample) as `invalid byte sequence for encoding 'UTF8': 0x00`, and this recommendation should fix this issue. 

But there is a caveat though, this transformation may break the comparison for affected tables, that's also added as notes.
