### PR TITLE
Update default value for Enable Image Proxy setting

### DIFF
--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -2434,8 +2434,8 @@ An image proxy is used by Mattermost apps to prevent them from connecting direct
   :configjson: .ImageProxySettings.Enable
   :environment: MM_IMAGEPROXYSETTINGS_ENABLE
 
-  - **true**: **(Default)** Enables an image proxy for loading external images.
-  - **false**: Disables the image proxy.
+  - **true**: Enables an image proxy for loading external images.
+  - **false**: **(Default)** Disables the image proxy.
 
 Enable image proxy
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Changing the default value for the Enable Image Proxy setting from `true `to `false`.

This was updated in v5.9 but was never changed to be reflected in the docs: https://docs.mattermost.com/about/unsupported-legacy-releases.html#id660
