### PR TITLE
Document presence components of MS Teams

### DIFF
--- a/source/collaborate/collaborate-within-connected-microsoft-teams.rst
+++ b/source/collaborate/collaborate-within-connected-microsoft-teams.rst
@@ -24,7 +24,7 @@ Mattermost will confirm when your account is connected, and prompt you to enable
 Enable notifications
 ^^^^^^^^^^^^^^^^^^^^
 
-Once you've connected your Mattermost account to your Microsoft Teams account, Mattermost prompts you to enable notifications. When enabled, any messages you receive in a chat or group chat in Microsoft Teams will be appear in Mattermost as a notification, with a link to open the chat in Microsoft Teams and continue the conversation.
+Once you've connected your Mattermost account to your Microsoft Teams account, Mattermost prompts you to enable notifications. When enabled and you're away from Teams, any messages you receive in a chat or group chat in Microsoft Teams will be appear in Mattermost as a notification, with a link to open the chat in Microsoft Teams and continue the conversation. These notifications won't appear if you've been recently active in Teams.
 
 .. note::
   Your system administrator must :ref:`enable support for notifications <configure/plugins-configuration-settings:sync notifications>`. 

--- a/source/integrate/microsoft-teams-interoperability.rst
+++ b/source/integrate/microsoft-teams-interoperability.rst
@@ -71,6 +71,7 @@ Replace ``(MM_SITE_URL)`` with your Mattermost server's Site URL. Select **Regis
 13. Select the following permissions:
 
  - ``Chat.Read.All``
+ - ``Presence.Read.All``
 
 14. Select **Add permissions** to submit the form.
 


### PR DESCRIPTION
#### Summary
Document the new presence permissions required to suppress notifications while users have been recently active in Teams.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-60005