### PR TITLE
Fix table width issue on important upgrade notes page

### DIFF
--- a/source/_static/css/homepage-v1.css
+++ b/source/_static/css/homepage-v1.css
@@ -333,6 +333,31 @@ table.align-default td {
   min-width: 200px;
 }
 
+/* Responsive table styles specifically for important upgrade notes page */
+section#important-upgrade-notes table.align-default {
+  width: 100% !important;
+  table-layout: fixed !important;
+  overflow-wrap: break-word !important;
+  min-width: unset !important;
+}
+
+section#important-upgrade-notes table.align-default td,
+section#important-upgrade-notes table.align-default th {
+  word-wrap: break-word !important;
+  vertical-align: top !important;
+  min-width: unset !important;
+}
+
+section#important-upgrade-notes table.align-default td:first-child,
+section#important-upgrade-notes table.align-default th:first-child {
+  width: 25% !important;
+}
+
+section#important-upgrade-notes table.align-default td:last-child,
+section#important-upgrade-notes table.align-default th:last-child {
+  width: 75% !important;
+}
+
 ::-moz-selection {
   /* Code for Firefox */
   background: rgba(255, 188, 31, 0.2);


### PR DESCRIPTION
Fixes the issue where the important upgrade notes table has content that is wider than it's width. 

The css should only affect the table on the important upgrade notes table and leave all other tables untouched.

Before:

![image](https://github.com/user-attachments/assets/37c50b28-5bd6-40cb-b664-96ccd839dbe4)


After: 

![image](https://github.com/user-attachments/assets/8cea3edd-b729-44c3-997f-88e53c3ed7e1)
