### PR TITLE
Fix Issue 7775 - duplicated text in make-calls.rst

### DIFF
--- a/source/collaborate/make-calls.rst
+++ b/source/collaborate/make-calls.rst
@@ -138,7 +138,7 @@ A chat thread is created automatically for every new call.
 
 .. tab:: Web/Desktop
 
-  Expand the call window using the arrows in the top-right of the call widget. From there, select the emoji icon to access frequently-used emojis or select additional emojis from the emoji picker.
+  Open the chat thread in the widget by selecting |gear| and there click on "Show chat thread". Alternative expand the call window using the arrows in the top-right of the call widget. From there, select the chat icon to access the chat thread.
 
 .. tab:: Mobile
   

--- a/source/collaborate/make-calls.rst
+++ b/source/collaborate/make-calls.rst
@@ -138,7 +138,7 @@ A chat thread is created automatically for every new call.
 
 .. tab:: Web/Desktop
 
-  Open the chat thread in the widget by selecting |gear| and there click on "Show chat thread". Alternative expand the call window using the arrows in the top-right of the call widget. From there, select the chat icon to access the chat thread.
+  Open the chat thread in the widget by selecting the **Gear** |gear| icon, then select **Show chat thread**. Alternatively, expand the call window using the arrows in the top-right of the call widget. From there, select the chat icon to access the chat thread.
 
 .. tab:: Mobile
   


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Replacing the duplicated sentence with a more explaining way for the Web/Desktop Chat thread in a call


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
  Fixes https://github.com/mattermost/docs/issues/7775


