### PR TITLE
GH 7066 (code block formatting and standardization issues) - `prepare-mattermost-database.rst`

### DIFF
--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -46,27 +46,27 @@ To set up a PostgreSQL database for use by the Mattermost server:
 
 5. If you're configuring PostgreSQL v15.x or later:
     
-  a. Grant the user access to the Mattermost database by running:
+a. Grant the user access to the Mattermost database by running:
 
-    .. code-block:: none
-      :class: mm-code-block 
+.. code-block:: none
+  :class: mm-code-block 
 
-        postgres=# GRANT ALL PRIVILEGES ON DATABASE mattermost to mmuser;
-                  
+    postgres=# GRANT ALL PRIVILEGES ON DATABASE mattermost to mmuser;
+                
 
-  b. Grant the user to change the owner of a database to a user ``mmuser`` by running:
+b. Grant the user to change the owner of a database to a user ``mmuser`` by running:
 
-     .. code-block:: none
-      :class: mm-code-block 
+.. code-block:: none
+  :class: mm-code-block 
 
-        ALTER DATABASE mattermost OWNER TO mmuser;
+    ALTER DATABASE mattermost OWNER TO mmuser;
 
-  c. Grant access to objects contained in the specified schema by running: 
+c. Grant access to objects contained in the specified schema by running: 
 
-    .. code-block:: none
-      :class: mm-code-block 
+.. code-block:: none
+  :class: mm-code-block 
 
-        GRANT USAGE, CREATE ON SCHEMA PUBLIC TO mmuser;
+    GRANT USAGE, CREATE ON SCHEMA PUBLIC TO mmuser;
 
 6. Exit the PostgreSQL interactive terminal by running:
 

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -16,10 +16,10 @@ To set up a PostgreSQL database for use by the Mattermost server:
 
 2. Access PostgreSQL by running:
 
-  .. code-block:: none
-    :class: mm-code-block 
+.. code-block:: none
+  :class: mm-code-block 
 
-      sudo -u postgres psql
+    sudo -u postgres psql
 
 3. Create the Mattermost database by running:
 

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -70,10 +70,10 @@ c. Grant access to objects contained in the specified schema by running:
 
 6. Exit the PostgreSQL interactive terminal by running:
 
-  .. code-block:: none
-    :class: mm-code-block 
+.. code-block:: none
+  :class: mm-code-block 
 
-      postgres=# \q
+    postgres=# \q
 
 7. (Optional) If you use separate servers for your database and the Mattermost server, you may allow PostgreSQL to listen on all assigned IP addresses. We recommend ensuring that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -77,39 +77,39 @@ c. Grant access to objects contained in the specified schema by running:
 
 7. (Optional) If you use separate servers for your database and the Mattermost server, you may allow PostgreSQL to listen on all assigned IP addresses. We recommend ensuring that only the Mattermost server is able to connect to the PostgreSQL port using a firewall.
 
-  .. tab:: Ubuntu
+.. tab:: Ubuntu
 
-    Open ``/etc/postgresql/{version}/main/postgresql.conf`` as *root* in a text editor.
-    
-    Replace ``{version}`` with the version of PostgreSQL that's currently running.
+  Open ``/etc/postgresql/{version}/main/postgresql.conf`` as *root* in a text editor.
+  
+  Replace ``{version}`` with the version of PostgreSQL that's currently running.
 
-    a. Find the following line: ``#listen_addresses = 'localhost'``
+  a. Find the following line: ``#listen_addresses = 'localhost'``
 
-    b. Uncomment the line and change ``localhost`` to ``*``: ``listen_addresses = '*'``
+  b. Uncomment the line and change ``localhost`` to ``*``: ``listen_addresses = '*'``
 
-    c. Restart PostgreSQL for the change to take effect by running:
+  c. Restart PostgreSQL for the change to take effect by running:
 
-      .. code-block:: none
-        :class: mm-code-block 
+  .. code-block:: none
+    :class: mm-code-block 
 
-          sudo systemctl restart postgresql-{version}
+      sudo systemctl restart postgresql-{version}
 
-  .. tab:: Red Hat
+.. tab:: Red Hat
 
-    Open ``/var/lib/pgsql/{version}/data/postgresql.conf`` as *root* in a text editor.
+  Open ``/var/lib/pgsql/{version}/data/postgresql.conf`` as *root* in a text editor.
 
