### PR TITLE
Fixes typo in mmctl token generate command example

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -5917,7 +5917,7 @@ Generate token for a user.
 
 .. code-block:: sh
 
-   mmctl generate testuser test-token
+   mmctl token generate testuser test-token
 
 **Options**
 


### PR DESCRIPTION
**Note:** I have not signed the CLA. 

#### Summary
In file source/manage/mmctl-command-line-tool.rst the command on line 5920 is mmctl generate testuser test-token and should be mmctl token generate testuser test-token.

#### Ticket Link
https://github.com/mattermost/docs/issues/7838
