### PR TITLE
Update install-desktop-app.rst with note about network share installation

### DIFF
--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -28,6 +28,9 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
     1. Download the latest version of the Mattermost desktop app for the `64-bit version of Windows <https://releases.mattermost.com/desktop/5.9.0/mattermost-desktop-5.9.0-win-x64.msi>`_
     2. From the **\Downloads** folder, right-click on the file ``mattermost-desktop-setup-5.9.0-win.exe``, then select **Open** to start an installer for the app. Once finished, the Mattermost desktop app opens automatically.
 
+.. warning:: 
+  Mattermost Desktop should always be installed on a local drive. Network Shares are not supported as installation locations.
+
   **MSI Installer and group policies**
 
   The following group policies are available supporting a state option of Not Configured, Enabled, or Disabled:
@@ -46,9 +49,6 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
   **Disable automatic updates**
   
   Automatic desktop app updates can be disabled by configuring the supported group policy. See the :doc:`MSI installer and group policy documentation </install/desktop-msi-installer-and-group-policy-install>` for instructions on installing the Mattermost Desktop App via an MSI installer, configuring supported group policies, and performing silent MSI installations. Changes to group policies require you to restart Mattermost for those changes to take effect.
-
-.. warning:: 
-  Mattermost Desktop should always be installed on a local drive. Network Shares are not supported as installation locations.
 
 .. tab:: macOS
 

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -28,7 +28,7 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
     1. Download the latest version of the Mattermost desktop app for the `64-bit version of Windows <https://releases.mattermost.com/desktop/5.9.0/mattermost-desktop-5.9.0-win-x64.msi>`_
     2. From the **\Downloads** folder, right-click on the file ``mattermost-desktop-setup-5.9.0-win.exe``, then select **Open** to start an installer for the app. Once finished, the Mattermost desktop app opens automatically.
 
-.. warning:: 
+  .. warning:: 
   Mattermost Desktop should always be installed on a local drive. Network Shares are not supported as installation locations.
 
   **MSI Installer and group policies**

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -29,7 +29,7 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
     2. From the **\Downloads** folder, right-click on the file ``mattermost-desktop-setup-5.9.0-win.exe``, then select **Open** to start an installer for the app. Once finished, the Mattermost desktop app opens automatically.
 
   .. warning:: 
-  Mattermost Desktop should always be installed on a local drive. Network Shares are not supported as installation locations.
+    Mattermost Desktop should always be installed on a local drive. Network Shares are not supported as installation locations.
 
   **MSI Installer and group policies**
 

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -47,6 +47,9 @@ You can download the `desktop app <https://mattermost.com/apps/>`_ directly from
   
   Automatic desktop app updates can be disabled by configuring the supported group policy. See the :doc:`MSI installer and group policy documentation </install/desktop-msi-installer-and-group-policy-install>` for instructions on installing the Mattermost Desktop App via an MSI installer, configuring supported group policies, and performing silent MSI installations. Changes to group policies require you to restart Mattermost for those changes to take effect.
 
+.. warning:: 
+  Mattermost Desktop should always be installed on a local drive. Network Shares are not supported as installation locations.
+
 .. tab:: macOS
 
   MacOS 11+ is required. You have two ways to install the desktop app, and how you install the app determines whether it updates automatically.


### PR DESCRIPTION
Network shares are not supported for desktop app installation so I added a warning to the windows install docs