### PR TITLE
Added justification for disabling key configs to improve performance

### DIFF
--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -1097,6 +1097,17 @@ Disable database search
 | - If all of the above methods fail or are disabled, the search results will be empty.                                                        |
 +---------------------------------------------------------------+------------------------------------------------------------------------------+
 
+.. note::
+
+  Disabling this configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Reduced Database Load: When database search is enabled, every search query executed by users needs to interact with the database, leading to additional load on the database server. By disabling database search, you can avoid these queries, thereby reducing the database load.
+  - Improved Response Time: Database searches can be time-consuming, especially with large datasets. Disabling database search can result in faster response times because the system no longer spends time fetching and processing search results from the database.
+  - Offloading Search to Indexing Services: Disabling database search often means that searches are offloaded to specialized indexing services like Elasticsearch, which are optimized for search operations. These services can provide faster and more efficient search capabilities compared to traditional database searches.
+  - Lower Resource Consumption: Running search queries directly against the database can be resource-intensive (using CPU and memory). With database search disabled, these resources can be allocated to other critical functions, improving overall system performance.
+  - Enhanced Scalability: As the number of users and data volume grow, database search can become less efficient. Specialized search services are designed to scale more effectively, enhancing overall system scalability and performance.
+  - However, the ability to perform database searches in Mattermost is a critical feature for many users, particularly when other search engines aren't enabled. Disabling this feature will result in users seeing an error if they attempt to use the Mattermost Search box. It’s important to balance performance improvements with the needs of your organization and users.
+
 Applied schema migrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -253,11 +253,21 @@ Enable automatic replies
 Enable channel viewed websocket messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This setting determines whether ``channel_viewed WebSocket`` events are sent, which synchronize unread notifications across clients and devices. Disabling the setting in larger deployments may improve server performance.
+This setting determines whether ``channel_viewed WebSocket`` events are sent, which synchronize unread notifications across clients and devices.
 
 +------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableChannelViewedMessages": true`` with options ``true`` and ``false``. |
 +------------------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+  Disabling this experimental configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Reduced Database Load: When channel_viewed events are disabled, the server no longer needs to log these events in the database. This reduces the number of write and update operations, which can be substantial in a busy server with many users frequently switching channels.
+  - Decreased Network Traffic: Disabling these events means there are fewer messages sent between the server and clients. This reduction in network traffic can lower latency and improve the overall responsiveness of the server, especially for users with slower connections.
+  - Lower Server CPU Usage: Processing channel_viewed events requires CPU resources to handle database transactions and network communication. Without these events, the server's CPU can be utilized more efficiently for other tasks, improving the overall performance.
+  - Improved User Experience: With reduced server load and network traffic, users may experience faster loading times and a more fluid interaction with the application.
+  - However, disabling this configuration setting affects some functionality, such as accurate tracking of read and unread messages in channels. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: exp-enabledefaultchannelleavejoinmessages
   :displayname: Enable default channel leave/join system messages (Experimental)
@@ -437,11 +447,19 @@ Enable onboarding flow
 Enable user typing messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This setting determines whether "user is typing..." messages are displayed below the message box. Disabling the setting in larger deployments may improve server performance.
+This setting determines whether "user is typing..." messages are displayed below the message box when using Mattermost in a web browser or the desktiop app. 
 
 +---------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableUserTypingMessages": true`` with options ``true`` and ``false``. |
 +---------------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+  Disabling this experimental configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Reduced Server Load: Typing events generate additional websocket traffic. Disabling them can reduce the amount of data that needs to be handled by the server, improving the overall response time and decreasing server load.
+  - Lower Network Traffic: When typing events are enabled, every keystroke generates a network event. This can lead to a significant amount of network traffic, particularly in busy channels. Disabling these events reduces the amount of information transmitted over the network.
+  - Client Performance: On the client side, processing typing events requires resources. By not having to handle these events, the client can be more responsive and use less memory and CPU.
 
 .. config:setting:: exp-usertypingtimeout
   :displayname: User typing timeout (Experimental)
