### PR TITLE
AI-Aided: Add documentation for automatic channel category sorting feature (v10.10)

### DIFF
--- a/source/collaborate/create-channels.rst
+++ b/source/collaborate/create-channels.rst
@@ -43,7 +43,6 @@ Anyone can create public channels, private channels, direct messages, and group 
 
   Tap |plus| in the top right corner of the app, then select **Create New Channel**. Channels are created as public by default. If you want to create a private channel, tap the **Make Private** option.
 
-  If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you can also assign the channel to a category during creation by selecting an existing category or creating a new one.
 
     .. image:: ../images/create-channel-or-open-direct-message-on-mobile.jpg
       :alt: You can create a new channel by tapping the plus in the top right corner.

--- a/source/collaborate/create-channels.rst
+++ b/source/collaborate/create-channels.rst
@@ -19,7 +19,7 @@ Anyone can create public channels, private channels, direct messages, and group 
   2. Enter a channel name.
   3. Choose whether this is a public or private channel. See the :doc:`channel types </collaborate/channel-types>` documentation to learn more about public and private channels.
   4. (Optional) Describe the channel's focus or purpose. This text is visible to all channel members in the channel header.
-  5. (Optional) Assign the channel to a category. If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the new channel to a new or existing channel category. If this option isn't available, you can` customize your channel sidebar </preferences/customize-your-channel-sidebar>`.
+  5. (Optional) Assign the channel to a category. If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the new channel to a new or existing channel category. If this option isn't available, you can `customize your channel sidebar </preferences/customize-your-channel-sidebar>`.
 
   **To start a direct or group message**
 

--- a/source/collaborate/create-channels.rst
+++ b/source/collaborate/create-channels.rst
@@ -19,7 +19,7 @@ Anyone can create public channels, private channels, direct messages, and group 
   2. Enter a channel name.
   3. Choose whether this is a public or private channel. See the :doc:`channel types </collaborate/channel-types>` documentation to learn more about public and private channels.
   4. (Optional) Describe the channel's focus or purpose. This text is visible to all channel members in the channel header.
-  5. (Optional) Assign the channel to a category. If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you can select an existing category or create a new one to organize your channel. If this option isn't available, you can organize channels into categories after creation using :doc:`channel sidebar customization </preferences/customize-your-channel-sidebar>`.
+  5. (Optional) Assign the channel to a category. If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the new channel to a new or existing channel category. If this option isn't available, you can` customize your channel sidebar </preferences/customize-your-channel-sidebar>`.
 
   **To start a direct or group message**
 

--- a/source/collaborate/create-channels.rst
+++ b/source/collaborate/create-channels.rst
@@ -19,6 +19,7 @@ Anyone can create public channels, private channels, direct messages, and group 
   2. Enter a channel name.
   3. Choose whether this is a public or private channel. See the :doc:`channel types </collaborate/channel-types>` documentation to learn more about public and private channels.
   4. (Optional) Describe the channel's focus or purpose. This text is visible to all channel members in the channel header.
+  5. (Optional) Assign the channel to a category. If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you can select an existing category or create a new one to organize your channel. If this option isn't available, you can organize channels into categories after creation using :doc:`channel sidebar customization </preferences/customize-your-channel-sidebar>`.
 
   **To start a direct or group message**
 
@@ -41,6 +42,8 @@ Anyone can create public channels, private channels, direct messages, and group 
   **To create a public or private channel**
 
   Tap |plus| in the top right corner of the app, then select **Create New Channel**. Channels are created as public by default. If you want to create a private channel, tap the **Make Private** option.
+
+  If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you can also assign the channel to a category during creation by selecting an existing category or creating a new one.
 
     .. image:: ../images/create-channel-or-open-direct-message-on-mobile.jpg
       :alt: You can create a new channel by tapping the plus in the top right corner.

--- a/source/collaborate/rename-channels.rst
+++ b/source/collaborate/rename-channels.rst
@@ -13,6 +13,8 @@ Anyone can rename the channels they belong to, unless the system admin has :doc:
   - **Channel name:** The channel name that displays in the Mattermost user interface for all users. Enter a different channel name if needed or preferred.
   - **Channel URL:** The web URL used to access the channel in a web browser. Select **Edit** to change the URL, and select **Done** to save your changes.
 
+  If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you may also see an option to assign the channel to a different category or create a new category during the renaming process.
+
   For example, a channel could be named ``UX Design`` and have a URL of ``https://community.mattermost.com/core/channels/ux-design``.
 
 .. tab:: Mobile
