### PR TITLE
Update ABAC documentation to reflect guest invite restrictions in v10.10+

### DIFF
--- a/source/manage/admin/attribute-based-access-control.rst
+++ b/source/manage/admin/attribute-based-access-control.rst
@@ -8,10 +8,6 @@ From Mattermost v10.9, system admins in large or complex organizations who requi
 
 Enforcing strict access controls based on user attributes eliminates manual role adjustment processes that can lead to security risks, inefficiencies, or inappropriate access, while maintaining security and compliance by ensuring that only authorized users can access specific Mattermost channels.
 
-.. note::
-  
-  Starting from Mattermost v10.10, channels with attribute-based access controls do not allow guest invitations. This restriction ensures that guest users cannot bypass attribute-based access policies, maintaining the security and integrity of channels protected by ABAC rules.
-
 Before you begin
 ------------------
 
@@ -42,7 +38,7 @@ You can add multiple rules to a single policy, and each rule can include multipl
 
   .. tab:: Simple Mode
 
-    Simple Mode is ideal for simple and straightforward access control scenarios. Each row is a single condition that must be met for a user to comply with the policy. Simple Mode only supports simple conditions without nested logic or mixed logical operators. All rules are combined with a logical AND operator ``&&``. 
+    Simple Mode is ideal for simple and straightforward access control scenarios. Each row is a single condition that must be met for a user to comply with the policy. Simple Mode only supports simple conditions without nested logic or mixed logical operators. All rules are combined with a logical AND operator ``&&``.
 
     1. Select **Add attribute** and select the attribute you want to use for access control.
     2. Specify how you want the attribute to match the user profile. You can choose from the following options:
@@ -88,8 +84,8 @@ Assign policies to private channels
 Specify the private channel that your access control policy applies to by selecting **Add channels** to search for and select the channels you want. You can assign the policy to multiple channels at once, or you can `assign it to individual channels <#define-access-controls-per-channel>`__ later. Select **Save** to save your changes.
 
 .. note::
-  
-  Channels with attribute-based access control policies cannot have guest users invited to them (Mattermost v10.10+). Only users who match the defined attribute criteria can be added to ABAC-controlled channels, ensuring strict adherence to access control policies.
+
+  Private channels with attribute-based access control policies can't have guest users invited to them. Only users who match the defined attribute criteria can be added to ABAC-controlled channels, ensuring strict adherence to access control policies.
 
 Delete policies
 ~~~~~~~~~~~~~~~~
@@ -104,10 +100,6 @@ You can assign an existing access control policy to a private channels for more 
 1. In the System Console, go to **User Management > Channels** to select the private channel you want to configure, and select **Edit**.
 2. In the **Channel Management** section, enable the **Enable attribute-based channel access** option.
 3. Under **Access policy**, select **Link to a policy** to select an existing policy.
-
-.. note::
-  
-  Once attribute-based access controls are enabled for a channel, guest users cannot be invited to that channel (Mattermost v10.10+). This restriction maintains the integrity of your attribute-based access policies.
 
 Remove channel policies
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION


- Added note that ABAC-controlled channels do not allow guest invitations starting from Mattermost v10.10
- Added important callouts in policy assignment and per-channel configuration sections
- Ensures users understand the security implications and restrictions of ABAC channels with guest users

Documentation for: https://github.com/mattermost/mattermost/pull/31139
Closes https://github.com/mattermost/docs/issues/8139