### PR TITLE
Add documentation for v10.10 license seat count enforcement

### DIFF
--- a/source/about/self-hosted-subscriptions.rst
+++ b/source/about/self-hosted-subscriptions.rst
@@ -43,6 +43,19 @@ When you buy an annual Mattermost subscription, you agree to provide Mattermost 
 
 We'll send you an email notice around the end of the quarter reminding you to send us your report.
 
+License seat count enforcement
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.10
+
+From Mattermost server v10.10 onward, system administrators can optionally enable active license seat count enforcement as an alternative to the traditional quarterly true-up reporting model. When the :ref:`IsSeatCountEnforced <configure/environment-configuration-settings:enforce license seat count>` setting is enabled:
+
+- **Real-time compliance**: License seat limits are enforced immediately when reached, preventing new user registration and activation.
+- **Proactive notifications**: System administrators receive alerts when approaching license limits.
+- **Automated compliance**: Reduces reliance on manual quarterly reporting processes.
+
+When seat count enforcement is disabled (default), Mattermost continues to use the quarterly true-up reporting model described below for license compliance management.
+
 .. image:: ../images/true-up-schedule.png
    :alt: The timeframes followed for the true-up notifications.
 

--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -20,6 +20,7 @@ Review and manage the following environmental configuration options in the Syste
 - `Performance monitoring <#performance-monitoring>`__
 - `Developer <#developer>`__
 - `Mobile security <#mobile-security>`__ 
+- `License enforcement <#license-enforcement>`__ 
 - `config.json-only settings <#config-json-only-settings>`__
 
 .. tip::
@@ -4082,3 +4083,46 @@ Enable dedicated export filestore target
 
   - When an alternate filestore target is configured, Mattermost Cloud admins can generate an S3 presigned URL for exports using the ``/exportlink [job-id|zip file|latest]`` slash command. See the :ref:`Mattermost data migration <manage/cloud-data-export:create the export>` documentation for details. Alternatively, Cloud and self-hosted admins can use the :ref:`mmctl export generate-presigned-url <manage/mmctl-command-line-tool:mmctl export generate-presigned-url>` command to generate a presigned URL directly from mmctl.
   - Generating an S3 presigned URL requires the feature flag ``EnableExportDirectDownload`` to be set to ``true``,  the storage must be compatible with generating an S3 link, and this experimental configuration setting must be set to ``true``. Presigned URLs for exports aren't supported for systems with shared storage.
+
+License enforcement
+-------------------
+
+.. include:: ../_static/badges/ent-pro-selfhosted.rst
+  :start-after: :nosearch:
+
+.. versionadded:: 10.10
+
+Configure license seat count enforcement by editing the ``config.json`` file as described in the following table. Changes to configuration settings in this section require a server restart before taking effect.
+
+.. config:setting:: license-seat-count-enforced
+  :displayname: Enforce license seat count (License enforcement)
+  :systemconsole: N/A
+  :configjson: .ServiceSettings.IsSeatCountEnforced
+  :environment: MM_SERVICESETTINGS_ISSEATCOUNTENFORCED
+  :description: Controls whether licensed seat count limits are actively enforced on the server.
+
+Enforce license seat count
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+| Controls whether licensed seat count limits are actively     | - System Config path: **N/A**                                            |
+| enforced on the server.                                      | - ``config.json`` setting: ``.ServiceSettings.IsSeatCountEnforced``     |  
+|                                                               | - Environment variable: ``MM_SERVICESETTINGS_ISSEATCOUNTENFORCED``       |
+| - **true**: Licensed seat count limits are actively enforced.|                                                                          |
+|   When the total number of activated users reaches the       |                                                                          |
+|   licensed seat count, new user registration and activation  |                                                                          |
+|   will be blocked until users are deactivated or the license |                                                                          |
+|   is upgraded.                                               |                                                                          |
+| - **false**: **(Default)** Licensed seat count limits are    |                                                                          |
+|   not actively enforced. User count compliance is managed    |                                                                          |
+|   through quarterly true-up reporting processes.             |                                                                          |
+|                                                               |                                                                          |
+| Boolean input.                                                |                                                                          |
++---------------------------------------------------------------+--------------------------------------------------------------------------+
+
+.. note::
+
+  - When seat count enforcement is enabled, system administrators will receive notifications when approaching license limits.
+  - Guest accounts and deactivated users do not count toward the licensed seat count.
+  - This setting requires Mattermost Enterprise or Professional licenses and is available from Mattermost server v10.10 onward.
+  - If enforcement is enabled but no valid license is installed, the server will operate in read-only mode for new user operations.

--- a/source/manage/admin/installing-license-key.rst
+++ b/source/manage/admin/installing-license-key.rst
@@ -38,6 +38,19 @@ You don't need to wait for your current license key to expire before replacing i
     
     To find the total number of users, go to **System Console > Reporting > Site Statistics**. The total number of users is displayed in the **Total Activated Users** field. The license will be rejected if this value is greater than the value allowed by your license key.
 
+License seat count enforcement
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 10.10
+
+From Mattermost server v10.10 onward, system administrators can configure active enforcement of licensed seat count limits using the :ref:`IsSeatCountEnforced <configure/environment-configuration-settings:enforce license seat count>` setting. When this feature is enabled:
+
+- **Active enforcement**: New user registration and activation is blocked when the total number of activated users reaches the licensed seat count.
+- **System admin notifications**: Administrators receive notifications when approaching license limits.
+- **Compliance management**: Organizations can enforce license compliance in real-time rather than relying solely on quarterly true-up processes.
+
+When seat count enforcement is disabled (default), Mattermost continues to use the traditional quarterly true-up reporting model for license compliance.
+
 Follow these steps to change your license key:
 
 1. Go to **System Console > About > Edition and License**.


### PR DESCRIPTION
Add documentation for the new IsSeatCountEnforced setting introduced in Mattermost server v10.10, based on changes from mattermost/mattermost##31354.

## Changes
- Add IsSeatCountEnforced configuration setting documentation in environment settings
- Document new license enforcement behavior in installation guide
- Update self-hosted subscriptions to explain enforcement vs true-up models
- Include cross-references and version information for v10.10+ feature

## Summary
This introduces documentation for the new license seat count enforcement feature that allows system administrators to enable active enforcement of licensed seat limits, providing an alternative to the traditional quarterly true-up reporting model.

Closes #8126. Documentation for: https://github.com/mattermost/mattermost/pull/31354

Generated with [Claude Code](https://claude.ai/code)