### PR TITLE
remove locale from sitemap urls

### DIFF
--- a/extensions/sitemap/__init__.py
+++ b/extensions/sitemap/__init__.py
@@ -195,10 +195,8 @@ def create_sitemap(app: Sphinx, exception):
 
         url = ElementTree.SubElement(root, "url")
         scheme = app.config.sitemap_url_scheme
-        if app.builder.config.language:
-            lang = app.builder.config.language + "/"
-        else:
-            lang = ""
+
+        lang = ""
 
         ElementTree.SubElement(url, "loc").text = site_url + scheme.format(
             lang=lang, version=version, link=link


### PR DESCRIPTION
my previous PR caused the sitemap extension to add the translation string /en/ to every url. this needs to be removed to conform to the actual url.
    
correct: `https://docs.mattermost.com/agents/docs/sovereign_ai.html`
incorrect: `https://docs.mattermost.com/en/agents/docs/sovereign_ai.html`