@@ -46,6 +48,8 @@ Anyone can rename the channels they belong to, unless the system admin has :doc:
     - **Name:** This appears in the Mattermost user interface.
     - **Purpose:** (Optional) Used to describe the channel's function or goal.
     - **Header:** (Optional) Used to include information relevant to the channel, such as key contacts or document links.
+
+    If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you may also see an option to assign the channel to a different category or create a new category.
 
     Tap on **Save** to save the new channel name.
 

--- a/source/collaborate/rename-channels.rst
+++ b/source/collaborate/rename-channels.rst
@@ -49,7 +49,6 @@ Anyone can rename the channels they belong to, unless the system admin has :doc:
     - **Purpose:** (Optional) Used to describe the channel's function or goal.
     - **Header:** (Optional) Used to include information relevant to the channel, such as key contacts or document links.
 
-    If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the renamed channel to a new or existing category. 
 
     Tap on **Save** to save the new channel name.
 

--- a/source/collaborate/rename-channels.rst
+++ b/source/collaborate/rename-channels.rst
@@ -49,7 +49,7 @@ Anyone can rename the channels they belong to, unless the system admin has :doc:
     - **Purpose:** (Optional) Used to describe the channel's function or goal.
     - **Header:** (Optional) Used to include information relevant to the channel, such as key contacts or document links.
 
-    If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you may also see an option to assign the channel to a different category or create a new category.
+    If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the renamed channel to a new or existing category. 
 
     Tap on **Save** to save the new channel name.
 

--- a/source/collaborate/rename-channels.rst
+++ b/source/collaborate/rename-channels.rst
@@ -13,7 +13,7 @@ Anyone can rename the channels they belong to, unless the system admin has :doc:
   - **Channel name:** The channel name that displays in the Mattermost user interface for all users. Enter a different channel name if needed or preferred.
   - **Channel URL:** The web URL used to access the channel in a web browser. Select **Edit** to change the URL, and select **Done** to save your changes.
 
-  If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature, you may also see an option to assign the channel to a different category or create a new category during the renaming process.
+  If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the renamed channel to a new or existing channel category. 
 
   For example, a channel could be named ``UX Design`` and have a URL of ``https://community.mattermost.com/core/channels/ux-design``.
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1623,7 +1623,7 @@ Enable channel category sorting
   :start-after: :nosearch:
 
 .. note::
-  From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can select or create custom categories when creating or renaming channels.
+  From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can assign channels to new or existing channel categories when creating or renaming channels.
 
 **True**: Users can assign channels to new or existing categories when creating or renaming channels.
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1625,7 +1625,7 @@ Enable channel category sorting
 .. note::
   From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can select or create custom categories when creating or renaming channels.
 
-**True**: Enables users to assign channels to categories during channel creation and renaming workflows. When creating or renaming a channel, users will see an option to select an existing category or create a new category for the channel.
+**True**: Users can assign channels to new or existing categories when creating or renaming channels.
 
 **False**: Disables automatic channel category assignment during channel creation and renaming. Users must manually organize channels into categories after creation using the channel sidebar customization options.
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1614,7 +1614,7 @@ This setting applies to the new sidebar only. You must disable the :ref:`Enable 
   :environment: N/A
 
   - **true**: Users can assign channels to new or existing categories when creating or renaming channels.
-  - **false**: **(Default)** Disables automatic channel category assignment during channel creation and renaming.
+  - **false**: **(Default)** Disables the ability to automatically assign channels to new or existing channel categories.
 
 Enable channel category sorting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1619,10 +1619,10 @@ This setting applies to the new sidebar only. You must disable the :ref:`Enable 
 Enable channel category sorting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: ../_static/badges/ent-selfhosted-only.rst
+.. include:: ../_static/badges/allplans-cloud.rst
   :start-after: :nosearch:
 
-From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can assign channels to new or existing channel categories when creating or renaming channels.
+From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can assign channels to new or existing channel categories when creating or renaming channels. This configuration setting applies only to cloud-based deployments.
 
 **True**: Users can assign channels to new or existing channel categories when creating or renaming channels.
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1627,7 +1627,7 @@ Enable channel category sorting
 
 **True**: Users can assign channels to new or existing categories when creating or renaming channels.
 
-**False**: Disables automatic channel category assignment during channel creation and renaming. Users must manually organize channels into categories after creation using the channel sidebar customization options.
+**False**: **(Default)** Disables the ability to automatically assign channels to new or existing channel categories.
 
 +------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"ExperimentalEnableChannelCategorySorting": false`` with options ``true`` and ``false``. |

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1623,7 +1623,7 @@ Enable channel category sorting
   :start-after: :nosearch:
 
 .. note::
