### PR TITLE
[MM-57546] Update preview mode documentation

### DIFF
--- a/source/install/common-local-deploy-docker.rst
+++ b/source/install/common-local-deploy-docker.rst
@@ -14,13 +14,15 @@ Using the `Mattermost Docker Preview Image <https://github.com/mattermost/matter
     
     **Preview Mode** shouldn't be used in a production environment, as it uses a known password string, contains other non-production configuration settings, has email disabled, keeps no persistent data (all data lives inside the container), and doesn't support upgrades. 
 
+    If you are planning to use the calling functionality in **Preview Mode** on a non-local environment, you should ensure that the server is running on a secure (HTTPs) connection and that the :ref:`network requirements <configure/calls-deployment:network>` to run calls are met.
+
 1. Install `Docker <https://www.docker.com/get-started/>`__.
 
 2. Once you have Docker, run the following command in a terminal window:
 
   .. code:: bash
 
-    docker run --name mattermost-preview -d --publish 8065:8065 mattermost/mattermost-preview
+    docker run --name mattermost-preview -d --publish 8065:8065 --publish 8443:8443 mattermost/mattermost-preview
 
 3. When Docker is done fetching the image, navigate to ``http://localhost:8065/`` in your browser to preview Mattermost.
 4. Select **Don't have an account** in the top right corner of the screen to create an account for your preview instance. If you don't see this option, ensure that the :ref:`Enable open server <configure/authentication-configuration-settings:enable open server>` configuration setting is enabled. This setting is disabled for self-hosted Mattermost deployments by default.


### PR DESCRIPTION
#### Summary

PR updates the documentation for our Docker preview image to include an additional note for users looking to test Calls functionality as part of the preview. It also updates the docker command to expose the necessary port to make the connections to calls work.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57546

