### PR TITLE
Add Warning About HA Deployment Across Multiple Datacenters

### DIFF
--- a/source/scale/high-availability-cluster-based-deployment.rst
+++ b/source/scale/high-availability-cluster-based-deployment.rst
@@ -25,7 +25,7 @@ Update sequence for continuous operation
 
   **Exception:** Changes to configuration settings that require a server restart, and server version upgrades that involve a change to the database schema, require a short period of downtime. Downtime for a server restart is around five seconds. For a database schema update, downtime can be up to 30 seconds.
 
-.. warning::
+.. important::
 
    Mattermost does not support high availability deployments spanning multiple datacenters. All nodes in a high availability cluster must reside within the same datacenter to ensure proper functionality and performance.
 

--- a/source/scale/high-availability-cluster-based-deployment.rst
+++ b/source/scale/high-availability-cluster-based-deployment.rst
@@ -25,6 +25,10 @@ Update sequence for continuous operation
 
   **Exception:** Changes to configuration settings that require a server restart, and server version upgrades that involve a change to the database schema, require a short period of downtime. Downtime for a server restart is around five seconds. For a database schema update, downtime can be up to 30 seconds.
 
+.. warning::
+
+   Mattermost does not support high availability deployments spanning multiple datacenters. All nodes in a high availability cluster must reside within the same datacenter to ensure proper functionality and performance.
+
 Deployment guide
 ----------------
 


### PR DESCRIPTION
This pull request adds a warning to the documentation for high availability (HA) deployments to clarify that Mattermost does not support HA clusters spanning multiple datacenters.

