### PR TITLE
Fix gencert.sh and update related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ source/developer/localization.md
 
 # IDEs
 .idea/
+
+#
+*.key
+*.crt

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,6 @@ source/developer/localization.md
 # IDEs
 .idea/
 
-#
+# Generated PKI files
 *.key
 *.crt

--- a/source/onboard/sso-saml-before-you-begin.rst
+++ b/source/onboard/sso-saml-before-you-begin.rst
@@ -3,7 +3,7 @@
 Before you begin
 ----------------
 
-Before you begin, you need generate encryption certificates for encrypting the SAML connection.
+Before you begin, you need to generate encryption certificates for encrypting the SAML connection.
 
-1. You can use the `Bash script <https://github.com/mattermost/docs/tree/master/source/scripts/generate-certificates>`__ from the ``mattermost/docs`` repository on GitHub, or any other suitable method.
+1. You can use the `Bash script <https://github.com/mattermost/docs/tree/master/source/scripts/generate-certificates>`_ from the ``mattermost/docs`` repository on GitHub, or any other suitable method. See the `generate self-signed certificates <https://github.com/mattermost/docs/blob/master/source/scripts/generate-certificates/gencert.md>`_ documentation for details on generating a self-signed x509v3 certificate for use with multiple URLs / IPs.
 2. Save the two files that are generated. They are the private key and the public key. In the System Console, they are referred to as the **Service Provider Private Key** and the **Service Provider Public Certificate** respectively.

--- a/source/onboard/sso-saml-before-you-begin.rst
+++ b/source/onboard/sso-saml-before-you-begin.rst
@@ -5,5 +5,5 @@ Before you begin
 
 Before you begin, you need to generate encryption certificates for encrypting the SAML connection.
 
-1. You can use the `Bash script <https://github.com/mattermost/docs/tree/master/source/scripts/generate-certificates>`_ from the ``mattermost/docs`` repository on GitHub, or any other suitable method. See the `generate self-signed certificates <https://github.com/mattermost/docs/blob/master/source/scripts/generate-certificates/gencert.md>`_ documentation for details on generating a self-signed x509v3 certificate for use with multiple URLs / IPs.
+1. You can use the `Bash script <https://github.com/mattermost/docs/tree/master/source/scripts/generate-certificates>`_ from the ``mattermost/docs`` repository on GitHub, or any other suitable method. See the :doc:`generate self-signed certificates </scripts/generate-certificates/gencert>` documentation for details on generating a self-signed x509v3 certificate for use with multiple URLs / IPs.
 2. Save the two files that are generated. They are the private key and the public key. In the System Console, they are referred to as the **Service Provider Private Key** and the **Service Provider Public Certificate** respectively.

--- a/source/onboard/sso-saml.rst
+++ b/source/onboard/sso-saml.rst
@@ -28,6 +28,7 @@ Mattermost officially supports Okta, OneLogin, and Microsoft ADFS as the identit
   :titlesonly:
 
   Okta SAML Configuration <sso-saml-okta>
+  Generate self-signed certificates </scripts/generate-certificates/gencert>
   OneLogin SAML Configuration <sso-saml-onelogin.rst>
   Microsoft ADFS SAML Configuration for Windows Server 2012 <sso-saml-adfs>
   Microsoft ADFS SAML Configuration for Windows Server 2016 <sso-saml-adfs-msws2016>

--- a/source/scale/performance-monitoring-metrics.rst
+++ b/source/scale/performance-monitoring-metrics.rst
@@ -77,8 +77,9 @@ Login and session metrics
 
 .. note::
   From Mattermost version v9.9, this value includes any potentially unauthenticated connections. Furthermore, this metric comes with an ``origin_client`` label that can be used to see the distribution of connections from different client types (i.e. web, mobile, and desktop).
-- ``mattermost_login_logins_fail_total``: The total number of failed logins.
-- ``mattermost_login_logins_total``: The total number of successful logins.
+
+  - ``mattermost_login_logins_fail_total``: The total number of failed logins.
+  - ``mattermost_login_logins_total``: The total number of successful logins.
 
 Mattermost channels metrics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/scripts/generate-certificates/gencert.md