-  This is an experimental feature introduced in Mattermost v10.10. When enabled, users can select or create custom categories to organize their channels during the channel creation and renaming processes.
+  From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can select or create custom categories when creating or renaming channels.
 
 **True**: Enables users to assign channels to categories during channel creation and renaming workflows. When creating or renaming a channel, users will see an option to select an existing category or create a new category for the channel.
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1613,7 +1613,7 @@ This setting applies to the new sidebar only. You must disable the :ref:`Enable 
   :configjson: ExperimentalEnableChannelCategorySorting
   :environment: N/A
 
-  - **true**: Users can assign channels to new or existing categories when creating or renaming channels.
+  - **true**: Users can assign channels to new or existing channel categories when creating or renaming channels.
   - **false**: **(Default)** Disables the ability to automatically assign channels to new or existing channel categories.
 
 Enable channel category sorting

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1624,7 +1624,7 @@ Enable channel category sorting
 
 From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can assign channels to new or existing channel categories when creating or renaming channels.
 
-**True**: Users can assign channels to new or existing categories when creating or renaming channels.
+**True**: Users can assign channels to new or existing channel categories when creating or renaming channels.
 
 **False**: **(Default)** Disables the ability to automatically assign channels to new or existing channel categories.
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1614,7 +1614,7 @@ This setting applies to the new sidebar only. You must disable the :ref:`Enable 
   :environment: N/A
 
   - **true**: Users can assign channels to new or existing channel categories when creating or renaming channels.
-  - **false**: **(Default)** Disables the ability to automatically assign channels to new or existing channel categories.
+  - **false**: **(Default)** Disables the ability to assign channels to new or existing channel categories when creating or renaming channels.
 
 Enable channel category sorting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1630,7 +1630,7 @@ Enable channel category sorting
 **False**: **(Default)** Disables the ability to automatically assign channels to new or existing channel categories.
 
 +------------------------------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ExperimentalEnableChannelCategorySorting": false`` with options ``true`` and ``false``. |
+| This feature's ``config.json`` setting is ``"ExperimentalEnableChannelCategorySorting": false`` with options ``true`` and ``false``.     |
 +------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. config:setting:: strict-csrf-token-enforcement

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1622,7 +1622,7 @@ Enable channel category sorting
 .. include:: ../_static/badges/ent-selfhosted-only.rst
   :start-after: :nosearch:
 
-  From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can assign channels to new or existing channel categories when creating or renaming channels.
+From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can assign channels to new or existing channel categories when creating or renaming channels.
 
 **True**: Users can assign channels to new or existing categories when creating or renaming channels.
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1613,7 +1613,7 @@ This setting applies to the new sidebar only. You must disable the :ref:`Enable 
   :configjson: ExperimentalEnableChannelCategorySorting
   :environment: N/A
 
-  - **true**: Enables users to assign channels to categories during channel creation and renaming workflows.
+  - **true**: Users can assign channels to new or existing categories when creating or renaming channels.
   - **false**: **(Default)** Disables automatic channel category assignment during channel creation and renaming.
 
 Enable channel category sorting

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1622,7 +1622,6 @@ Enable channel category sorting
 .. include:: ../_static/badges/ent-selfhosted-only.rst
   :start-after: :nosearch:
 
-.. note::
   From Mattermost v10.10, when this :ref:`experimental <manage/feature-labels:experimental>` feature is enabled, users can assign channels to new or existing channel categories when creating or renaming channels.
 
 **True**: Users can assign channels to new or existing categories when creating or renaming channels.

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1607,6 +1607,32 @@ This setting applies to the new sidebar only. You must disable the :ref:`Enable 
 | This feature's ``config.json`` setting is ``"ExperimentalGroupUnreadChannels": "default_off"`` with options ``"default_off"`` and ``"default_on"``. |
 +-----------------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. config:setting:: enable-channel-category-sorting
+  :displayname: Enable channel category sorting (Experimental)
+  :systemconsole: Experimental > Features
+  :configjson: ExperimentalEnableChannelCategorySorting
+  :environment: N/A
+
+  - **true**: Enables users to assign channels to categories during channel creation and renaming workflows.
+  - **false**: **(Default)** Disables automatic channel category assignment during channel creation and renaming.
+
+Enable channel category sorting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../_static/badges/ent-selfhosted-only.rst
+  :start-after: :nosearch:
+
+.. note::
+  This is an experimental feature introduced in Mattermost v10.10. When enabled, users can select or create custom categories to organize their channels during the channel creation and renaming processes.
+
+**True**: Enables users to assign channels to categories during channel creation and renaming workflows. When creating or renaming a channel, users will see an option to select an existing category or create a new category for the channel.
+
+**False**: Disables automatic channel category assignment during channel creation and renaming. Users must manually organize channels into categories after creation using the channel sidebar customization options.
+
++------------------------------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ExperimentalEnableChannelCategorySorting": false`` with options ``true`` and ``false``. |
++------------------------------------------------------------------------------------------------------------------------------------------+
+
 .. config:setting:: strict-csrf-token-enforcement
   :displayname: Strict CSRF token enforcement (Experimental)
   :systemconsole: N/A

