### PR TITLE
Add note on system roles about the configuration endpoint

### DIFF
--- a/source/onboard/delegated-granular-administration.rst
+++ b/source/onboard/delegated-granular-administration.rst
@@ -8,7 +8,7 @@ Mattermost supports the creation and customization of system administration role
 
 These admin roles permit granular access to specific areas of the System Console and related API endpoints. These roles enable users to perform certain administrative tasks without requiring access to all system administration areas. These system roles never supersede the user's original role or the user's permissions configured by the Permissions scheme.
 
-.. note::
+.. warning::
   Even when a role is set to **No Access** or **Read Only** for a System Console page, granting **Can Edit** on any System Console page enables access to the underlying configuration endpoint (``PUT /api/v4/config/patch``). This means a user with write access in one area can modify configuration values across all areas. Administrators should assign **Can Edit** permissions with caution.
 
 Available roles

--- a/source/onboard/delegated-granular-administration.rst
+++ b/source/onboard/delegated-granular-administration.rst
@@ -8,6 +8,9 @@ Mattermost supports the creation and customization of system administration role
 
 These admin roles permit granular access to specific areas of the System Console and related API endpoints. These roles enable users to perform certain administrative tasks without requiring access to all system administration areas. These system roles never supersede the user's original role or the user's permissions configured by the Permissions scheme.
 
+.. note::
+  Even if a role is set to "No Access" or "Read Only" for one page, granting "Can Edit" on any System Console page enables access to the underlying configuration endpoint (`PUT /api/v4/config/patch`). This means a user with write access in one area can modify configuration values across all areas. Administrators should assign "Can Edit" permissions with caution.
+
 Available roles
 ----------------
 

--- a/source/onboard/delegated-granular-administration.rst
+++ b/source/onboard/delegated-granular-administration.rst
@@ -9,7 +9,7 @@ Mattermost supports the creation and customization of system administration role
 These admin roles permit granular access to specific areas of the System Console and related API endpoints. These roles enable users to perform certain administrative tasks without requiring access to all system administration areas. These system roles never supersede the user's original role or the user's permissions configured by the Permissions scheme.
 
 .. note::
-  Even if a role is set to "No Access" or "Read Only" for one page, granting "Can Edit" on any System Console page enables access to the underlying configuration endpoint (`PUT /api/v4/config/patch`). This means a user with write access in one area can modify configuration values across all areas. Administrators should assign "Can Edit" permissions with caution.
+  Even when a role is set to **No Access** or **Read Only** for a System Console page, granting **Can Edit** on any System Console page enables access to the underlying configuration endpoint (``PUT /api/v4/config/patch``). This means a user with write access in one area can modify configuration values across all areas. Administrators should assign **Can Edit** permissions with caution.
 
 Available roles
 ----------------


### PR DESCRIPTION
#### Summary

The roles defined in Delegated Granular Administration have different permissions set to "No Access", "Read only" and "Can Edit".

In our docs we say that 
> These admin roles permit granular access to specific areas of the System Console and related API endpoints. 

Now here's the issue: If a delegated granular administration role has write access to any system console page, this gives them access to the underlying configuration endpoint (`PUT /api/v4/config/patch`) and allows them to modify any configuration value. So even if they have "No Access" or "Read only" to a page A in System Console, having "Can Edit" in an area B allows then to edit the configuration values of page A. 

This is currently by design, but it's not intuitive, nor clear in our docs. 

While we may opt to improve this situation in the future, I'm adding a note for clarity. 

