### PR TITLE
AI-Aided: Add v10.10 documentation with GitLab plugin v1.10.0 update

### DIFF
--- a/source/about/mattermost-server-releases.md
+++ b/source/about/mattermost-server-releases.md
@@ -18,6 +18,7 @@ Mattermost releases a new server version on the 16th of each month in [binary fo
 
 | **Release** | **Released on** | **Support ends** |
 |:---|:---|:---|
+| v10.10 [Download](https://releases.mattermost.com/10.10.0/mattermost-10.10.0-linux-amd64.tar.gz) \| {ref}`Changelog <release-v10.10-feature-release>` \| [SBOM download](https://github.com/mattermost/mattermost/releases/download/v10.10.0/sbom-mattermost-v10.10.0.json) | 2025-07-16 | 2025-10-15 |
 | v10.9 [Download](https://releases.mattermost.com/10.9.1/mattermost-10.9.1-linux-amd64.tar.gz) \| {ref}`Changelog <release-v10.9-feature-release>` \| [SBOM download](https://github.com/mattermost/mattermost/releases/download/v10.9.1/sbom-mattermost-v10.9.1.json) | 2025-06-16 | 2025-09-15 |
 | v10.8 [Download](https://releases.mattermost.com/10.8.3/mattermost-10.8.3-linux-amd64.tar.gz) \| {ref}`Changelog <release-v10.8-feature-release>` \| [SBOM download](https://github.com/mattermost/mattermost/releases/download/v10.8.3/sbom-mattermost-v10.8.3.json) | 2025-05-16 | 2025-08-15 |
 | v10.7 [Download](https://releases.mattermost.com/10.7.4/mattermost-10.7.4-linux-amd64.tar.gz) \| {ref}`Changelog <release-v10.7-feature-release>` \| [SBOM download](https://github.com/mattermost/mattermost/releases/download/v10.7.4/sbom-mattermost-v10.7.4.json) | 2025-04-16 | 2025-07-15 |

--- a/source/about/mattermost-v10-changelog.md
+++ b/source/about/mattermost-v10-changelog.md
@@ -3,6 +3,17 @@
 ```{Important}
 ```{include} common-esr-support-upgrade.md
 ```
+(release-v10.10-feature-release)=
+## Release v10.10 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+
+- **10.10.0, released TBD**
+  - Original 10.10.0 release.
+
+### Improvements
+
+#### User Interface (UI)
+ - Pre-packaged GitLab plugin version [v1.10.0](https://github.com/mattermost/mattermost-plugin-gitlab/releases/tag/v1.10.0).
+
 (release-v10.9-feature-release)=
 ## Release v10.9 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
 

--- a/source/integrate/gitlab.rst
+++ b/source/integrate/gitlab.rst
@@ -128,7 +128,7 @@ You can create GitLab issues and manage issue comments directly from Mattermost 
 Create a GitLab issue
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Run the ``/gitlab issue create`` slash command to open an interactive modal where you can create a new GitLab issue. The modal allows you to:
+Run the ``/gitlab issue create`` slash command to open an interactive modal where you can create a new GitLab issue. The modal allows you to perform the following actions:
 
 - Set the issue title and description
 - Assign labels

--- a/source/integrate/gitlab.rst
+++ b/source/integrate/gitlab.rst
@@ -91,6 +91,21 @@ Run the ``/gitlab subscriptions list`` to review all of your subscriptions.
 
 Run the ``/gitlab subscriptions add group[/project] [features]`` slash command to subscribe a Mattermost channel and receive posts for new merge requests, issues, or other features, from a GitLab project. To unsubscribe and stop receiving posts, run the ``/gitlab subscriptions delete group[/project]`` slash command.
 
+The following features are supported for channel subscriptions:
+
+- ``merges`` - Get notified when merge requests are merged
+- ``issues`` - Get notified when issues are created
+- ``pushes`` - Get notified when commits are pushed to a branch
+- ``issue_comments`` - Get notified when comments are made on issues
+- ``merge_request_comments`` - Get notified when comments are made on merge requests
+- ``tag`` - Get notified when tags are created
+- ``pipeline`` - Get notified about pipeline events
+- ``wiki`` - Get notified about wiki page events
+- ``releases`` - Get notified when releases are created
+- ``deployments`` - Get notified about deployment events
+
+For example, to subscribe to release and deployment events: ``/gitlab subscriptions add group[/project] releases,deployments``
+
 For each project you want to receive notifications for or subscribe to, create a webhook in a channel where you want to watch events sent from GitLab by running the ``/gitlab webhook`` slash command. For example: ``/gitlab webhook add group[/project]``
 
 .. note::
@@ -104,6 +119,27 @@ For each project you want to receive notifications for or subscribe to, create a
     - **Secret Token**: Copy the webhook secret you generated earlier.
     - Select all the events in **Triggers**.
     - Add the webhook.
+
+Create issues and manage comments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can create GitLab issues and manage issue comments directly from Mattermost using slash commands and interactive modals.
+
+Create a GitLab issue
+^^^^^^^^^^^^^^^^^^^^^^
+
+Run the ``/gitlab issue create`` slash command to open an interactive modal where you can create a new GitLab issue. The modal allows you to:
+
+- Set the issue title and description
+- Assign labels
+- Set the assignee
+- Choose the milestone
+- Select the target project
+
+Attach comments to existing issues
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Run the ``/gitlab issue comment [issue-number]`` slash command to attach a comment to an existing GitLab issue. This opens an interactive modal where you can compose and submit your comment directly from Mattermost.
 
 Update settings
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Documentation for:
- https://github.com/mattermost/mattermost/pull/30797
- https://github.com/mattermost/mattermost-plugin-gitlab/pull/532
- https://github.com/mattermost/mattermost-plugin-gitlab/pull/525
- https://github.com/mattermost/mattermost-plugin-gitlab/pull/515
- https://github.com/mattermost/mattermost-plugin-gitlab/pull/522
- https://github.com/mattermost/mattermost-plugin-gitlab/pull/306

Updates:
- Add v10.10 release section to changelog with GitLab plugin v1.10.0 entry
- Update server releases table with v10.10 release information
- Follow established patterns for plugin version documentation

Related to issue #8086 for GitLab plugin version bump to 1.10.0