### PR TITLE
Docs listening: Added caveat about metrics plugin not making system/OS level metrics

### DIFF
--- a/source/about/integrations.rst
+++ b/source/about/integrations.rst
@@ -18,12 +18,37 @@ For self-hosted deployments in small setups, you might host integrations on the 
 
 You can customize Mattermost with the following capabilities and frameworks.
 
-Custom Apps
------------
+Webhooks
+--------
 
-Apps are lightweight, interactive add-ons that can be written in any language and run on any HTTP-compatible hosting service. They enable you to connect with external services and build interactions that users can easily follow and work across the Mattermost web app, desktop app, and mobile app.   
+A webhook is a way for one app to send real-time data to another app. In Mattermost, `incoming webhooks <https://developers.mattermost.com/integrate/webhooks/incoming/>`_ receive data from external applications and make a post in a specified channel. They’re great for setting up notifications when something happens in an external application.
 
-Prebuilt apps are available on the `Mattermost Marketplace <https://mattermost.com/marketplace/>`_.
+`Outgoing webhooks <https://developers.mattermost.com/integrate/webhooks/outgoing/>`_ take data from Mattermost, and send it to an external application. Then the outgoing webhook can post a response back in Mattermost. They’re great for listening in on channels, and then notifying external applications when a trigger word is used.
+
+.. tip::
+
+    Mattermost webhooks are "Slack-compatible”. This means that Mattermost accepts integrations that have a payload in the same format as Slack. In an application that already supports Slack webhooks, you can replace the Slack webhook URL with a Mattermost webhook URL and the integration will “just work”. 
+    
+    If you have an integration that outputs a payload in a different format, you need to write an intermediate application to act as a translation layer to change it to the format Mattermost uses. Since there’s currently no general standard for webhook formatting, this is unavoidable and just a part of how webhooks work.
+
+Custom slash commands
+---------------------
+
+A :doc:`slash command </collaborate/run-slash-commands>` is similar to an `outgoing webhooks <https://developers.mattermost.com/integrate/webhooks/outgoing/>`_, but instead of listening to a channel, it's used as a command tool in a channel.
+
+Slash commands enable users to trigger custom actions, such as creating Jira tickets or GitHub pull requests within Mattermost channels. See the :doc:`built-in slash commands </collaborate/built-in-slash-commands>` product documentation and the `custom slash command <https://developers.mattermost.com/integrate/slash-commands/custom/>`_ developer documentation to learn more.
+
+.. tip::
+    The Mattermost slash command format is compatible with Slack's format, so you can easily port commands from Slack. 
+
+Bots
+-----
+
+You can deploy interactive bots to help users with processes and tasks with Mattermost by  issuing messages to users they can respond to using buttons and dropdown menus. Bots can be used together with apps and plugins. The Hubot open source project, created by GitHub, Inc., is among the most popular of the bot options.
+
+Prebuilt bots are available on the `Mattermost Marketplace <https://mattermost.com/marketplace/>`_, or you can `configure your own bots <https://developers.mattermost.com/integrate/reference/bot-accounts/>`_.
+
+Learn about `Mattermost Hubot integration (hubot-matteruser on npm) <https://www.npmjs.com/package/hubot-matteruser>`_ and `other open source community bots available <https://mattermost.com/marketplace/>`_ or you can `build your own <https://developers.mattermost.com/integrate/reference/bot-accounts/>`_.
 
 API 
 ----
