### PR TITLE
Remove 1000 Day Elasticsearch Limitation

### DIFF
--- a/source/scale/elasticsearch.rst
+++ b/source/scale/elasticsearch.rst
@@ -143,8 +143,7 @@ Limitations
 
 1. Elasticsearch uses a standard selection of "stop words" to keep search results relevant. Results for the following words will not be returned: "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these", "they", "this", "to", "was", "will", and "with".
 2. Searching stop words in quotes returns more results than just the searched terms (`ticket <https://mattermost.atlassian.net/browse/MM-7216>`__).
-3. AWS Elasticsearch implementations have a limit of 1000 days of post history that is searchable.
-4. Search results are limited to a user's team and channel membership. This is enforced by the Mattermost server. The entities are indexed in Elasticsearch in a way that allows Mattermost to filter them when querying, so the Mattermost server narrows down the results on every Elasticsearch request applying those filters.
+3. Search results are limited to a user's team and channel membership. This is enforced by the Mattermost server. The entities are indexed in Elasticsearch in a way that allows Mattermost to filter them when querying, so the Mattermost server narrows down the results on every Elasticsearch request applying those filters.
 
 Frequently asked questions (FAQ)
 --------------------------------


### PR DESCRIPTION
As discussed in Mattermost staff channel:

https://hub.mattermost.com/private-core/pl/3yg6q6hietyydbyp9db56jqmhh