@@ -1724,11 +1742,22 @@ Enable post search
 
 This setting isn't available in the System Console and can only be set in ``config.json``.
 
-If this setting is enabled, users can search messages. Disabling search can result in a performance increase, but users get an error message when they attempt to use the search box.
+If this setting is enabled, users can search for messages in their Mattermost instance.
 
 +-------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnablePostSearch": true`` with options ``true`` and ``false``. |
 +-------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+  Disabling this experimental configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Reduced Database Load: When post search is enabled, every search query adds additional load to the database. Disabling search reduces these queries, leading to better database performance and lower response times for other operations.
+  - Lower Memory Usage: Search functionality often requires indexing of posts, which consumes memory. By disabling search, the memory required for maintaining these indexes is freed up for other uses, improving overall system performance.
+  - Faster Write Operations: When post search is enabled, indexing has to be updated with every new post, edit, or deletion. Disabling search avoids this overhead, allowing for faster write operations.
+  - Performance Consistency: Without the search feature, the application avoids potential performance bottlenecks and can maintain more consistent performance levels, especially under heavy usage scenarios with a high number of posts.
+  - Simplified System Maintenance: Managing search indexes can be complex and resource-intensive. Disabling search simplifies this aspect of system maintenance, potentially reducing the risk of performance issues related to search index corruption or degradation.
+  - However, the ability to search messages in Mattermost is a critical feature for many users, and disabling this feature will result in users seeing an error if they attempt to use the Mattermost Search box. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: exp-enablefilesearch
   :displayname: Enable file search (Experimental)
@@ -1742,7 +1771,9 @@ Enable file search
 
 This setting isn't available in the System Console and can only be set in ``config.json``.
 
-This configuration setting enables users to search documents attached to messages by filename. To enable users to search documents by their content, you must also enable the ``ExtractContent`` configuration setting. See our :ref:`Enable Document Search by Content <configure/environment-configuration-settings:enable document search by content>` documentation for details. Document content search is available in Mattermost Server from v5.35, with mobile support coming soon.
+.. important::
+
+  This experimental configuration setting enables users to search documents attached to messages by filename. To enable users to search documents by their content, you must also enable the ``ExtractContent`` configuration setting. See our :ref:`Enable Document Search by Content <configure/environment-configuration-settings:enable document search by content>` documentation for details. Document content search is available in Mattermost Server from v5.35, with mobile support coming soon.
 
 **True**: Supported document types are searchable by their filename.
 
@@ -1751,6 +1782,15 @@ This configuration setting enables users to search documents attached to message
 +-------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableFileSearch": true`` with options ``true`` and ``false``. |
 +-------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+  Disabling this experimental configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Less Data to Index: Indexing files in addition to messages adds to the amount of data that needs to be processed and stored in the search index.
+  - Fewer Complex Queries: Searching through files can require more complex queries, which can be more resource-intensive and time-consuming as compared to searching through messages alone.
+  - Lower IO Operations: Searching files can generate more input/output operations, impacting the overall disk performance, especially if the system handles a large volume of file uploads and searches.
+  - However, the ability to search for files in Mattermost is a critical feature for many users, and disabling this feature will result in users seeing an error if they attempt to use the Mattermost Search box. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: exp-enableuserstatusupdates
   :displayname: Enable user status updates (Experimental)

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -447,7 +447,7 @@ Enable onboarding flow
 Enable user typing messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This setting determines whether "user is typing..." messages are displayed below the message box when using Mattermost in a web browser or the desktiop app. 
+This setting determines whether "user is typing..." messages are displayed below the message box when using Mattermost in a web browser or the desktop app. 
 
 +---------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"EnableUserTypingMessages": true`` with options ``true`` and ``false``. |