@@ -44,38 +69,6 @@ Prebuilt plugins are available on the `Mattermost Marketplace <https://mattermos
 
     .. include:: ./cloud-supported-integrations.rst
        :start-after: :nosearch:
-
-Bots
------
-
-You can deploy interactive bots to help users with processes and tasks with Mattermost by  issuing messages to users they can respond to using buttons and dropdown menus. Bots can be used together with apps and plugins. The Hubot open source project, created by GitHub, Inc., is among the most popular of the bot options.
-
-Prebuilt bots are available on the `Mattermost Marketplace <https://mattermost.com/marketplace/>`_, or you can `configure your own bots <https://developers.mattermost.com/integrate/reference/bot-accounts/>`_.
-
-Learn about `Mattermost Hubot integration (hubot-matteruser on npm) <https://www.npmjs.com/package/hubot-matteruser>`_ and `other open source community bots available <https://mattermost.com/marketplace/>`_ or you can `build your own <https://developers.mattermost.com/integrate/reference/bot-accounts/>`_.
-
-Custom slash commands
----------------------
-
-A :doc:`slash command </collaborate/run-slash-commands>` is similar to an `outgoing webhooks <https://developers.mattermost.com/integrate/webhooks/outgoing/>`_, but instead of listening to a channel, it's used as a command tool in a channel.
-
-Slash commands enable users to trigger custom actions, such as creating Jira tickets or GitHub pull requests within Mattermost channels. See the :doc:`built-in slash commands </collaborate/built-in-slash-commands>` product documentation and the `custom slash command <https://developers.mattermost.com/integrate/slash-commands/custom/>`_ developer documentation to learn more.
-
-.. tip::
-    The Mattermost slash command format is compatible with Slack's format, so you can easily port commands from Slack. 
-
-Webhooks
---------
-
-A webhook is a way for one app to send real-time data to another app. In Mattermost, `incoming webhooks <https://developers.mattermost.com/integrate/webhooks/incoming/>`_ receive data from external applications and make a post in a specified channel. They’re great for setting up notifications when something happens in an external application.
-
-`Outgoing webhooks <https://developers.mattermost.com/integrate/webhooks/outgoing/>`_ take data from Mattermost, and send it to an external application. Then the outgoing webhook can post a response back in Mattermost. They’re great for listening in on channels, and then notifying external applications when a trigger word is used.
-
-.. tip::
-
-    Mattermost webhooks are "Slack-compatible”. This means that Mattermost accepts integrations that have a payload in the same format as Slack. In an application that already supports Slack webhooks, you can replace the Slack webhook URL with a Mattermost webhook URL and the integration will “just work”. 
-    
-    If you have an integration that outputs a payload in a different format, you need to write an intermediate application to act as a translation layer to change it to the format Mattermost uses. Since there’s currently no general standard for webhook formatting, this is unavoidable and just a part of how webhooks work.
 
 Source code customizations
 --------------------------

--- a/source/configure/calls-deployment.md
+++ b/source/configure/calls-deployment.md
@@ -175,7 +175,8 @@ Both the plugin and the external `rtcd` service expose some Prometheus metrics t
 Metrics for the calls plugin are exposed through the `/plugins/com.mattermost.calls/metrics` subpath under the existing Mattermost server metrics endpoint. This is controlled by the [Listen address for performance](https://docs.mattermost.com/configure/environment-configuration-settings.html#listen-address-for-performance) configuration setting. It defaults to port `8067`.
 
 ```{note}
-On Mattermost versions prior to v9.5, plugin metrics were exposed through the public `/plugins/com.mattermost.calls/metrics` API endpoint controlled by the [Web server listen address](https://docs.mattermost.com/configure/environment-configuration-settings.html#web-server-listen-address) configuration setting. This defaults to port `8065`.
+- The [Metrics plugin](https://docs.mattermost.com/scale/collect-performance-metrics.html) collects application-level metrics only and does not make system or OS-level calls. As a result, data typically derived from system-level metrics may be missing in the Grafana panel.
+- On Mattermost versions prior to v9.5, plugin metrics were exposed through the public `/plugins/com.mattermost.calls/metrics` API endpoint controlled by the [Web server listen address](https://docs.mattermost.com/configure/environment-configuration-settings.html#web-server-listen-address) configuration setting. This defaults to port `8065`.
 ```
 
 **Process**


### PR DESCRIPTION
Incorporated docs feedback: "We need to add a caveat about metrics plugin not making system/OS level metrics, so some data will be missing from the Grafana panel."