### PR TITLE
Update team/system schemes subscription plan requirements

### DIFF
--- a/source/onboard/advanced-permissions.rst
+++ b/source/onboard/advanced-permissions.rst
@@ -9,7 +9,7 @@ Mattermost system admins using Mattermost Cloud or Mattermost Server can use Adv
 Two permission schemes are provided in Mattermost:
 
 * **System Scheme**: Applies permissions universally across all teams and channels.
-* **Team Override Schemes**: Allow admins to customize permissions for each team (available in Mattermost Enterprise and Professional).
+* **Team Override Schemes**: Allow admins to customize permissions for each team.
 
 This document describes the types of permissions that can be given to users of Mattermost using schemes as well as channel settings and roles. The :doc:`permissions backend documentation </onboard/advanced-permissions-backend-infrastructure>` provides additional technical details around permissions.
   
@@ -36,9 +36,6 @@ You can access the System Scheme interface by going to **System Console > User M
 
 Team override scheme
 ~~~~~~~~~~~~~~~~~~~~
-
-.. include:: ../_static/badges/ent-pro-only.rst
-  :start-after: :nosearch:
 
 On systems with multiple :ref:`Mattermost teams <collaborate/organize-using-teams:single team versus multiple teams>`, each team may operate and collaborate in a unique way. Team Override Schemes give Admins the flexibility to tailor permissions to the needs of each team.
 

--- a/source/repeatable-processes/share-and-collaborate.rst
+++ b/source/repeatable-processes/share-and-collaborate.rst
@@ -10,7 +10,7 @@ There are different ways for teams to access and interact with collaborative pla
 Permissions are provided using:
 
 * **System Scheme:** Applies permissions universally across all teams, channels, and playbooks.
-* **Team Override Schemes:** Allow admins to customize permissions for each team (available in Mattermost Enterprise and Professional).
+* **Team Override Schemes:** Allow admins to customize permissions for each team.
 
 For more information about System and Team Override Schemes, refer to the :doc:`Advanced Permissions </onboard/advanced-permissions>` documentation.
 


### PR DESCRIPTION
- Remove Enterprise/Professional restrictions from Team Override Schemes
- Update Team Override Schemes to be available on all plans
- Remove specific Enterprise badge from Team Override Schemes section
- Align with updated subscription plan requirements for team schemes

Closes https://github.com/mattermost/docs/issues/8133