--- a/source/configure/integrations-configuration-settings.rst
+++ b/source/configure/integrations-configuration-settings.rst
@@ -71,6 +71,17 @@ Developers building integrations can create webhook tokens for public channels. 
 | This feature's ``config.json`` setting is ``"EnableOutgoingWebhooks": true`` with options ``true`` and ``false``. |
 +-------------------------------------------------------------------------------------------------------------------+
 
+.. note::
+
+  Disabling this configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Reduced Network Traffic: Outgoing webhooks generate network requests to external services. Disabling them reduces the amount of traffic and resource usage related to those requests.
+  - Decreased Load on Server: Handling webhook events and managing connections to external services uses server resources. By disabling outgoing webhooks, the server workload is reduced, allowing it to allocate more resources to other important tasks.
+  - Improved Response Time: When outgoing webhooks are enabled, the server waits for the external services to return responses, potentially slowing down the performance if the external services are slow or unresponsive. Disabling them removes this dependency, leading to faster response times for user requests.
+  - Lower Memory Usage: Webhooks need memory to process and store data about the requests and responses. Disabling them can free up memory which can be used to improve overall server performance.
+  - Simplified Error Handling: Managing errors and retries for outgoing webhook failures can add complexity and overhead. Disabling outgoing webhooks can simplify error handling and reduce the processing overhead associated with it.
+  - However, outgoing webhooks are often essential for integrating Mattermost with other services and workflows. It’s important to balance performance improvements with the needs of your organization and users.
+
 .. config:setting:: integrate-enablecustomslashcommands
   :displayname: Enable custom slash commands (Integrations)
   :systemconsole: Integrations > Integration Management

--- a/source/configure/plugins-configuration-settings.rst
+++ b/source/configure/plugins-configuration-settings.rst
@@ -31,6 +31,18 @@ Enable plugins
 |                                                                                                                                                                                                                           | - Environment variable: ``MM_PLUGINSETTINGS_ENABLE``                  |
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------+
 
+.. note::
+
+  Disabling this configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Resource Consumption: Plugins consume system resources such as CPU, memory, and disk. Disabling them frees up these resources, allowing the core Mattermost application to run more efficiently.
+  - Reduced Complexity: Each plugin can add additional logic and processing requirements. By reducing the number of active plugins, you lower the complexity and potential points of failure in the system.
+  - Faster Load Times: Disabling plugins can lead to faster server startup and lower latency during user interactions, as there are fewer components for the system to initialize and manage.
+  - Stability: Some plugins may have bugs or performance issues that can affect the overall performance and stability of the Mattermost instance. Disabling problematic or under-utilized plugins can enhance the stability of the system.
+  - Maintenance and Updates: Managing fewer plugins reduces the overhead associated with maintaining and updating them, which can contribute to smoother operation and less downtime
+  - However, plugins are often essential for integrating Mattermost with other services and workflows. It’s important to balance performance improvements with the needs of your organization and users.
+
+
 .. config:setting:: plugins-requiresignature
   :displayname: Require plugin signature (Plugins - Management)
   :systemconsole: Plugins > Plugin Management

--- a/source/configure/push-notification-server-configuration-settings.rst
+++ b/source/configure/push-notification-server-configuration-settings.rst
@@ -35,21 +35,22 @@ Enable push notifications
 |   own mobile push proxy service, and specify that URL in the     |                                                                                |
 |   **Push Notification Server** field.                            |                                                                                |
 +------------------------------------------------------------------+--------------------------------------------------------------------------------+
