### PR TITLE
Fixed broken mobile changelog links due to missing labels

### DIFF
--- a/source/about/mobile-app-changelog.md
+++ b/source/about/mobile-app-changelog.md
@@ -5,6 +5,7 @@
 
 This changelog summarizes updates to Mattermost mobile apps releases for [Mattermost](https://mattermost.com).
 
+(release-v2-18-0)=
 ## 2.18.0 Release
  - Release Date: July 16, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
@@ -32,6 +33,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
+(release-v2-17-1)=
 ## 2.17.1 Release
  - Release Date: June 25, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.


### PR DESCRIPTION
Markdown-formatted labels in the format ``(release-vx-yy-z)=`` (such as ``(release-v2-17-0)=``) within changelog source files serve as anchors that take docs visitors to the correct section of the changelog from each of our server, desktop, and mobile release pages.

In cases where a given release includes one more more dot-release, add the label before the most recent dot-release section title, and update the changelog link release number accordingly.