### PR TITLE
AIAided: Redirect All Plans badge links to local plans page

### DIFF
--- a/source/_static/badges/allplans-cloud-selfhosted.md
+++ b/source/_static/badges/allplans-cloud-selfhosted.md
@@ -2,7 +2,7 @@
 <div class="mm-plans-badge">
 ```
 
-![plans-img](/_static/images/badges/flag_icon.svg) Available on [all plans](https://mattermost.com/pricing/)
+![plans-img](/_static/images/badges/flag_icon.svg) Available on [all plans](../../about/plans.html)
 
 ![deployment-img](/_static/images/badges/deployment_icon.svg) [Cloud](https://mattermost.com/sign-up/) and [self-hosted](https://mattermost.com/download/) deployments
 

--- a/source/_static/badges/allplans-cloud-selfhosted.rst
+++ b/source/_static/badges/allplans-cloud-selfhosted.rst
@@ -5,7 +5,7 @@
 
   <div class="mm-plans-badge">
 
-|plans-img| Available on `all plans <https://mattermost.com/pricing/>`__
+|plans-img| Available on `all plans <../../about/plans.html>`__
 
 |deployment-img| `Cloud <https://mattermost.com/sign-up/>`__ and `self-hosted <https://mattermost.com/download/>`__ deployments
 

--- a/source/_static/badges/allplans-cloud.rst
+++ b/source/_static/badges/allplans-cloud.rst
@@ -5,7 +5,7 @@
 
   <div class="mm-plans-badge">
 
-|plans-img| Available on `all plans <https://mattermost.com/pricing/>`__
+|plans-img| Available on `all plans <../../about/plans.html>`__
 
 |deployment-img| `Cloud <https://mattermost.com/sign-up/>`__ deployments
 

--- a/source/_static/badges/allplans-selfhosted.md
+++ b/source/_static/badges/allplans-selfhosted.md
@@ -2,7 +2,7 @@
 <div class="mm-plans-badge">
 ```
 
-![plans-img](/_static/images/badges/flag_icon.svg) Available on [all plans](https://mattermost.com/pricing/)
+![plans-img](/_static/images/badges/flag_icon.svg) Available on [all plans](../../about/plans.html)
 
 ![deployment-img](/_static/images/badges/deployment_icon.svg) [self-hosted](https://mattermost.com/download/) deployments
 

--- a/source/_static/badges/allplans-selfhosted.rst
+++ b/source/_static/badges/allplans-selfhosted.rst
@@ -5,7 +5,7 @@
 
   <div class="mm-plans-badge">
 
-|plans-img| Available on `all plans <https://mattermost.com/pricing/>`__
+|plans-img| Available on `all plans <../../about/plans.html>`__
 
 |deployment-img| `self-hosted <https://mattermost.com/download/>`__ deployments
 


### PR DESCRIPTION
Fixes #8102

Update all plan/deployment badge files to redirect "All Plans" links from the external Mattermost pricing page to the local documentation page.

This provides docs visitors with direct access to the comprehensive plan comparison table instead of directing them to the external pricing page.

Generated with [Claude Code](https://claude.ai/code)