-| **Notes**:                                                                                                                                        |
-|                                                                                                                                                   |
-| - Mattermost Enterprise, Professional, and Cloud customers can use Mattermost’s SLA-bound :ref:`Hosted Push Notification Service (HPNS)           |
-|   <deploy/mobile-hpns:hosted push notifications service (hpns)>` in one of two locations, including the United States and Germany.                |
-|   Mattermost Team Edition customers can use Mattermost's                                                                                          |
-|   :ref:`Test Push Notification server (TPNS) <deploy/mobile-hpns:test push notifications service (tpns)>`.                                        |
-| - The TPNS is provided for testing push notifications prior to compiling your own service, and isn't available for Mattermost Cloud deployments.  |
-|   Ensure you’re familiar with its limitations.                                                                                                    |
-| - Review the :doc:`mobile push notifications </deploy/mobile-hpns>` and :doc:`mobile apps </deploy/build-custom-mobile-apps>` documentation,      |
-|   including guidance on compiling your own mobile apps and MPNS, before deploying to production.                                                  |
-| - See the :ref:`documentation <deploy/mobile-hpns:host your own push proxy service>` for details on hosting your own push proxy service.          |
-| - To confirm push notifications are working, connect to the `Mattermost iOS App <https://apps.apple.com/us/app/mattermost/id1257222717>`__        |
-|   available on the App Store, or the `Mattermost Android App <https://play.google.com/store/apps/details?id=com.mattermost.rn>`__ available on    |
-|   Google Play.                                                                                                                                    |
-+-----------------------------------------------------------------+---------------------------------------------------------------------------------+
+
+.. note::
+
+  - Mattermost Enterprise, Professional, and Cloud customers can use Mattermost’s SLA-bound :ref:`Hosted Push Notification Service (HPNS) <deploy/mobile-hpns:hosted push notifications service (hpns)>` in one of two locations, including the United States and Germany.
+  - Mattermost Team Edition customers can use Mattermost's :ref:`Test Push Notification server (TPNS) <deploy/mobile-hpns:test push notifications service (tpns)>`.
+  - The TPNS is provided for testing push notifications prior to compiling your own service, and isn't available for Mattermost Cloud deployments. Ensure you’re familiar with its limitations.
+  - Review the :doc:`mobile push notifications </deploy/mobile-hpns>` and :doc:`mobile apps </deploy/build-custom-mobile-apps>` documentation, including guidance on compiling your own mobile apps and MPNS, before deploying to production. See the :ref:`documentation <deploy/mobile-hpns:host your own push proxy service>` for details on hosting your own push proxy service.
+  - To confirm push notifications are working, connect to the `Mattermost iOS App <https://apps.apple.com/us/app/mattermost/id1257222717>`__ available on the App Store, or the `Mattermost Android App <https://play.google.com/store/apps/details?id=com.mattermost.rn>`__ available on Google Play.
+  - If you don't need or want Mattermost to send mobile push notifications, disabling this configuration setting in larger deployments may improve server performance in the following areas:
+
+    - Reduced Processing Load: Generating and sending push notifications requires processing power and resources. By disabling them, the server can allocate those resources to other tasks.
+    - Decreased Network Traffic: Push notifications involve network communication. Disabling them reduces the amount of data being transferred, which can enhance overall network performance.
+    - Lower Database Load: Each push notification may involve reading from and writing to the database. Reducing these operations decreases the load on the database, improving response times for other queries.
+    - Faster Response Times: With fewer tasks to handle related to notifications, the system can respond faster to other requests from users, leading to a better user experience.
+    - Simplified Error Handling: Push notification services can sometimes fail or have latency issues, requiring additional error handling. Disabling these notifications simplifies the system's operations.
+    - However, disabling push notifications can negatively impact user experience, communication efficiency, and overall productivity. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: push-serverlocation
   :displayname: Push notification server location (Push Notifications)
@@ -95,7 +96,15 @@ Maximum notifications per channel
 |                                                                 |                                                                                      |
 | Numerical input. Default is **1000**.                           |                                                                                      |
 +-----------------------------------------------------------------+--------------------------------------------------------------------------------------+