-    Replace ``{version}`` with the version of PostgreSQL that's currently running. 
+  Replace ``{version}`` with the version of PostgreSQL that's currently running. 
 
-    a. Find the following line: ``#listen_addresses = 'localhost'``
+  a. Find the following line: ``#listen_addresses = 'localhost'``
 
-    b. Uncomment the line and change ``localhost`` to ``*``: ``listen_addresses = '*'``
+  b. Uncomment the line and change ``localhost`` to ``*``: ``listen_addresses = '*'``
 
-    c. Restart PostgreSQL for the change to take effect by running:
+  c. Restart PostgreSQL for the change to take effect by running:
 
-      .. code-block:: none
-        :class: mm-code-block 
+  .. code-block:: none
+    :class: mm-code-block 
 
-          sudo systemctl restart postgresql-{version}
+      sudo systemctl restart postgresql-{version}
 
 8. Modify the file ``pg_hba.conf`` to allow the Mattermost server to communicate with the database by ensuring host connection types are set to ``trust``.
 

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -39,10 +39,10 @@ To set up a PostgreSQL database for use by the Mattermost server:
 
 4. Create the Mattermost user *mmuser* by running the following command. Ensure you use a password that's more secure than ``mmuser-password``.
 
-  .. code-block:: none
-    :class: mm-code-block 
+.. code-block:: none
+  :class: mm-code-block 
 
-      postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser-password';
+    postgres=# CREATE USER mmuser WITH PASSWORD 'mmuser-password';
 
 5. If you're configuring PostgreSQL v15.x or later:
     

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -113,65 +113,65 @@ c. Grant access to objects contained in the specified schema by running:
 
 8. Modify the file ``pg_hba.conf`` to allow the Mattermost server to communicate with the database by ensuring host connection types are set to ``trust``.
 
-  .. tab:: Ubuntu
+.. tab:: Ubuntu
 
-    These host connections are specific to Ubuntu 20.04, and will differ depending on the operating system version you're running. For example, in Ubuntu 22.04, the ``peer`` connection types are listed as ``sha-256`` instead.
+  These host connections are specific to Ubuntu 20.04, and will differ depending on the operating system version you're running. For example, in Ubuntu 22.04, the ``peer`` connection types are listed as ``sha-256`` instead.
 
-    **Local Database (same server)**
+  **Local Database (same server)**
 
-    If the Mattermost server and the database are on the same machine:
+  If the Mattermost server and the database are on the same machine:
 
-    a. Open ``/etc/postgresql/{version}/main/pg_hba.conf`` as *root* in a text editor. 
+  a. Open ``/etc/postgresql/{version}/main/pg_hba.conf`` as *root* in a text editor. 
 
-    b.  Find the following lines:
+  b.  Find the following lines:
 
-      ``local   all             all                        peer``
+    ``local   all             all                        peer``
 
-      ``host    all             all         ::1/128        ident``
+    ``host    all             all         ::1/128        ident``
 
-    c. Change ``peer`` and ``ident`` to ``trust``:
+  c. Change ``peer`` and ``ident`` to ``trust``:
 
-      ``local   all             all                        trust``
+    ``local   all             all                        trust``
 
-      ``host    all             all         ::1/128        trust``
+    ``host    all             all         ::1/128        trust``
 
-    **Remote Database (separate server)**
+  **Remote Database (separate server)**
 
-    If the Mattermost server and the database are on different machines:
+  If the Mattermost server and the database are on different machines:
 
-    a. Open ``/etc/postgresql/{version}/main/pg_hba.conf`` in a text editor as *root* user.
+  a. Open ``/etc/postgresql/{version}/main/pg_hba.conf`` in a text editor as *root* user.
 
-    b. Add the following line to the end of the file, where ``{mattermost-server-IP}`` is the IP address of the Mattermost server: ``host all all {mattermost-server-IP}/32 md5``.
+  b. Add the following line to the end of the file, where ``{mattermost-server-IP}`` is the IP address of the Mattermost server: ``host all all {mattermost-server-IP}/32 md5``.
 
-  .. tab:: Red Hat
+.. tab:: Red Hat
 
-    These host connections are specific to Red Hat 8, and will differ depending on the operating system version you're running.
+  These host connections are specific to Red Hat 8, and will differ depending on the operating system version you're running.
 
