### PR TITLE
Update compliance-export.rst

### DIFF
--- a/source/comply/compliance-export.rst
+++ b/source/comply/compliance-export.rst
@@ -175,6 +175,11 @@ See the `Global Relay <#global-relay-eml>`__ section for details on updated Glob
 Frequently Asked Questions (FAQ)
 --------------------------------
 
+Are Playbooks and Boards data included in compliance exports?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No. Compliance exports only include channel messages, direct messages, file uploads, and posts from plugins/bots/webhooks. Data from Mattermost Playbooks (including run activities, status updates, and retrospectives) and Mattermost Boards (including cards, comments, and board activities) are not included in the compliance export functionality. Organizations requiring compliance archiving of Playbooks and Boards data should consider separate data retention strategies for these features.
+
 How do I export past history?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION

## Add FAQ entry for Playbooks and Boards data exclusion from compliance exports

**What changed:**
- Added new FAQ section "Are Playbooks and Boards data included in compliance exports?"

**Why:**
- Clarifies that compliance exports only include messaging data (channels, DMs, file uploads, plugin/bot posts)
- Explicitly states that Playbooks and Boards data are excluded from compliance export functionality
- Provides guidance for organizations requiring compliance archiving of these features

**Impact:**
- Improves documentation clarity for compliance teams
- Prevents confusion about export scope
- Helps organizations plan appropriate data retention strategies