### PR TITLE
Clarify SQL queries in schema changes are automatically executed

### DIFF
--- a/source/upgrade/important-upgrade-notes.rst
+++ b/source/upgrade/important-upgrade-notes.rst
@@ -8,13 +8,10 @@ Important Upgrade Notes
 
   - Upgrading the Microsoft Teams Calling plugin to v2.0.0 requires users to reconnect their accounts.
   - Mattermost plugins built with Go versions 1.22.0 and 1.22.1 do not work. Plugin developers should use Go 1.22.2 or newer instead.
-  - Keybase has stopped serving our Ubuntu repository signing key. If you were using it, update your installation scripts to retrieve the key as mentioned in our docs: https://docs.mattermost.com/deploy/server/deploy-linux.
-  - MySQL 8.0.22 contains an `issue with JSON column types <https://bugs.mysql.com/bug.php?id=101284>`__ changing string values to integers which is preventing Mattermost from working properly. Users are advised to avoid this database version.
-  - When upgrading to 7.x from a 5.x release please make sure to upgrade to 5.37.10 first for the upgrade to complete successfully.
-
-.. important::
-
-  **SQL Queries in Schema Changes**: The SQL queries shown in the schema changes below are **automatically executed** during the Mattermost upgrade process. **You do not need to run these queries manually**. They are provided for informational purposes only to help you understand what database changes will occur during the upgrade. Running these queries manually is optional and only recommended if you want to reduce downtime by pre-applying schema changes.
+  - Keybase has stopped serving Mattermost's Ubuntu repository signing key. If you were using it, update your installation scripts to retrieve the key as mentioned in our :doc:`Linux deployment documentation </deploy/server/deploy-linux>`.
+  - We recommend avoiding the use of MySQL 8.0.22 as it contains an `issue with JSON column types <https://bugs.mysql.com/bug.php?id=101284>`_ changing string values to integers which is preventing Mattermost from working properly.
+  - When upgrading to Mattermost 7.x from a 5.x release, upgrade to 5.37.10 first before attempting the v7.x upgrade.
+  - SQL queries for related schema changes below are **automatically executed** during the Mattermost server upgrade process. **You don't need to run these queries manually**. These SQL queries are provided to help you understand what database changes will occur during the upgrade, and for cases where you prefer to reduce downtime by pre-applying schema changes.
 
 +----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | If you’re upgrading                                | Then...                                                                                                                                                          |

--- a/source/upgrade/important-upgrade-notes.rst
+++ b/source/upgrade/important-upgrade-notes.rst
@@ -12,6 +12,10 @@ Important Upgrade Notes
   - MySQL 8.0.22 contains an `issue with JSON column types <https://bugs.mysql.com/bug.php?id=101284>`__ changing string values to integers which is preventing Mattermost from working properly. Users are advised to avoid this database version.
   - When upgrading to 7.x from a 5.x release please make sure to upgrade to 5.37.10 first for the upgrade to complete successfully.
 
+.. important::
+
+  **SQL Queries in Schema Changes**: The SQL queries shown in the schema changes below are **automatically executed** during the Mattermost upgrade process. **You do not need to run these queries manually**. They are provided for informational purposes only to help you understand what database changes will occur during the upgrade. Running these queries manually is optional and only recommended if you want to reduce downtime by pre-applying schema changes.
+
 +----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | If you’re upgrading                                | Then...                                                                                                                                                          |
 | from a version earlier than...                     |                                                                                                                                                                  |

--- a/source/upgrade/important-upgrade-notes.rst
+++ b/source/upgrade/important-upgrade-notes.rst
@@ -3,15 +3,7 @@ Important Upgrade Notes
 
 .. include:: ../about/common-esr-support-rst.rst
 
-
-.. note::
-
-  - Upgrading the Microsoft Teams Calling plugin to v2.0.0 requires users to reconnect their accounts.
-  - Mattermost plugins built with Go versions 1.22.0 and 1.22.1 do not work. Plugin developers should use Go 1.22.2 or newer instead.
-  - Keybase has stopped serving Mattermost's Ubuntu repository signing key. If you were using it, update your installation scripts to retrieve the key as mentioned in our :doc:`Linux deployment documentation </deploy/server/deploy-linux>`.
-  - We recommend avoiding the use of MySQL 8.0.22 as it contains an `issue with JSON column types <https://bugs.mysql.com/bug.php?id=101284>`_ changing string values to integers which is preventing Mattermost from working properly.
-  - When upgrading to Mattermost 7.x from a 5.x release, upgrade to 5.37.10 first before attempting the v7.x upgrade.
-  - SQL queries for related schema changes below are **automatically executed** during the Mattermost server upgrade process. **You don't need to run these queries manually**. These SQL queries are provided to help you understand what database changes will occur during the upgrade, and for cases where you prefer to reduce downtime by pre-applying schema changes.
+We recommend reviewing the `additional upgrade notes <#additional-upgrade-notes>`__ at the bottom of this page.
 
 +----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | If you’re upgrading                                | Then...                                                                                                                                                          |
@@ -1512,3 +1504,15 @@ Important Upgrade Notes
 | v3.4.0                                             | If public links are enabled, existing public links will no longer be valid. This is because in earlier versions, existing public links were not invalidated      |
 |                                                    | when the Public Link Salt was regenerated. You must update any place where you have published these links.                                                       |
 +----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Additional upgrade notes
+------------------------
+
+.. note::
+
+  - Upgrading the Microsoft Teams Calling plugin to v2.0.0 requires users to reconnect their accounts.
+  - Mattermost plugins built with Go versions 1.22.0 and 1.22.1 do not work. Plugin developers should use Go 1.22.2 or newer instead.
+  - Keybase has stopped serving Mattermost's Ubuntu repository signing key. If you were using it, update your installation scripts to retrieve the key as mentioned in our :doc:`Linux deployment documentation </deploy/server/deploy-linux>`.
+  - We recommend avoiding the use of MySQL 8.0.22 as it contains an `issue with JSON column types <https://bugs.mysql.com/bug.php?id=101284>`_ changing string values to integers which is preventing Mattermost from working properly.
+  - When upgrading to Mattermost 7.x from a 5.x release, upgrade to 5.37.10 first before attempting the v7.x upgrade.
+  - SQL queries for related schema changes below are **automatically executed** during the Mattermost server upgrade process. **You don't need to run these queries manually**. These SQL queries are provided to help you understand what database changes will occur during the upgrade, and for cases where you prefer to reduce downtime by pre-applying schema changes.


### PR DESCRIPTION
Add prominent note explaining that SQL queries shown in schema changes are automatically executed during upgrades and don't require manual execution by administrators.

Fixes #8142
