### PR TITLE
Fix v9.9 changelog video url

### DIFF
--- a/source/deploy/mattermost-changelog.md
+++ b/source/deploy/mattermost-changelog.md
@@ -24,7 +24,7 @@ If you upgrade from a release earlier than v9.5, please read the other [Importan
 
 ### Improvements
 
-See [this walkthrough video](https://mattermost.com/video/mattermost-v9-9-changelog/) on some of the improvements in our latest release below.
+See [this walkthrough video](https://mattermost.com/video/video-mattermost-v9-9-changelog/) on some of the improvements in our latest release below.
 
 #### User Interface (UI)
  - Pre-packaged Calls plugin version [v0.27.0](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v0.27.0).


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The v9.9 changelog video URL seems to be different from the other changelog videos. The updated URL links to the correct video 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
n/a

