### PR TITLE
Reordered K8 deployment options

### DIFF
--- a/source/deploy/server/deploy-kubernetes.rst
+++ b/source/deploy/server/deploy-kubernetes.rst
@@ -23,7 +23,6 @@ Choose your preferred platform below for specific deployment instructions:
   .. include:: kubernetes/deploy-k8s-oke.rst
     :start-after: :nosearch:
 
-
 Frequently Asked Questions
 --------------------------
 


### PR DESCRIPTION
put the operator first in ordering as it's the most generic/widely used option.