-| **Note**: We recommend increasing this value a little at a time, monitoring system health by tracking :doc:`performance monitoring metrics             |
-| </scale/deploy-prometheus-grafana-for-performance-monitoring>`, and only increasing this value if large channels have restricted permissions           |
-| controlling who can post to the channel, such as a :ref:`read-only channel <onboard/advanced-permissions:read only channels>`.                         |
-+-----------------------------------------------------------------+--------------------------------------------------------------------------------------+
+
+.. note::
+
+  - We recommend increasing this value a little at a time, monitoring system health by tracking :doc:`performance monitoring metrics </scale/deploy-prometheus-grafana-for-performance-monitoring>`, and only increasing this value if large channels have restricted permissions controlling who can post to the channel, such as a :ref:`read-only channel <onboard/advanced-permissions:read only channels>`.
+  - Reducing this configuration setting value to **10** in larger deployments may improve server performance in the following areas:
+
+    - Reduced Load on Notification System: Each notification generates a certain amount of computational and network load. By limiting the number of notifications per channel, the system processes fewer notifications, thereby reducing the load on servers.
+    - Database Efficiency: Notifications are typically stored in a database. Fewer notifications mean less frequent database writes and reads, leading to quicker database operations and reduced latency.
+    - Minimized Client Processing: Users' clients (e.g., desktop and mobile apps) have to fetch and process notifications. With fewer notifications, clients can operate more efficiently, reducing memory and CPU usage on users' devices.
+    - Improved User Experience: An overload of notifications can lead to performance lags and a cluttered experience for users. Limiting the number ensures that users receive only the most important notifications, which can enhance usability and response times.
+    - Network Bandwidth: High numbers of notifications can consume a lot of bandwidth, particularly if they are being sent to many users. Fewer notifications can lead to lower overall network usage and potentially faster delivery of critical messages.
+    - Server Load Balancing: By reducing the number of notifications, the workload can be more evenly distributed across the servers, leading to better load balancing and preventing any single server from becoming a bottleneck.

--- a/source/configure/site-configuration-settings.rst
+++ b/source/configure/site-configuration-settings.rst
@@ -819,6 +819,14 @@ Enable email notifications
   - Cloud admins can't modify this configuration setting.
   - If this setting is **false**, and the SMTP server is set up, account-related emails (such as authentication messages) will be sent regardless of this setting.
   - Email invitations and account deactivation emails aren't affected by this setting.
+  - If you don't plan on :doc:`configuring Mattermost for email </configure/smtp-email>`, disabling this configuration setting in larger deployments may improve server performance in the following areas, particularly in high-traffic environments where performance is a key concern:
+
+    - Reduced Server Load: Generating and sending emails requires processing power and resources. By disabling email notifications, you reduce the load on the server, which can be reallocated to other tasks.
+    - Decreased I/O Operations: Sending emails involves input/output (I/O) operations, such as writing to logs and databases, and handling communication with the email server. Reducing these I/O operations can improve overall system efficiency.
+    - Lowered Network Traffic: Each email sent contributes to network traffic. Disabling email notifications decreases the amount of data being transmitted, which can lead to better performance, especially in environments with limited bandwidth.
+    - Faster Response Times: With fewer background tasks (like sending emails) to handle, the application can potentially respond to user requests more quickly, improving perceived performance.
+    - Resource Allocation: Resources like CPU cycles, memory, and network bandwidth that would have been used for sending emails can be used elsewhere, possibly improving the performance of other critical components of the system.
+    - However, disabling email notifications can negatively impact user experience, communication efficiency, and overall productivity. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: notification-enablepreviewbanner
   :displayname: Enable preview mode banner (Notifications)
@@ -1271,6 +1279,10 @@ Threaded discussions
 Message priority
 ~~~~~~~~~~~~~~~~~
 
+.. tip::
+  `Mattermost Enterprise or Professional <https://mattermost.com/pricing>`__ customers can additionally request message acknowledgements to
+  track that specific, time-sensitive messages have been seen and actioned. See the :doc:`message priority </collaborate/message-priority>` documentation to learn more.
+
 +-----------------------------------------------------------------------------+----------------------------------------------------------------------------------+
 | - **true**: **(Default)** Enables message priority for all users which      | - System Config path: **Site Configuration > Posts**                             |
 |   enables them to set a visual indiciator for important or urgent root      | - ``config.json`` setting: ``ServiceSettings`` > ``PostPriority`` > ``true``     |
