### PR TITLE
Add callout for licensing in kubernetes docs

### DIFF
--- a/source/install/install-kubernetes.rst
+++ b/source/install/install-kubernetes.rst
@@ -109,7 +109,7 @@ Deploy Mattermost
 
   .. note::
     A Mattermost Enterprise license is required for a seamless experience deploying Mattermost with multiple server instances. If you plan to deploy Mattermost without an Enterprise license, we recommend a single server deployment by adding ``Replicas:  1`` to the ``spec`` section in step 2.
-    For more information a running highly-available Mattermost deployment please refer to :doc:`this documentation </scale/high-availability-cluster-based-deployment>`.
+    See the :doc:`high availability </scale/high-availability-cluster-based-deployment>` documentation for details on running a highly-available Mattermost deployment.
 
 2. Create an installation manifest file ``mattermost-installation.yaml`` locally, and open it with a text editor. Copy and paste the YAML structure below, and make any necessary adjustments for your configuration and environment. 
 

--- a/source/install/install-kubernetes.rst
+++ b/source/install/install-kubernetes.rst
@@ -107,6 +107,10 @@ Deploy Mattermost
     stringData:
       license: <LICENSE_FILE_CONTENTS>
 
+  .. note::
+    An enterprise license is required for a seamless experience running a Mattermost installation with multiple server instances. If you will be deploying Mattermost without an enterprise license it is recommended to only use a single server instance. This can be done by adding ``Replicas:  1`` to the ``spec`` section in step 2.
+    For more information a running highly-available Mattermost deployment please refer to :doc:`this documentation </scale/high-availability-cluster-based-deployment>`.
+
 2. Create an installation manifest file ``mattermost-installation.yaml`` locally, and open it with a text editor. Copy and paste the YAML structure below, and make any necessary adjustments for your configuration and environment. 
 
   .. code-block:: yaml

--- a/source/install/install-kubernetes.rst
+++ b/source/install/install-kubernetes.rst
@@ -108,7 +108,7 @@ Deploy Mattermost
       license: <LICENSE_FILE_CONTENTS>
 
   .. note::
-    An enterprise license is required for a seamless experience running a Mattermost installation with multiple server instances. If you will be deploying Mattermost without an enterprise license it is recommended to only use a single server instance. This can be done by adding ``Replicas:  1`` to the ``spec`` section in step 2.
+    A Mattermost Enterprise license is required for a seamless experience deploying Mattermost with multiple server instances. If you plan to deploy Mattermost without an Enterprise license, we recommend a single server deployment by adding ``Replicas:  1`` to the ``spec`` section in step 2.
     For more information a running highly-available Mattermost deployment please refer to :doc:`this documentation </scale/high-availability-cluster-based-deployment>`.
 
 2. Create an installation manifest file ``mattermost-installation.yaml`` locally, and open it with a text editor. Copy and paste the YAML structure below, and make any necessary adjustments for your configuration and environment. 


### PR DESCRIPTION
This callout is intended to help individuals who will be using the Mattermost Operator, but don't have an enterprise license.

Fixes https://mattermost.atlassian.net/browse/CLD-8138

