### PR TITLE
Desktop: add note about rotated key, chrome-sandbox instructions

### DIFF
--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -87,7 +87,7 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
 
   .. important::
 
-    The GPG public key has changed. If you had previously setup the repository on your system, you'll need to download the new key: you can set the ``UPDATE_GPG_KEY=yes`` environment variable when running the setup script, to configure it to overwrite the previous key on your system with the new one. E.g. the first step of the instructions would become ``curl -fsS -o- https://deb.packages.mattermost.com/setup-repo.sh | sudo UPDATE_GPG_KEY=yes bash``. Note that depending on your setup, additional steps may also be required, particularly for installations that didn't rely on the repository setup script.
+    The GPG public key has changed. If you had previously set up the repository on your system, you'll need to download the new key. You can set the ``UPDATE_GPG_KEY=yes`` environment variable when running the setup script to configure it to overwrite the previous key on your system with the new one. The first step of installation then becomes: ``curl -fsS -o- https://deb.packages.mattermost.com/setup-repo.sh | sudo UPDATE_GPG_KEY=yes bash``. Depending on your setup, additional steps may also be required, particularly for installations that don't rely on the repository setup script.
 
   1. At the command line, set up the Mattermost repository on your system: 
 

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -175,7 +175,7 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
       - 64-bit systems: `mattermost-desktop-5.8.1-linux-x64.tar.gz <https://releases.mattermost.com/desktop/5.8.1/mattermost-desktop-5.8.1-linux-x64.tar.gz>`_
       - 32-bit systems: `mattermost-desktop-5.8.1-linux-ia32.tar.gz <https://releases.mattermost.com/desktop/5.8.1/mattermost-desktop-5.8.1-linux-ia32.tar.gz>`_
 
-  2. Extract the archive to a convenient location, then give ``chrome-sandbox`` in the extracted directory the required ownership and permissions: ``sudo chown root:root chrome-sandbox && sudo chmod 4700 chrome-sandbox``
+  2. Extract the archive to a convenient location, then give ``chrome-sandbox`` in the extracted directory the required ownership and permissions: ``sudo chown root:root chrome-sandbox && sudo chmod 4755 chrome-sandbox``
 
   3. Execute ``mattermost-desktop`` located inside the extracted directory.
 

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -85,6 +85,10 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
 
   Both a ``.deb`` package (Beta), and an official APT repository is available for Debian 9 and for Ubuntu releases 20.04 LTS or later. Automatic app updates are supported and enabled. When a new version of the desktop app is released, your app updates automatically.
 
+  .. important::
+
+    The GPG public key has changed. If you had previously setup the repository on your system, you'll need to download the new key: you can set the ``UPDATE_GPG_KEY=yes`` environment variable when running the setup script, to configure it to overwrite the previous key on your system with the new one. E.g. the first step of the instructions would become ``curl -fsS -o- https://deb.packages.mattermost.com/setup-repo.sh | sudo UPDATE_GPG_KEY=yes bash``. Note that depending on your setup, additional steps may also be required, particularly for installations that didn't rely on the repository setup script.
+
   1. At the command line, set up the Mattermost repository on your system: 
 
     .. code-block:: none
@@ -171,9 +175,11 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
       - 64-bit systems: `mattermost-desktop-5.8.1-linux-x64.tar.gz <https://releases.mattermost.com/desktop/5.8.1/mattermost-desktop-5.8.1-linux-x64.tar.gz>`_
       - 32-bit systems: `mattermost-desktop-5.8.1-linux-ia32.tar.gz <https://releases.mattermost.com/desktop/5.8.1/mattermost-desktop-5.8.1-linux-ia32.tar.gz>`_
 
-  2. Extract the archive to a convenient location, then execute ``mattermost-desktop`` located inside the extracted directory.
+  2. Extract the archive to a convenient location, then give ``chrome-sandbox`` in the extracted directory the required ownership and permissions: ``sudo chown root:root chrome-sandbox && sudo chmod 4700 chrome-sandbox``
 
-  3. To create a Desktop launcher, open the file ``README.md``, and follow the instructions in the **Desktop launcher** section.
+  3. Execute ``mattermost-desktop`` located inside the extracted directory.
+
+  4. To create a Desktop launcher, open the file ``README.md``, and follow the instructions in the **Desktop launcher** section.
 
 Log in using the desktop app
 -----------------------------


### PR DESCRIPTION
#### Summary

This PR tackles two issues of the Desktop app installation instructions:
- https://github.com/mattermost/docs/issues/7229: add a note on what to do if you have the expired GPG repo key on your system. We had updated the docs for server and omnibus for as part of [this PR](https://github.com/mattermost/docs/pull/7050), but didn't update them for Desktop.
- https://github.com/mattermost/docs/issues/7230: add instructions required to have the mattermost-desktop tarball run on Ubuntu Noble.

Regarding the second issue: this seems to be a widespread issue with electron-builder apps, e.g. see [here](https://youtrack.jetbrains.com/issue/IJPL-59368/IDE-crashes-due-to-chrome-sandbox-is-owned-by-root-and-has-mode-error-when-IDE-is-launching-the-JCEF-in-a-sandbox) or [here](https://github.com/NixOS/nixpkgs/issues/308128). The root cause is the following:
- `chrome-sandbox` needs to be owned by `root` and to have the SETUID bit enabled. If not, AppArmor will deny some operations on Ubuntu Noble (but not on previous Ubuntu releases).
- When electron-builder creates the archive, it gives `root` ownership to all the files in the archive (can be verified with `tar -tv`)
- If the electron-builder tar extraction is done by a non-root user, all of the file will belong to that user instead, including `chrome-sandbox`. This also drops the setuid bit in the process.

The above points mean that with our current installation instructions don't work on Ubuntu Noble, and we must explicitly address the `chrome-sandbox` file permissions when using the tarball.

Note that an alternative solution to what I documented is requesting to extract the whole tarball as root user, e.g. to `/opt/mattermost-desktop/`. cc @devinbinnie please let me know if you have any feedback or more insight on this, thanks!

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7945
https://mattermost.atlassian.net/browse/CLD-7949