### PR TITLE
Update bulk-loading-data.rst to use proper user `email_interval`

### DIFF
--- a/source/onboard/bulk-loading-data.rst
+++ b/source/onboard/bulk-loading-data.rst
@@ -859,7 +859,7 @@ Fields of the User object
       <td valign="middle">email_interval</td>
       <td valign="middle">string</td>
       <td>Specify an email batching interval during bulk import. Can have one of the following values:<br>
-          <kbd>"immediate"</kbd> - Emails are sent immediately.  <br>
+          <kbd>"immediately"</kbd> - Emails are sent immediately.  <br>
           <kbd>"fifteen"</kbd> - Emails are batched and sent every 15 minutes.<br>
           <kbd>"hour"</kbd> - Emails are batched and sent every hour.<br> </td>
       <td align="center" valign="middle">Yes</td>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Update the documentation to show the correct options for `email_interval` in `user`

