### PR TITLE
Clarify domain access

### DIFF
--- a/source/collaborate/team-settings.rst
+++ b/source/collaborate/team-settings.rst
@@ -7,7 +7,7 @@ Team settings
 Team settings enable system and team administrators to adjust settings applied to a specific team. Using Mattermost in a web browser or the desktop app, select the team name to access **Team Settings**.
 
 .. image:: ../images/team-settings.png
-  :alt: Access team settings from the team name. 
+  :alt: Access team settings from the team name.
 
 Info settings
 -------------
@@ -17,29 +17,29 @@ Info settings provide configuration options for how teams are displayed to users
 Team name
 ~~~~~~~~~
 
-Your **Team Name** is displayed on the login screen, and in the top of the channel sidebar for your team. 
+Your **Team Name** is displayed on the login screen, and in the top of the channel sidebar for your team.
 
-Team names can contain any letters, numbers, or symbols, must be 2 - 64 characters in length, and are case-sensitive. 
+Team names can contain any letters, numbers, or symbols, must be 2 - 64 characters in length, and are case-sensitive.
 
 .. note::
-  
-  Team names don't support `some unicode characters <https://www.w3.org/TR/unicode-xml/#Charlist>`__. 
+
+  Team names don't support `some unicode characters <https://www.w3.org/TR/unicode-xml/#Charlist>`__.
 
 Team description
 ~~~~~~~~~~~~~~~~
 
 Your **Team Description** is displayed when viewing the list of teams available to join and in the tooltip when hovering over the team name in the team sidebar.
 
-You can enter a description up to 50 characters in length. 
+You can enter a description up to 50 characters in length.
 
 .. note::
-  
-  Team descriptions don't support `some unicode characters <https://www.w3.org/TR/unicode-xml/#Charlist>`__. 
+
+  Team descriptions don't support `some unicode characters <https://www.w3.org/TR/unicode-xml/#Charlist>`__.
 
 Team icon
 ~~~~~~~~~
 
-A **Team Icon** displays in the team sidebar. By default, the team icon contains the first two letters of the team name. 
+A **Team Icon** displays in the team sidebar. By default, the team icon contains the first two letters of the team name.
 
 To customize the team icon:
 
@@ -66,9 +66,9 @@ Access settings enable the ability to control who can join the team.
 Users with a specific email domain
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-System and team administrators can limit who can join the team based on their email domain. Enable this option to specify approved email domains. Separate multiple email domains using spaces, commas, pressing :kbd:`Tab`, or pressing :kbd:`Enter`. 
+System and team administrators can limit who can join the team based on their email domain. Enable this option to specify approved email domains. Separate multiple email domains using spaces, commas, pressing :kbd:`Tab`, or pressing :kbd:`Enter`.
 
-When enabled, only users that have an email domain from the approved domain list is able to join the team. Team members who joined prior to approved domains being specified won't be removed from the team once approved email domains are configured and enforced.
+When enabled, only users that have an email domain from the approved domain list is able to join the team. The setting's intent is solely to gate joining a team. Once joined, team members will be able to update their email to a non-approved domain without any restrictions. Additionally, team members who joined prior to approved domains being specified won't be removed from the team once approved email domains are configured and enforced.
 
 .. important::
 
@@ -80,7 +80,7 @@ Users on this server
 System and team administrators can include the team in a list of teams to join for new Mattermost users who aren't yet members of a team. Enable this option to allow any user with a Mattermost account on this instance to join this team from the **Teams you can join** page.
 
 .. tip::
-  
+
   When you enable this option, users looking for more teams to join will also see this team in the list when they select the |plus| icon in the team sidebar.
 
 Invite code


### PR DESCRIPTION
#### Summary
Clarify Allowed Domains of team settings. This setting only gates joining a team. 

Line 71 is the only change. The rest is my commit hook removing trailing spaces. 