### PR TITLE
Docs listening: Clarified deprecated vs. official Docker GH repos

### DIFF
--- a/source/install/common-prod-deploy-docker.rst
+++ b/source/install/common-prod-deploy-docker.rst
@@ -3,13 +3,15 @@
 
 .. This page is intentionally not accessible via the LHS navigation pane because it's common content included on other docs pages.
 
-You'll need `Docker Engine <https://docs.docker.com/engine/install/>`__ and `Docker Compose <https://docs.docker.com/compose/install/>`__ (release 1.28 or later) Follow the steps in the `Mattermost Docker Setup README <https://github.com/mattermost/docker#mattermost-docker-setup>`__ or follow the steps below.
+You'll need `Docker Engine <https://docs.docker.com/engine/install/>`__ and `Docker Compose <https://docs.docker.com/compose/install/>`__ (release 1.28 or later).
 
 .. important::
 
    - The production configuration results in two separate containers: one for the database and one for the application. An optional third container results when using NGINX for reverse proxy.
    - Encountering issues with your Docker deployment? See the :ref:`Docker deployment troubleshooting <install/troubleshooting:docker deployments>` documentation for details.
-      
+
+To deploy Mattermost on Docker:
+
 1. In a terminal window, clone the repository and enter the directory.
 
    .. code:: bash

--- a/source/install/install-docker.rst
+++ b/source/install/install-docker.rst
@@ -4,10 +4,6 @@ Deploy Mattermost via Docker
 .. include:: ../_static/badges/allplans-selfhosted.rst
   :start-after: :nosearch:
 
-.. tip::
-
-  Looking to a way to evaluate Mattermost in a non-production environment using Docker? See the :doc:`trial Mattermost using Docker </install/trial-mattermost-using-docker>` documentation for details.
-
 Install Docker
 ---------------
 
@@ -51,7 +47,9 @@ Deploy Mattermost on Docker for production use
 Upgrade from ``mattermost-docker``
 -----------------------------------
 
-The `mattermost-docker <https://github.com/mattermost/mattermost-docker>`__ repository is deprecated. To migrate from the ``mattermost/mattermost-prod-app`` image, we recommend migrating to either ``mattermost/mattermost-enterprise-edition`` or ``mattermost/mattermost-team-edition`` images, which are the official images supported by Mattermost. These images support PostgreSQL 11+ databases, which we know has been a long-running challenge for the community, and you will not lose any features or functionality by moving to these new images.
+The `mattermost-docker <https://github.com/mattermost/mattermost-docker>`__ GitHub repository is deprecated. Visit the `mattermost/docker <https://github.com/mattermost/docker>`_ GitHub repository to access the official Docker deployment solution for Mattermost.
+
+To migrate from an existing ``mattermost/mattermost-prod-app`` image, we recommend migrating to either ``mattermost/mattermost-enterprise-edition`` or ``mattermost/mattermost-team-edition`` images, which are the official images supported by Mattermost. These images support PostgreSQL 11+ databases, which we know has been a long-running challenge for the community, and you will not lose any features or functionality by moving to these new images.
 
 For additional help or questions, please refer to `this issue <https://github.com/mattermost/mattermost-docker/issues/489>`__.
 
@@ -103,4 +101,11 @@ For an in-depth guide to configuring the TLS certificate and key for Nginx, plea
 Further help
 ~~~~~~~~~~~~~
 
-If you encounter other problems while installing Mattermost, please refer to our :doc:`troubleshooting guide </install/troubleshooting>`. 
+If you encounter other problems while installing Mattermost, please refer to our :doc:`troubleshooting guide </install/troubleshooting>`.
+
+Trial Mattermost using Docker Preview
+--------------------------------------
+
+Looking to a way to evaluate Mattermost in a non-production environment using Docker? We recommend using the `Mattermost Docker Preview Image <https://github.com/mattermost/mattermost-docker-preview>`_ to install Mattermost in Preview Mode. 
+
+See the :doc:`trial Mattermost using Docker </install/trial-mattermost-using-docker>` documentation for details.


### PR DESCRIPTION
Clarified the differences between the deprecated, preview, and official GitHub repos in product documentation to avoid confusion and churn.