### PR TITLE
Updated config.json example blocks

### DIFF
--- a/source/onboard/sso-entraid.rst
+++ b/source/onboard/sso-entraid.rst
@@ -91,7 +91,8 @@ Instead of using the System Console, you can add the Entra ID settings directly 
 
 .. code-block:: text
 
-  "Enable": false,
+  "Office365Settings": {
+        "Enable": false,
         "Secret": "i.hddd6Pu3--5dg~cRddddqOrBdd1a",
         "Id": "28ddd714-1f2f-4f9c-9486-90b8dddd27",
         "Scope": "profile openid email",

--- a/source/onboard/sso-google.rst
+++ b/source/onboard/sso-google.rst
@@ -78,7 +78,8 @@ Instead of using the System Console, you can add the Google settings directly to
 
 .. code-block:: text
 
-  "Enable": true,
+  "GoogleSettings": {
+        "Enable": true,
         "Secret": "P-k9R-7E7ayX9LdddddWdXVg",
         "Id": "1022ddddd5846-bkddddd4a1ddddd9d88j1kb6eqc.apps.googleusercontent.com",
         "Scope": "profile openid email",


### PR DESCRIPTION
I didn't like how the codeblocks were formatted with the `"Enable":` line being not indented with the rest of the code. I could be convinced to leave off the `"Office365Settings":` and `"GoogleSettings":` line since that is mentioned in the line above it as part of the instructions, but the first line not being indented I think looked off.