### PR TITLE
Update shared channels documentation for DM button behavior from v10.10

### DIFF
--- a/source/onboard/connected-workspaces.rst
+++ b/source/onboard/connected-workspaces.rst
@@ -152,6 +152,8 @@ Once a connection is established between two Mattermost servers, system admins c
 
     The ability to create a direct or group message with remote users across connected workspaces is only available when the feature flag ``EnableSharedChannelsDMs`` is enabled. While this feature is in :ref:`Beta <manage/feature-labels:beta>`, there are some known issues that may impact reliability of direct message delivery across servers.
 
+    From Mattermost server v10.10 onward, when viewing the profile popup of a shared channel user, the direct message button is disabled and unavailable when the ``EnableSharedChannelsDMs`` feature flag is disabled. This ensures that users cannot attempt to initiate direct messages with remote users when the feature is not enabled on their Mattermost instance.
+
 Manage connections and invitations
 ----------------------------------
 


### PR DESCRIPTION
Updates the Mattermost Product Documentation to reflect shared channels product experience changes from v10.10 onward.

Adds documentation about disabled DM button behavior in user profile popups for shared channel users when the EnableSharedChannelsDMs feature flag is disabled.

Closes #8115. Documentation for: https://github.com/mattermost/mattermost/pull/30903

Generated with [Claude Code](https://claude.ai/code)