### PR TITLE
Fix Acknowledgement icons in Dark Mode

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -3827,7 +3827,6 @@ rst_prolog = """
     :class: theme-icon
 .. |acknowledge-button| image:: /images/Ack-Button-Default.svg
     :alt: Select the Acknowledge button to indicate that you've read it and taken necessary action.
-    :class: theme-icon
 .. |reply-arrow| image:: /images/reply-outline_F0F20.svg
     :alt: Reply icon.
     :class: theme-icon


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Removes CSS class from `|acknowledge-button|` which causes the button to appear red instead of green in dark mode.

Before:
![before change](https://github.com/user-attachments/assets/8e0de8cd-e8c4-4c0d-98e1-62630fb9a037)

After:
![after change](https://github.com/user-attachments/assets/f63f1728-658e-4729-a110-2b54d62bc45d)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/docs/issues/7459
