### PR TITLE
Fix missing links due to RST markup issue

### DIFF
--- a/source/manage/cloud-data-export.rst
+++ b/source/manage/cloud-data-export.rst
@@ -4,7 +4,7 @@ Mattermost workspace migration
 .. include:: ../_static/badges/allplans-cloud.rst
   :start-after: :nosearch:
 
-This document outlines the process for migrating an existing Mattermost instance `from self-hosted to Cloud <#migrate-from-self-hosted-to-cloud>`, and `from Cloud to self-hosted <#migrate-from-cloud-to-self-hosted>`.
+This document outlines the process for migrating an existing Mattermost instance `from self-hosted to Cloud <#migrate-from-self-hosted-to-cloud>`_, and `from Cloud to self-hosted <#migrate-from-cloud-to-self-hosted>`_.
 
 .. note::
    

--- a/source/manage/cloud-data-export.rst
+++ b/source/manage/cloud-data-export.rst
@@ -4,7 +4,7 @@ Mattermost workspace migration
 .. include:: ../_static/badges/allplans-cloud.rst
   :start-after: :nosearch:
 
-This document outlines the process for migrating an existing Mattermost instance `from self-hosted to Cloud <#migrate-from-self-hosted-to-cloud>`_, and `from Cloud to self-hosted <#migrate-from-cloud-to-self-hosted>`_.
+This document outlines the process for migrating an existing Mattermost instance `from self-hosted to Cloud <#migrate-from-self-hosted-to-cloud>`__, and `from Cloud to self-hosted <#migrate-from-cloud-to-self-hosted>`__.
 
 .. note::
    


### PR DESCRIPTION

#### Summary

The header of [this page](https://docs.mattermost.com/manage/cloud-data-export.html) currently looks like this:

![Capture d’écran du 2024-12-26 12-42-56](https://github.com/user-attachments/assets/75983dcf-f3da-4a4a-8241-e9d73203fb01)

The RST markup is invalid, this PR fixes it so that the links appear correctly.

#### Ticket Link
None
