### PR TITLE
fix typo: from "GitHub" to "GitLab"

### DIFF
--- a/source/integrate/gitlab-interoperability.rst
+++ b/source/integrate/gitlab-interoperability.rst
@@ -37,7 +37,7 @@ Mattermost configuration
 
 A Mattermost system admin must perform the following steps in Mattermost.
 
-Install the GitHub integration from the in-product App Marketplace:
+Install the GitLab integration from the in-product App Marketplace:
 
 1. In Mattermost, from the Product menu |product-list|, select **App Marketplace**.
 2. Search for or scroll to GitLab, and select **Install**.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Small fix - typo. Replace "GitHub" with "GitLab" in text: https://docs.mattermost.com/integrate/gitlab-interoperability.html#mattermost-configuration
> Install the GitHub integration from the in-product App Marketplace:

screenshot:
<img width="1476" alt="Screen 2024-09-11 at 20 00 10" src="https://github.com/user-attachments/assets/85b0fafd-a7f1-4017-86be-92d137b8e2b1">



#### Ticket Link
 \-