+++ b/source/scripts/generate-certificates/gencert.md
@@ -1,9 +1,3 @@
----
-nosearch: true
----
-
-<!---This documentation page is intentionally missing from the LHS. You can safely ignore related build warnings.--->
-
 # gencert.sh for Mattermost
 
 Generate a self-signed x509v3 certificate for use with multiple URLs / IPs.

--- a/source/scripts/generate-certificates/gencert.renamed
+++ b/source/scripts/generate-certificates/gencert.renamed
@@ -21,6 +21,7 @@ CRT_CN="client.com" CRT_SAN="DNS.1:www.client.com,DNS.2:admin.client.com,IP.1:19
 You may change the `CRT_CN` and `CRT_SAN` values of the above command based on your needs.
 
 Additionally you may use any of the following environment variables :
+- `CRT_FILENAME`: the name of the cert and key files i.e. `<CRT_FILENAME>.key` and `<CRT_FILENAME>.crt`
 - `CRT_C` : Country value
 - `CRT_L` : Locality value
 - `CRT_O` : Organization value
@@ -31,8 +32,8 @@ Additionally you may use any of the following environment variables :
 ### Result
 
 The command will generate two files:
-- pkcs#8 private key : `mattermost-x509.key`
-- x509v3 certificate : `mattermost-x509.crt`
+- pkcs#8 private key : `mattermost-x509.key` (unless you set `CRT_FILENAME`)
+- x509v3 certificate : `mattermost-x509.crt` (unless you set `CRT_FILENAME`)
 
 You can confirm the certificate content by using the following standard `x509` command:
 

--- a/source/scripts/generate-certificates/gencert.sh
+++ b/source/scripts/generate-certificates/gencert.sh
@@ -44,3 +44,5 @@ fi
 
 rm $CSR
 chmod 600 $CERT
+
+echo -e "\nSuccess! $KEY and $CERT generated."

--- a/source/scripts/generate-certificates/gencert.sh
+++ b/source/scripts/generate-certificates/gencert.sh
@@ -2,21 +2,45 @@
 
 umask 007
 
-certname="${CRT_FILENAME:-"mattermost-x509"}"
+FILE_NAME="${CRT_FILENAME:-"mattermost-x509"}"
+CERT="${FILE_NAME}.crt"
+KEY="${FILE_NAME}.key"
+CSR="${FILE_NAME}.csr"
+
+# generate key
+openssl genrsa -out $KEY 4096
+
+if [ $? -ne 0 ]; then
+    echo "Error generating key"
+    exit
+fi
+
+# generate certificate signing request
+openssl req \
+    -new \
+    -key $KEY \
+    -out $CSR \
+    -subj "/C=${CRT_C:-"US"}/L=${CRT_L:-"Palo Alto"}/O=${CRT_O:-"Mattermost"}/OU=${CRT_OU:-"DevOps"}/CN=${CRT_CN:-"base.example.com"}"
+
+if [ $? -ne 0 ]; then
+    echo "Error generating certificate signing request (csr)"
+    exit
+fi
+
+# generate self-signed certificate
 openssl x509 \
-    -in <(
-        openssl req \
-            -days 3650 \
-            -newkey rsa:4096 \
-            -nodes \
-            -keyout "${certname}.key" \
-            -subj "/C=${CRT_C:-"US"}/L=${CRT_L:-"Palo Alto"}/O=${CRT_O:-"Mattermost"}/OU=${CRT_OU:-"DevOps"}/CN=${CRT_CN:-"base.example.com"}"
-        ) \
     -req \
-    -signkey "${certname}.key" \
-    -sha256 \
     -days 3650 \
-    -out "${certname}.crt" \
+    -in $CSR \
+    -signkey $KEY \
+    -sha256 \
+    -out $CERT \
     -extfile <(echo -e "basicConstraints=critical,CA:true,pathlen:0\nsubjectAltName=${CRT_SAN:-"DNS.1:logs.example.com,DNS.2:metrics.example.com,IP.1:192.168.0.1,IP.2:127.0.0.1"}")
 
-chmod 600 ${certname}.crt
+if [ $? -ne 0 ]; then
+    echo "Error generating self-signed certificate"
+    exit
+fi
+
+rm $CSR
+chmod 600 $CERT


### PR DESCRIPTION
#### Summary
- Fix `gencert.sh` so it correctly creates `.crt` and `.key` files
- Add better error messaging to `gencert.sh`
- Update related documentation
- Add crt/key to gitignore

#### Ticket Link
N/A

