### PR TITLE
Fix the order of deps explanations

### DIFF
--- a/source/about/security/dependency-vulnerability-analysis.rst
+++ b/source/about/security/dependency-vulnerability-analysis.rst
@@ -38,11 +38,11 @@ Below is a list of dependencies flagged as vulnerable by security scanners, alon
    * - github.com/redis/go-redis/v9 v9.7.0
      - GHSA-92cp-5422-2mw7
        CVE-2025-29923
-     - Mattermost doesn't use the vulnerable ``bleve/http`` package.
+     - Mattermost doesn't use this transitive dependency.
    * - github.com/blevesearch/bleve/v2 v2.4.4-0.20250115090822-cbafdca08538
      - GHSA-9w9f-6mg8-jp7w
        CVE-2022-31022
-     - Mattermost doesn't use this transitive dependency.
+     - Mattermost doesn't use the vulnerable ``bleve/http`` package.
    * - golang stdlib v1.23.7
      - CVE-2025-22871
      - Mattermost doesn't use the vulnerable functions ``chunkedReader.Read`` and ``readChunkLine``.


### PR DESCRIPTION
#### Summary
Swap the dependency vulnerability explanations to match the correct row. 
