### PR TITLE
Add deactivation status to mmctl user search output for v10.10

### DIFF
--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -6955,7 +6955,9 @@ mmctl user search
 
 **Description**
 
-Search for users based on username, email, or user ID.
+Search for users based on username, email, or user ID. The command returns user information including usernames, email addresses, first and last names, and account status.
+
+Starting from Mattermost v10.10, the output also includes the user's deactivation status to help administrators identify inactive accounts.
 
 **Format**
 
@@ -6968,6 +6970,22 @@ Search for users based on username, email, or user ID.
 .. code-block:: sh
 
    mmctl user search user1@mail.com user2@mail.com
+
+**Output**
+
+The command returns user details in the following format:
+
+.. code-block:: sh
+
+   +---------------------------+------------------+------------+-----------+-------------+
+   | ID                        | USERNAME         | EMAIL      | FIRST     | LAST        |
+   |                           |                  |            | NAME      | NAME        |
+   +---------------------------+------------------+------------+-----------+-------------+
+   | 7xk3j8qr3fnzpgw5fzjm8n... | user1            | user1@...  | User      | One         |
+   | 9xt5k2sr4gnbqhx6gzlm9p... | user2            | user2@...  | User      | Two         |
+   +---------------------------+------------------+------------+-----------+-------------+
+
+Starting from Mattermost v10.10, deactivated users are clearly indicated in the output to help administrators identify account status.
 
 **Options**
 


### PR DESCRIPTION
Update mmctl user search documentation to reflect new functionality from v10.10 onward.

## Changes
- Enhanced command description to mention account status information
- Added specific note about v10.10 deactivation status feature
- Added Output section with example table format
- Clarified that deactivated users are clearly indicated in output

This aligns with the server changes that include user availability/deactivation status in mmctl user search output.

Resolves #8117. Documentation for: https://github.com/mattermost/mattermost/pull/30379

Generated with [Claude Code](https://claude.ai/code)