### PR TITLE
add mmctl config export docs

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -1826,6 +1826,7 @@ Configuration settings.
 
    Child Commands
       -  `mmctl config edit`_ - Edit the configuration settings
+      -  `mmctl config export`_ - Export the server configuration
       -  `mmctl config get`_ - Get the value of a configuration setting
       -  `mmctl config migrate`_ - Migrate existing configuration between backends
       -  `mmctl config patch`_ - Patch the configuration
@@ -1865,6 +1866,47 @@ Open the editor defined in the EDITOR environment variable to modify the server'
 .. code-block:: sh
 
    -h, --help   help for edit
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
+   --disable-pager                disables paged output
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+   --json                         the output format will be in json format
+   --local                        allows communicating with the server through a unix socket
+   --quiet                        prevent mmctl to generate output for the commands
+   --strict                       will only run commands if the mmctl version matches the server one
+   --suppress-warnings            disables printing warning messages
+
+mmctl config export
+~~~~~~~~~~~~~~~~~~~
+
+**Description**
+
+Use this command to export the server configuration, which can then be imported into another server or environment. Masked values are only exported when the tool is running in `local mode <#local-mode>`__.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl config export [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   mmctl config export --remove-masked --remove-defaults
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help              help for export
+       --remove-defaults   remove default values from the exported configuration
+       --remove-masked     remove masked values from the exported configuration (default true)
 
 **Options inherited from parent commands**
 


### PR DESCRIPTION

#### Summary
Add necessary documentation for the new `mmctl config export` sub command.

#### Ticket Link
https://github.com/mattermost/mattermost/pull/28412

