### PR TITLE
Update Documentation for Newly Supported Import/Export Components

### DIFF
--- a/source/manage/bulk-export-tool.rst
+++ b/source/manage/bulk-export-tool.rst
@@ -12,11 +12,14 @@ Moving data from one Mattermost instance into another begins with exporting data
 You can export the following data types:
 
 - Teams
+- Threaded discussions
 - Channels (public, private, and direct)
 - Users
 - Users' team memberships
 - Users' channel memberships
 - Users' custom status
+- Direct message and group message channels
+- Direct message and group message channels' read/unread status
 - Posts (messages in public or private channels and replies to those messages)
 
 .. include:: bulk-export-data.rst

--- a/source/onboard/bulk-loading-data.rst
+++ b/source/onboard/bulk-loading-data.rst
@@ -9,6 +9,7 @@ Large quantities of data can be imported from a `JSONL <https://jsonlines.org>`_
 You can import the following data types:
 
 - Teams
+- Threaded discussions
 - Channels (public and private)
 - Users
 - Users' team memberships
@@ -20,6 +21,7 @@ You can import the following data types:
 - Posts' reactions
 - Posts' file attachments
 - Direct message and group message channels
+- Direct message and group message channels' read/unread status
 - Direct messages and group messages
 - Direct messages from a user to themselves
 - Permissions schemes


### PR DESCRIPTION
Hello Mattermost Team,

I have added newly supported components (Mattermost v10.1) to `onboard/bulk-loading-data.rst` and `manage/bulk-export-tool.rst`.

#### Summary

I made sure that both files mention the following components:

- direct and group message channels
- direct and group message read/unread status
- threaded discussions

 `onboard/bulk-loading-data.rst` :
 
https://github.com/arilloid/docs/blob/issue-7458/source/onboard/bulk-loading-data.rst

<img width="475" alt="image" src="https://github.com/user-attachments/assets/b56c7694-a517-46c5-ade1-c51abccc575b">

`manage/bulk-export-tool.rst`:

https://github.com/arilloid/docs/blob/issue-7458/source/manage/bulk-export-tool.rst

<img width="467" alt="image" src="https://github.com/user-attachments/assets/93df33db-a644-4ec3-9805-471e188f1b42">


#### Ticket Link

Fixes https://github.com/mattermost/docs/issues/7458



