### PR TITLE
Fix Typo in Gitlab Interoperability Docs

### DIFF
--- a/source/integrate/gitlab-interoperability.rst
+++ b/source/integrate/gitlab-interoperability.rst
@@ -65,7 +65,7 @@ Notify your teams that they can `connect their GitLab accounts to Mattermost <#c
 Upgrade
 -------
 
-We recommend updating this integration as new versions are released. Generally, updates are seamless and don't interrupt the user experience in Mattermost. Visit the `Releases page <https://github.com/mattermost/mattermost-plugin-gitlab/releases>`__ for the latest release, available releases, and compatibiilty considerations.
+We recommend updating this integration as new versions are released. Generally, updates are seamless and don't interrupt the user experience in Mattermost. Visit the `Releases page <https://github.com/mattermost/mattermost-plugin-gitlab/releases>`__ for the latest release, available releases, and compatibility considerations.
 
 Usage
 -----
@@ -79,14 +79,14 @@ Connect a GitLab account to Mattermost
 
 Run the ``/gitlab connect`` slash account in any Mattermost channel to link your Mattermost account with your GitLab account.
 
-Disconnect a GitLab account by running the ``/gitlab disconnect`` slash comamnd. Run the ``/gitlab me`` slash command to review which account is connected to GitLab.
+Disconnect a GitLab account by running the ``/gitlab disconnect`` slash command. Run the ``/gitlab me`` slash command to review which account is connected to GitLab.
 
 Once connected, run the ``/gitlab help`` slash command to see what you can do.
 
 Get started
 ~~~~~~~~~~~
 
-Run the  ``/gitlab todo`` slash command to get a list of todos, assigned issues, assigned merge requests and merge requests awaiting your review. Alternatively, use the options located in the left sidebar.
+Run the  ``/gitlab todo`` slash command to get a list of to-do's, assigned issues, assigned merge requests and merge requests awaiting your review. Alternatively, use the options located in the left sidebar.
 
 Run the ``/gitlab webhook`` slash command to have GitLab send events to Mattermost. For example: ``/gitlab webhook add group[/project]``
 
@@ -124,7 +124,7 @@ Get help
 
 Mattermost customers can open a `Mattermost support case <https://support.mattermost.com/hc/en-us/requests/new>`_. To report a bug, please open a GitHub issue against the `Mattermost GitLab plugin repository <https://github.com/mattermost/mattermost-plugin-gitlab>`_.
 
-For questions, feedback, and assistance, join our pubic `Integrations and Apps channel <https://community.mattermost.com/core/channels/integrations>`_ on the `Mattermost Community Server <https://community.mattermost.com/>`_ for assistance.
+For questions, feedback, and assistance, join our public `Integrations and Apps channel <https://community.mattermost.com/core/channels/integrations>`_ on the `Mattermost Community Server <https://community.mattermost.com/>`_ for assistance.
 
 Customize
 ---------


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Fix a few typo's in Gitlab interoperability documentation.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
N/A
