### PR TITLE
Improve 'Get Help' section for MMC

### DIFF
--- a/source/integrate/mattermost-mission-collaboration-for-m365.rst
+++ b/source/integrate/mattermost-mission-collaboration-for-m365.rst
@@ -154,6 +154,6 @@ FAQ
 Where can I get support?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mattermost customers can open a `Mattermost support case <https://support.mattermost.com/hc/en-us/requests/new>`_. 
+Mattermost commercial customers can open a `Mattermost support case <https://support.mattermost.com/hc/en-us/requests/new>`_. 
 
 For questions, feedback, and assistance, join our pubic `Integrations and Apps channel <https://community.mattermost.com/core/channels/integrations>`_ on the `Mattermost Community Server <https://community.mattermost.com/>`_ for assistance.

--- a/source/integrate/mattermost-mission-collaboration-for-m365.rst
+++ b/source/integrate/mattermost-mission-collaboration-for-m365.rst
@@ -154,4 +154,6 @@ FAQ
 Where can I get support?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`Submit an issue on GitHub <https://github.com/mattermost/mattermost-plugin-msteams-devsecops/issues>`_. Share your thoughts and suggestions in the `~user-feedback channel <https://community.mattermost.com/core/channels/user-feedback>`_ on the Mattermost Community server.
+Mattermost customers can open a `Mattermost support case <https://support.mattermost.com/hc/en-us/requests/new>`_. 
+
+For questions, feedback, and assistance, join our pubic `Integrations and Apps channel <https://community.mattermost.com/core/channels/integrations>`_ on the `Mattermost Community Server <https://community.mattermost.com/>`_ for assistance.


### PR DESCRIPTION
#### Summary
Improve 'Get Help' section for `Mattermost Mission Collaboration for Microsoft 365 (Beta)` to include link to support ticket site.

#### Ticket Link
NONE