### PR TITLE
Added support end dates for  last 2 major & last 3 ESR releases

### DIFF
--- a/source/about/mattermost-server-releases.md
+++ b/source/about/mattermost-server-releases.md
@@ -5,7 +5,7 @@
 ```
 
 ```{Important}
- Support for Mattermost Server v8.1 [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#extended-support-releases) has come to the end of its life cycle in May 15, 2024. Upgrading to Mattermost Server v9.5 or later is required.
+ Support for Mattermost Server v8.1 [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on May 15, 2024. Upgrading to Mattermost Server v9.5 or later is required.
 ```
 
 ## Frequency

--- a/source/about/mattermost-v10-changelog.md
+++ b/source/about/mattermost-v10-changelog.md
@@ -1,7 +1,7 @@
 # v10 changelog
 
 ```{Important}
-Support for Mattermost Server v8.1 [Extended Support Release](https://docs.mattermost.com/deploy/about/release-policy.html#extended-support-releases) has come to the end of its life cycle in May 15, 2024. Upgrading to Mattermost Server v9.5 or later is required.
+Support for Mattermost Server v8.1 [Extended Support Release](https://docs.mattermost.com/deploy/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on May 15, 2024. Upgrading to Mattermost Server v9.5 or later is required.
 - See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) documentation for details on upgrading to a newer release.
 - See the [changelog in progress](https://bit.ly/2nK3cVf) for details about the upcoming release.
 ```

--- a/source/about/mattermost-v9-changelog.md
+++ b/source/about/mattermost-v9-changelog.md
@@ -1,7 +1,7 @@
 # v9 changelog
 
 ```{Important}
-Support for Mattermost Server v8.1 [Extended Support Release](https://docs.mattermost.com/deploy/about/release-policy.html#extended-support-releases) has come to the end of its life cycle in May 15, 2024. Upgrading to Mattermost Server v9.5 or later is required.
+Support for Mattermost Server v8.1 [Extended Support Release](https://docs.mattermost.com/deploy/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on May 15, 2024. Upgrading to Mattermost Server v9.5 or later is required.
 - See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) documentation for details on upgrading to a newer release.
 - See the [changelog in progress](https://bit.ly/2nK3cVf) for details about the upcoming release.
 ```

--- a/source/about/unsupported-legacy-releases.md
+++ b/source/about/unsupported-legacy-releases.md
@@ -3,6 +3,10 @@
 (release-v8-1-extended-support-release)=
 ## Release v8.1 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
 
+```{Important}
+Support for Mattermost Server v8.1 [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on May 15, 2024. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
+```
+
 - **8.1.13, released 2024-04-25**
   - Mattermost v8.1.13 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
   - Mattermost v8.1.13 contains no database or functional changes.
@@ -154,6 +158,10 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 (release-v8-0-major-release)=
 ## Release v8.0 - [Major Release](https://docs.mattermost.com/upgrade/release-definitions.html#major-release)
+
+```{Important}
+Support for Mattermost Server v8.0 [Major Release](https://docs.mattermost.com/about/release-policy.html#release-types) has come to the end of its life cycle on October 15, 2023. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
+```
 
 - **8.0.4, released 2023-10-06**
   - Mattermost v8.0.4 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -625,6 +633,10 @@ If you upgrade from a release earlier than v7.8, please read the other [Importan
 
 (release-v7-8-extended-support-release)=
 ## Release v7.8 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
+
+```{Important}
+Support for Mattermost Server v7.8 [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on November 15, 2023. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
+```
 
 - **7.8.15 released 2023-11-13**
   - Mattermost v7.8.15 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1505,6 +1517,10 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ## Release v7.1 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
 
+```{Important}
+Support for Mattermost Server v7.1 [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on May 15, 2023. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
+```
+
 - **v7.1.9, released 2023-04-27**
   - Mattermost v7.1.9 contains a medium severity level security fix. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
 - **v7.1.8, released 2023-04-12**
@@ -1648,6 +1664,10 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 ----
 
 ## Release v7.0 - [Major Release](https://docs.mattermost.com/upgrade/release-definitions.html#major-release)
+
+```{Important}
+Support for Mattermost Server v7.0 [Major Release](https://docs.mattermost.com/about/release-policy.html#release-types) has come to the end of its life cycle on September 15, 2022. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
+```
 
 - **v7.0.2, released 2022-08-23**
   - Mattermost v7.0.2 contains a medium severity level security fix. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).


### PR DESCRIPTION
Important "end of support" notes added to the following legacy (unsupported) release changelogs: 

Customers on the last 3 ESR and last 2 major unsupported legacy releases (including v8.1, v8.0, v7.8, v7.1, & v7.0.) are notified with an important note at the top of the changelog entry indicating when support ended for the release.

See [Unsupported legacy releases](http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/7245/about/unsupported-legacy-releases.html) for a generated preview of page updates.