--- a/source/preferences/customize-your-channel-sidebar.rst
+++ b/source/preferences/customize-your-channel-sidebar.rst
@@ -36,7 +36,7 @@ Create custom categories to group channels together for quicker and easier navig
 To create categories, select the **+** symbol at the top of the sidebar. Or, select the **More options** |more-icon| icon in the sidebar on any category header, then select **Create New Category**.
 
 .. note::
-  If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign channels to new or existing channel categories when :doc:`creating channels </collaborate/create-channels>` and :doc:`renaming channels </collaborate/rename-channels>` workflows.
+  If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign channels to new or existing channel categories when :doc:`creating channels </collaborate/create-channels>` and :doc:`renaming channels </collaborate/rename-channels>`.
 
 Next, type a category name, select **Create**, then drag any channels or direct messages into this new category. You can also multi-select channels and direct messages to drag them together as a group by pressing :kbd:`Ctrl` or :kbd:`Shift` and selecting on Windows or Linux, or :kbd:`⌘` or :kbd:`⇧` and selecting on Mac. See the section `drag and drop selections <#drag-and-drop-selections>`__ below for details.
 

--- a/source/preferences/customize-your-channel-sidebar.rst
+++ b/source/preferences/customize-your-channel-sidebar.rst
@@ -36,7 +36,7 @@ Create custom categories to group channels together for quicker and easier navig
 To create categories, select the **+** symbol at the top of the sidebar. Or, select the **More options** |more-icon| icon in the sidebar on any category header, then select **Create New Category**.
 
 .. note::
-  If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature (available from Mattermost v10.10), you can also assign channels to categories directly during :doc:`channel creation </collaborate/create-channels>` and :doc:`channel renaming </collaborate/rename-channels>` workflows.
+  If your system admin has enabled :ref:`channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>`, you can assign channels to new or existing channel categories when :doc:`creating channels </collaborate/create-channels>` and :doc:`renaming channels </collaborate/rename-channels>` workflows.
 
 Next, type a category name, select **Create**, then drag any channels or direct messages into this new category. You can also multi-select channels and direct messages to drag them together as a group by pressing :kbd:`Ctrl` or :kbd:`Shift` and selecting on Windows or Linux, or :kbd:`⌘` or :kbd:`⇧` and selecting on Mac. See the section `drag and drop selections <#drag-and-drop-selections>`__ below for details.
 

--- a/source/preferences/customize-your-channel-sidebar.rst
+++ b/source/preferences/customize-your-channel-sidebar.rst
@@ -35,6 +35,9 @@ Create custom categories to group channels together for quicker and easier navig
 
 To create categories, select the **+** symbol at the top of the sidebar. Or, select the **More options** |more-icon| icon in the sidebar on any category header, then select **Create New Category**.
 
+.. note::
+  If your system admin has enabled the :ref:`Enable channel category sorting <configure/experimental-configuration-settings:enable channel category sorting>` experimental feature (available from Mattermost v10.10), you can also assign channels to categories directly during :doc:`channel creation </collaborate/create-channels>` and :doc:`channel renaming </collaborate/rename-channels>` workflows.
+
 Next, type a category name, select **Create**, then drag any channels or direct messages into this new category. You can also multi-select channels and direct messages to drag them together as a group by pressing :kbd:`Ctrl` or :kbd:`Shift` and selecting on Windows or Linux, or :kbd:`⌘` or :kbd:`⇧` and selecting on Mac. See the section `drag and drop selections <#drag-and-drop-selections>`__ below for details.
 
 Your custom categories can't be shared with other Mattermost users.


### PR DESCRIPTION
This commit adds comprehensive documentation for the new experimental channel category sorting feature introduced in Mattermost v10.10, which allows users to assign channels to categories during creation and renaming workflows via https://github.com/mattermost/mattermost/pull/30866

Changes include:
- Added ExperimentalEnableChannelCategorySorting configuration setting to experimental config
- Updated channel creation documentation with category assignment option
- Updated channel renaming documentation with category assignment option  
- Added cross-references in channel sidebar customization documentation

The feature is behind an experimental server-side configuration setting that system administrators must enable.

Related to #8082