### PR TITLE
Add example for LDAP trace logging

### DIFF
--- a/source/manage/logging.rst
+++ b/source/manage/logging.rst
@@ -541,7 +541,7 @@ The ``MM_LOGSETTINGS_ADVANCEDLOGGINGJSON`` environment variable is used to confi
 How can I turn on trace logging for LDAP?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please use the following JSON configuration as as starting point to enable trace logging for LDAP
+Please use the following JSON configuration as as starting point to enable trace logging for LDAP:
 
 .. code-block:: JSON
 

--- a/source/manage/logging.rst
+++ b/source/manage/logging.rst
@@ -536,3 +536,50 @@ The ``MM_LOGSETTINGS_ADVANCEDLOGGINGJSON`` environment variable is used to confi
             "MaxQueueSize": 1000
         }
     }')
+
+
+How can I turn on trace logging for LDAP?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Please use the following JSON configuration as as starting point to enable trace logging for LDAP
+
+.. code-block:: JSON
+
+    {
+        "ldap-file": {
+            "type": "file",
+            "format": "plain",
+            "levels": [
+                {
+                    "id": 144,
+                    "name": "LDAPTrace"
+                },
+                {
+                    "id": 143,
+                    "name": "LDAPDebug"
+                },
+                {
+                    "id": 142,
+                    "name": "LDAPInfo"
+                },
+                {
+                    "id": 141,
+                    "name": "LDAPWarn",
+                    "stacktrace": true
+                },
+                {
+                    "id": 140,
+                    "name": "LDAPError",
+                    "stacktrace": true
+                }
+            ],
+            "options": {
+                "filen_name": "./logs/ldap",
+                "max_size": 100,
+                "max_age": 14,
+                "max_backups": 3,
+                "compress": false
+            },
+            "maxqueuesize": 1000
+        }
+    }

--- a/source/manage/logging.rst
+++ b/source/manage/logging.rst
@@ -574,7 +574,7 @@ Please use the following JSON configuration as as starting point to enable trace
                 }
             ],
             "options": {
-                "filen_name": "./logs/ldap",
+                "filen_name": "./logs/ldap.log",
                 "max_size": 100,
                 "max_age": 14,
                 "max_backups": 3,


### PR DESCRIPTION
#### Summary
Add an example of how to configure LDAP trace logging via advanced logging configuration.

Review page: http://mattermost-docs-preview-pulls.s3-website-us-east-1.amazonaws.com/7323/manage/logging.html#how-can-i-turn-on-trace-logging-for-ldap

#### Ticket Link
NONE

