### PR TITLE
Make curl output silent

### DIFF
--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -89,7 +89,7 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
 
     .. code-block:: none
 
-      curl -o- https://deb.packages.mattermost.com/setup-repo.sh | sudo bash
+      curl -fsS -o- https://deb.packages.mattermost.com/setup-repo.sh | sudo bash
 
   2. Install the Mattermost desktop app: 
   


### PR DESCRIPTION
#### Summary

A couple of weeks ago a user [reported](https://forum.mattermost.com/t/mattermost-desktop-repository-install-on-24-04-lts-noble/18693) having trouble with the Desktop install documentation.

Part of his problem was the confusion caused by the `curl -o- https://deb.packages.mattermost.com/setup-repo.sh | sudo bash` command seemingly hanged his terminal. It was actually just waiting for him to input his root password, but this wasn't clear because the output from `curl` actually shifted away the output from `sudo`, which led to confusion. This PR makes curl silent unless it has to output errors.

Note that the user's other issues came from both:
- The recent repository key renewal
- A very much understandable confusion between `setup-repo.sh` and `repo-setup.sh`, which we plan to improve as part of [this ticket](https://mattermost.atlassian.net/browse/CLD-7855)

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7801