-    **Local Database (same server)**
+  **Local Database (same server)**
 
-    If the Mattermost server and the database are on the same machine:
+  If the Mattermost server and the database are on the same machine:
 
-    a. Open ``/var/lib/pgsql/{version}/data/pg_hba.conf`` as *root* in a text editor. 
+  a. Open ``/var/lib/pgsql/{version}/data/pg_hba.conf`` as *root* in a text editor. 
 
-    b.  Find the following lines:
+  b.  Find the following lines:
 
-      ``local   all             all                        peer``
+    ``local   all             all                        peer``
 
-      ``host    all             all         ::1/128        scram-sha-256``
+    ``host    all             all         ::1/128        scram-sha-256``
 
-    c. Change ``peer`` and ``ident`` to ``trust``:
+  c. Change ``peer`` and ``ident`` to ``trust``:
 
-      ``local   all             all                        trust``
+    ``local   all             all                        trust``
 
-      ``host    all             all         ::1/128        trust``
+    ``host    all             all         ::1/128        trust``
 
-    **Remote Database (separate server)**
+  **Remote Database (separate server)**
 
-    If the Mattermost server and the database are on different machines:
+  If the Mattermost server and the database are on different machines:
 
-    a. Open ```/var/lib/pgsql/{version}/data/pg_hba.conf`` in a text editor as *root* user.
+  a. Open ```/var/lib/pgsql/{version}/data/pg_hba.conf`` in a text editor as *root* user.
 
-    b. Add the following line to the end of the file, where ``{mattermost-server-IP}`` is the IP address of the Mattermost server: ``host all all {mattermost-server-IP}/32 md5``.
+  b. Add the following line to the end of the file, where ``{mattermost-server-IP}`` is the IP address of the Mattermost server: ``host all all {mattermost-server-IP}/32 md5``.
 
 9. Reload PostgreSQL by running:
 

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -23,19 +23,19 @@ To set up a PostgreSQL database for use by the Mattermost server:
 
 3. Create the Mattermost database by running:
 
-  .. tab:: Ubuntu
+.. tab:: Ubuntu
 
-    .. code-block:: none
-      :class: mm-code-block 
+  .. code-block:: none
+    :class: mm-code-block 
 
-      postgres=# CREATE DATABASE mattermost;
+    postgres=# CREATE DATABASE mattermost;
 
-  .. tab:: Red Hat
+.. tab:: Red Hat
 
-    .. code-block:: none
-      :class: mm-code-block 
+  .. code-block:: none
+    :class: mm-code-block 
 
-      postgres=# CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;
+    postgres=# CREATE DATABASE mattermost WITH ENCODING 'UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' TEMPLATE=template0;
 
 4. Create the Mattermost user *mmuser* by running the following command. Ensure you use a password that's more secure than ``mmuser-password``.
 

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -175,10 +175,10 @@ c. Grant access to objects contained in the specified schema by running:
 
 9. Reload PostgreSQL by running:
 
-  .. code-block:: none
-    :class: mm-code-block 
+.. code-block:: none
+  :class: mm-code-block 
 
-      sudo systemctl reload postgresql-{version}
+    sudo systemctl reload postgresql-{version}
 
 10. Verify that you can connect with the user *mmuser*.
 

--- a/source/install/prepare-mattermost-database.rst
+++ b/source/install/prepare-mattermost-database.rst
@@ -186,19 +186,19 @@ c. Grant access to objects contained in the specified schema by running:
 
   If the Mattermost server and the database are on the same machine, use the following command: 
 
-    .. code-block:: none
-      :class: mm-code-block 
+  .. code-block:: none
+    :class: mm-code-block 
 
-        psql --dbname=mattermost --username=mmuser --password
+      psql --dbname=mattermost --username=mmuser --password
 
 .. tab:: Remote Database (separate server)
 
   If the Mattermost server is on a different machine, log into that machine and use the following command: 
 
-    .. code-block:: none
-      :class: mm-code-block 
+  .. code-block:: none
+    :class: mm-code-block 
 
-        psql --host={postgres-server-IP} --dbname=mattermost --username=mmuser --password
+      psql --host={postgres-server-IP} --dbname=mattermost --username=mmuser --password
 
   .. note::
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request fixes the redundant background issue of the code blocks. Only one file named `prepare-mattermost-database.rst` has been fixed in this request.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Related to #7066
