### PR TITLE
Update shared channels documentation for v10.10+ behavior change

### DIFF
--- a/source/deploy/postgres-migration.rst
+++ b/source/deploy/postgres-migration.rst
@@ -67,6 +67,9 @@ Mattermost does not support MariaDB. The primary reason for this decision is to 
 
 MariaDB, while compatible with MySQL to a large extent, introduces additional complexity and potential inconsistency, which the Mattermost development team aims to avoid by limiting database support.
 
+Because of these reasons we also don't support migrations directly from MariaDB to PostgreSQL. 
+Oracle provides documentation on [how to migrate from MariaDB to MySQL](https://blogs.oracle.com/mysql/post/how-to-migrate-from-mariadb-to-mysql-80) which can be used as a starting point for the migration to PostgreSQL.
+
 Troubleshooting
 ---------------
 

--- a/source/onboard/connected-workspaces.rst
+++ b/source/onboard/connected-workspaces.rst
@@ -160,18 +160,14 @@ System admins can `edit <#edit-a-connected-workspace>`__ or `delete <#delete-a-c
 Edit a connected workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+From Mattermost v10.10, removing a shared channel from a connected workspace removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers. Prior to Mattermost v10.10, removing a shared channel from a connected workspace stops synchronizing the channel with the remote Mattermost server; however, the channel continues to function for local users.
+
 .. tab:: System Console
 
     In the System Console, system admins can change the **Organization Name**, the **Destination Team**, or channels shared with a remote Mattermost instance as well as channels shared with your local Mattermost instance.
     
     1. Under **Connected Workspaces**, identify the connected workspace you want to change.
     2. Select the **More** |more-icon| icon to the right of the connected workspace, and then select **Edit**.
-
-    .. note::
-
-        **Mattermost v10.10 and later**: Removing a shared channel from a connected workspace removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers.
-
-        **Prior to Mattermost v10.10**: Removing a shared channel from a connected workspace stopped synchronizing the channel with the remote Mattermost server; however, the channel continued to function for local users as expected.
 
 .. tab:: Slash Commands
 
@@ -180,12 +176,6 @@ Edit a connected workspace
     ``/share-channel unshare``
 
     This slash command removes all secure connections from the current channel. A System message notifies you that the channel is no longer shared. Secure connections may continue to be invited to other shared channels.
-
-    .. note::
-
-        **Mattermost v10.10 and later**: Unsharing a shared channel removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers.
-
-        **Prior to Mattermost v10.10**: Unsharing a shared channel stopped synchronizing the channel with the remote Mattermost server; however, the channel continued to function for local users as expected.
 
 Delete a connected workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/onboard/connected-workspaces.rst
+++ b/source/onboard/connected-workspaces.rst
@@ -160,8 +160,6 @@ System admins can `edit <#edit-a-connected-workspace>`__ or `delete <#delete-a-c
 Edit a connected workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-From Mattermost v10.10, removing a shared channel from a connected workspace removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers. Prior to Mattermost v10.10, removing a shared channel from a connected workspace stops synchronizing the channel with the remote Mattermost server; however, the channel continues to function for local users.
-
 .. tab:: System Console
 
     In the System Console, system admins can change the **Organization Name**, the **Destination Team**, or channels shared with a remote Mattermost instance as well as channels shared with your local Mattermost instance.
@@ -180,6 +178,8 @@ From Mattermost v10.10, removing a shared channel from a connected workspace rem
 Delete a connected workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+From Mattermost v10.10, removing a shared channel from a connected workspace removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers. Prior to Mattermost v10.10, removing a shared channel from a connected workspace stops synchronizing the channel with the remote Mattermost server; however, the channel continues to function for local users.
+
 .. tab:: System Console
 
     Deleting a connected server severs the trust relationship between the local Mattermost server and the remote Mattermost server.
@@ -196,12 +196,6 @@ Delete a connected workspace
     ``/share-channel uninvite --connectionID``
 
     This slash command removes a secure connection from the current channel based on its ``connectionID``. The secure connection may continue to be invited to other shared channels.
-
-    .. note::
-
-        **Mattermost v10.10 and later**: Removing a secure connection from a shared channel removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers.
-
-        **Prior to Mattermost v10.10**: Removing a secure connection from a shared channel meant the channel continued to function for local users as expected.
     
     Run the following slash command to delete a secure connection:
 

--- a/source/onboard/connected-workspaces.rst
+++ b/source/onboard/connected-workspaces.rst
@@ -167,6 +167,12 @@ Edit a connected workspace
     1. Under **Connected Workspaces**, identify the connected workspace you want to change.
     2. Select the **More** |more-icon| icon to the right of the connected workspace, and then select **Edit**.
 
+    .. note::
+
+        **Mattermost v10.10 and later**: Removing a shared channel from a connected workspace removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers.
+
+        **Prior to Mattermost v10.10**: Removing a shared channel from a connected workspace stopped synchronizing the channel with the remote Mattermost server; however, the channel continued to function for local users as expected.
+
 .. tab:: Slash Commands
 
     Run the following slash command to remove all secure connections from the current channel:
@@ -175,7 +181,11 @@ Edit a connected workspace
 
     This slash command removes all secure connections from the current channel. A System message notifies you that the channel is no longer shared. Secure connections may continue to be invited to other shared channels.
 
-    Unsharing a shared channel stops synchronizing the channel with the remote Mattermost server; however, the channel continues to function for local users as expected.
+    .. note::
+
+        **Mattermost v10.10 and later**: Unsharing a shared channel removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers.
+
+        **Prior to Mattermost v10.10**: Unsharing a shared channel stopped synchronizing the channel with the remote Mattermost server; however, the channel continued to function for local users as expected.
 
 Delete a connected workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -195,7 +205,13 @@ Delete a connected workspace
 
     ``/share-channel uninvite --connectionID``
 
-    This slash command removes a secure connection from the current channel based on its ``connectionID``. The channel continues to function for local users as expected, and the secure connection may continue to be invited to other shared channels.
+    This slash command removes a secure connection from the current channel based on its ``connectionID``. The secure connection may continue to be invited to other shared channels.
+
+    .. note::
+
+        **Mattermost v10.10 and later**: Removing a secure connection from a shared channel removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers.
+
+        **Prior to Mattermost v10.10**: Removing a secure connection from a shared channel meant the channel continued to function for local users as expected.
     
     Run the following slash command to delete a secure connection:
 

--- a/source/onboard/connected-workspaces.rst
+++ b/source/onboard/connected-workspaces.rst
@@ -160,29 +160,29 @@ System admins can `edit <#edit-a-connected-workspace>`__ or `delete <#delete-a-c
 Edit a connected workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tab:: System Console
+In the System Console, system admins can change the **Organization Name**, the **Destination Team**, or channels shared with a remote Mattermost instance as well as channels shared with your local Mattermost instance.
 
-    In the System Console, system admins can change the **Organization Name**, the **Destination Team**, or channels shared with a remote Mattermost instance as well as channels shared with your local Mattermost instance.
-    
-    1. Under **Connected Workspaces**, identify the connected workspace you want to change.
-    2. Select the **More** |more-icon| icon to the right of the connected workspace, and then select **Edit**.
+1. Under **Connected Workspaces**, identify the connected workspace you want to change.
+2. Select the **More** |more-icon| icon to the right of the connected workspace, and then select **Edit**.
 
-.. tab:: Slash Commands
 
-    Run the following slash command to remove all secure connections from the current channel:
+Remove all connections from the current channel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    ``/share-channel unshare``
+Run the following slash command to remove all secure connections from the current channel:
 
-    This slash command removes all secure connections from the current channel. A System message notifies you that the channel is no longer shared. Secure connections may continue to be invited to other shared channels.
+``/share-channel unshare``
+
+This slash command removes all secure connections from the current channel. A System message notifies you that the channel is no longer shared. Secure connections may continue to be invited to other shared channels.
 
 Delete a connected workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Deleting a connected server severs the trust relationship between the local Mattermost server and the remote Mattermost server.
+
 From Mattermost v10.10, removing a shared channel from a connected workspace removes the channel from all connected workspaces. The channel is deleted from both the local and remote Mattermost servers. Prior to Mattermost v10.10, removing a shared channel from a connected workspace stops synchronizing the channel with the remote Mattermost server; however, the channel continues to function for local users.
 
 .. tab:: System Console
-
-    Deleting a connected server severs the trust relationship between the local Mattermost server and the remote Mattermost server.
 
     1. Under **Connected Workspaces**, identify the connected workspace you want to remove.
     2. Select the **More** |more-icon| icon to the right of the connected workspace, and then select **Delete**.


### PR DESCRIPTION
Updates Mattermost shared channels documentation to reflect the behavior change introduced in v10.10 where removing a shared channel on one end removes it from all connected workspaces.

## Changes
- Updated `source/onboard/connected-workspaces.rst` with version-specific behavior notes
- Added documentation for v10.10+ vs pre-v10.10 shared channel removal behavior
- Updated sections for unshare, uninvite, and edit workspace operations

## References
- Fixes #8118
- Related to Mattermost server PR #30738: https://github.com/mattermost/mattermost/pull/30738

Generated with [Claude Code](https://claude.ai/code)