### PR TITLE
Update mmctl export create docs with additional options

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -2292,7 +2292,10 @@ Create an export file including message attachments.
 .. code-block:: sh
 
    --no-attachments              Omit file attachments in the export file.
+   --no-roles-and-schemes        Exclude roles and custom permission schemes from the export file.
    --include-archived-channels   Include archived channels in the export file.
+   --include-profile-pictures    Include profile pictures in the export file.
+   --team string                 Name of the team to restrict the export to.
    -h, --help                    help for create
 
 **Options inherited from parent commands**


### PR DESCRIPTION



#### Summary

This adds a couple of new options to the `mmctl export create` command:
* `--no-roles-and-schemes` and `--include-profile-pictures` (which are already supported in Mattermost 10)
* `--team`, which will be introduced by https://github.com/mattermost/mattermost/pull/29406.

This PR should only be merged once https://github.com/mattermost/mattermost/pull/29406 is.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61997