@@ -1280,9 +1292,13 @@ Message priority
 +-----------------------------------------------------------------------------+----------------------------------------------------------------------------------+
 
 .. note::
-  `Mattermost Enterprise or Professional <https://mattermost.com/pricing>`__ customers can additionally request message acknowledgements to
-  track that specific, time-sensitive messages have been seen and actioned. See the
-  :doc:`message priority </collaborate/message-priority>` documentation to learn more.
+
+  Disabling this configuration setting in larger deployments may improve server performance in the following areas, particularly in environments where performance and responsiveness are critical:
+
+  - Simplified Processing: When post priority is enabled, the system has to manage and prioritize posts based on their designated priority levels. This adds additional processing overhead as the system must evaluate and sort posts accordingly. By disabling this feature, all posts are treated equally, which simplifies the processing logic and reduces the computational load.
+  - Reduced Latency: With post priority enabled, there might be delays introduced while the system determines the priority of each post and processes them in the correct order. Disabling post priority can lead to more consistent and potentially quicker handling of posts because the system processes them on a first-come, first-served basis.
+  - Lower Resource Utilization: Managing post priorities can consume additional system resources such as CPU and memory. Disabling this feature can free up these resources, allowing the system to allocate them to other tasks, thereby improving overall performance.
+  - Improved Scalability: In a high-traffic environment, the complexity of managing post priorities can become more pronounced. Disabling this feature simplifies the system's operations, making it easier to scale as the number of users and posts increases.
 
 .. config:setting:: posts-persistentnotifications
   :displayname: Persistent notifications (Posts)
@@ -1365,6 +1381,10 @@ Total number of persistent notifications per post
 Enable website link previews
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. important::
+
+  The server must be connected to the internet to generate previews. This connection can be established through a :doc:`firewall or outbound proxy </configure/using-outbound-proxy>` if necessary.
+
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
 | - **true**: The server generates a preview of the first website, image, or YouTube video linked in a message. Users can disable website previews, but not image or YouTube previews, under **Settings > Display > Website Link Previews**. | - System Config path: **Site Configuration > Posts**                               |
 | - **false**: **(Default)** All previews are disabled and the server does not request metadata for any links contained in messages.                                                                                                         | - ``config.json`` setting: ``ServiceSettings`` > ``EnableLinkPreviews`` > ``true`` |
@@ -1372,7 +1392,15 @@ Enable website link previews
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
 
 .. note::
-  The server must be connected to the internet to generate previews. This connection can be established through a :doc:`firewall or outbound proxy </configure/using-outbound-proxy>` if necessary.
+
+  Disabling this configuration setting in larger deployments may improve server performance in the following areas:
+
+  - Reduced Network Requests: When link previews are enabled, the system needs to fetch metadata (such as title, description, or image) from the linked webpage. This requires additional network requests, which can slow down the system.
+  - Lower Server Load: Creating link previews involves parsing the content of the linked pages. If many users are sharing links, the server will have to perform numerous network requests and process a lot of additional data, increasing the load on the server.
+  - Less Data Processing: Every link shared needs to be processed to extract the necessary preview information. This processing consumes CPU and memory resources, which can otherwise be reserved for other tasks.
+  - Decreased Client-Side Rendering Time: On the client side, rendering link previews (adding text, images, and layouts) takes time and resources. Disabling link previews means that clients do not need to render these elements, leading to faster message display.
+  - Saved Bandwidth: Link previews often include images and other data from the linked content. By disabling them, you save the bandwidth that would be used to download these additional resources.
+  - However, disabling link previews can negatively impact user experience, communication efficiency, and overall productivity. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: posts-disablepreviewsperdomain
   :displayname: Disable link previews for specific domains (Posts)
