### PR TITLE
Added license requirement for schedule post feature in release notes

### DIFF
--- a/source/about/mattermost-v10-changelog.md
+++ b/source/about/mattermost-v10-changelog.md
@@ -36,7 +36,7 @@ See [this walkthrough video](https://mattermost.com/video/mattermost-v10-3-chang
 #### User Interface (UI)
  - Pre-packaged Calls plugin [v1.3.0](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.3.0).
  - Downgraded Traditional Chinese language to Beta.
- - Added a feature to schedule a post for the future. Scheduling a post requires a Professional/Enterprise license to activate.
+ - Added a feature to schedule a message at a future date (Professional and Enterprise plans).
  - Copilot plugin is now installed and enabled by default.
  - Added an option to test notifications.
  - Added a new search interface.

--- a/source/about/mattermost-v10-changelog.md
+++ b/source/about/mattermost-v10-changelog.md
@@ -36,7 +36,7 @@ See [this walkthrough video](https://mattermost.com/video/mattermost-v10-3-chang
 #### User Interface (UI)
  - Pre-packaged Calls plugin [v1.3.0](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.3.0).
  - Downgraded Traditional Chinese language to Beta.
- - Added a feature to schedule a post for the future.
+ - Added a feature to schedule a post for the future. Scheduling a post requires a Professional/Enterprise license to activate.
  - Copilot plugin is now installed and enabled by default.
  - Added an option to test notifications.
  - Added a new search interface.


### PR DESCRIPTION
#### Summary

Updated v10.3 changelog to clarify that Schedule posts requires a license to activate.

