### PR TITLE
Clarified x-asis labels & adjusted frequency to every other month

### DIFF
--- a/source/about/release-policy.md
+++ b/source/about/release-policy.md
@@ -49,7 +49,8 @@ We highly recommend working with your Mattermost Account Team to plan for a migr
 
 gantt
     dateFormat  YYYY-MM-DD
-    axisFormat  %b
+    axisFormat  %b %y
+    tickInterval 2month
     
     section 2024
     v9.5 Extended Support  :crit,    2024-02-16, 2024-11-15


### PR DESCRIPTION
Based on customer-centric feedback that the Gantt chart wasn't easy to parse at a glance.

Notable improvements for a future iteration include:
- labeling the "today" line to make its role obvious
- drawing monthly ticks along the x-axis and rotating the labels 30+ degrees for readability
- automatically updating the chart markdown by integrating with the Mattermost Release Cataloger that exposes an API list of releases, including the exact support dates