### PR TITLE
Removed specific Postgres version string

### DIFF
--- a/source/scale/high-availability-cluster-based-deployment.rst
+++ b/source/scale/high-availability-cluster-based-deployment.rst
@@ -355,7 +355,7 @@ The database can be configured for high availability and transparent failover us
 Recommended configuration settings for PostgreSQL
 ``````````````````````````````````````````````````
 
-If you're using PostgreSQL as the choice of database, we recommend the following configuration optimizations on your Mattermost server. These configurations were tested on an AWS Aurora r5.xlarge instance of PostgreSQL v11.7. There are also some general optimizations mentioned which requires servers with higher specifications.
+For the Postgres service we recommend the following configuration optimizations on your Mattermost server. These configurations were tested on an AWS Aurora r5.xlarge instance. There are also some general optimizations mentioned which requires servers with higher specifications.
 
 **Config for Postgres Primary or Writer node**
 


### PR DESCRIPTION
I noticed we mentioned "PostgreSQL v11.7" specifically, but we are deprecating (have deprecated?) support for that version.

For simplicity, removing any mention of version.

