### PR TITLE
Update sso-saml.rst to include missing de-provisioning warning

### DIFF
--- a/source/onboard/sso-saml.rst
+++ b/source/onboard/sso-saml.rst
@@ -18,7 +18,8 @@ Mattermost can be configured to act as a SAML 2.0 Service Provider. The SAML Sin
 - **Sync groups to predefined roles in Mattermost.** Assign team and channel roles to groups via LDAP Group Sync.
 - **Compliance alignment with administrator management.** Manage Administrator access to Mattermost in the System Console using SAML attributes.
 
-SAML Single sign-on itself does not support periodic updates of user attributes nor automatic deprovisioning. However, SAML with AD/LDAP sync can be configured to support these use cases.
+.. warning::
+  SAML Single sign-on itself does not support periodic updates of user attributes nor automatic deprovisioning. However, SAML with AD/LDAP sync can be configured to support these use cases.
 
 For more information about SAML, see `this article from Varonis <https://www.varonis.com/blog/what-is-saml/>`_, and `this conceptual example from DUO <https://duo.com/blog/the-beer-drinkers-guide-to-saml>`_.
 


### PR DESCRIPTION
Right now the fact that SAML does not support automatic de-provisioning is not very prominent in the SAML docs.

This PR adds a warning to make it more clear that this is the case and what can be done about it (use LDAP sync)