@@ -1407,6 +1435,17 @@ Enable message link previews
 | - **false**: Share links do not generate a preview.                                                                                                                                                         | - ``config.json`` setting: ``ServiceSettings`` > ``EnablePermalinkPreviews`` > ``true`` |
 |                                                                                                                                                                                                             | - Environment variable: ``MM_SERVICESETTINGS_ENABLEPERMALINKPREVIEWS``                  |
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
+
+.. note::
+
+  Disabling this configuration setting in larger deployments may improve server performance in the following areas, particularly in environments with high message throughput or limited resources:
+
+  - Reduced Server Load: When permalink previews are enabled, the server has to generate preview summaries for each shared link. This generates additional requests to fetch metadata and may involve parsing web pages, which increases the processing load on the server.
+  - Less Data Transfer: Permalink previews include additional metadata such as images, titles, and descriptions. Disabling previews reduces the amount of data that needs to be transferred, which can decrease bandwidth usage and improve message load times, particularly for channels with a high volume of links.
+  - Faster Message Rendering: On the client-side, rendering messages with multimedia previews takes more time compared to plain text messages. Disabling previews can reduce rendering complexity and improve client performance, especially on devices with limited resources.
+  - Network Latency: Fetching metadata for link previews may introduce network latency, as the server must reach out to external resources. Disabling this can eliminate these delays, ensuring faster message processing and display.
+  - Simplified Message Handling: In the absence of previews, messages are simpler and less resource-intensive to store, retrieve, and display. This can contribute to overall improved system responsiveness and efficiency.
+  - However, disabling permalink previews can negatively impact user experience, communication efficiency, and overall productivity. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: posts-enablesvg
   :displayname: Enable SVGs (Posts)
@@ -1553,6 +1592,17 @@ Enable server syncing of message drafts
 | - **false**: Draft messages are stored locally       |                                                                                          |
 |   on each device.                                    |                                                                                          |
 +------------------------------------------------------+------------------------------------------------------------------------------------------+
+
+.. note::
+
+  While drafts can be very useful for maintaining work continuity, especially in collaborative environments, disabling draft synchronization across devices can lead to noticeable performance improvements by reducing the computational and data management overhead as follows:
+
+  - Reduced Data Synchronization: When drafts are enabled and synchronized across devices, the system needs to handle those data synchronization operations which can consume significant bandwidth and computing resources. Disabling draft syncing reduces the load on servers and networks.
+  - Lower Storage Usage: Storing drafts requires additional database operations and storage space. Each draft is an extra piece of data that needs to be saved, managed, and retrieved. Without drafts, the system has fewer records to keep, which can streamline database operations.
+  - Decreased Client Processing: On the client side, draft management involves monitoring changes, saving drafts periodically, and handling conflict resolution if multiple drafts are edited from different devices. Disabling drafts reduces these client-side processes, thus freeing up memory and CPU resources.
+  - Simplified Architecture: Maintaining synced drafts often requires complex backend logic to ensure consistency and avoid data conflicts. Simplifying this architecture by removing draft syncing can lead to more efficient and faster backend operations.
+  - Improved User Experience: Users may experience faster load times and reduced latency without the overhead of draft syncing. This can be particularly noticeable in environments with limited or variable internet connectivity.
+  - However, disabling draft synchronization can negatively impact user experience, communication efficiency, and overall productivity. It’s important to balance performance improvements with the needs of your organization and users.
 
 .. config:setting:: posts-UniqueEmojiReactionLimit
   :displayname: Unique emoji reaction limit (Posts)


### PR DESCRIPTION
Incorporated [Engineering thought leadership](https://mattermost.atlassian.net/wiki/spaces/XYZ/pages/2548138281/Config+knobs+to+disable+for+a+faster+Mattermost) on disabling key config settings to improve performance.