### PR TITLE
fix sitemap url scheme in init.py

### DIFF
--- a/extensions/sitemap/__init__.py
+++ b/extensions/sitemap/__init__.py
@@ -39,7 +39,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     :return: A dict of Sphinx extension options
     """
     app.add_config_value("site_url", default=None, rebuild="")
-    app.add_config_value("sitemap_url_scheme", default="{lang}{link}", rebuild="")
+    app.add_config_value("sitemap_url_scheme", default="{link}", rebuild="")
     app.add_config_value("sitemap_locales", default=None, rebuild="")
     app.add_config_value("sitemap_filename", default="sitemap.xml", rebuild="")
 


### PR DESCRIPTION
the url scheme in the init config uses a language prefix that we actually don't use in the deployment of the real docs website, this causes all links to be invalid. 

this pr removes this prefix making the sitemap generation work again.