### PR TITLE
Move MessageExportSettings.BatchSize to compliance configuration settings

### DIFF
--- a/source/configure/compliance-configuration-settings.rst
+++ b/source/configure/compliance-configuration-settings.rst
@@ -274,6 +274,27 @@ The SMTP server port that will receive your Global Relay EML file when a `custom
 | This feature's ``config.json`` setting is ``".MessageExportSettings.GlobalRelaySettings.CustomSMTPPort": 25`` with string input. |
 +----------------------------------------------------------------------------------------------------------------------------------+
 
+.. config:setting:: message-export-batch-size
+  :displayname: Message export batch size (Compliance Export)
+  :systemconsole: N/A
+  :configjson: .MessageExportSettings.BatchSize
+  :environment: MM_MESSAGEEXPORTSETTINGS_BATCHSIZE
+  :description: Determines how many new posts are batched together to a compliance export file. Default is **10000** posts.
+
+Message export batch size
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../_static/badges/ent-only.rst
+  :start-after: :nosearch:
+
+This setting isn't available in the System Console and can only be set in ``config.json``.
+
+Determines how many new posts are batched together to a compliance export file.
+
++---------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"BatchSize": 10000`` with numerical input.     |
++---------------------------------------------------------------------------------------------+
+
 Run compliance export job now
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -1005,26 +1005,6 @@ This setting is used to maximize performance for large Enterprise deployments.
 | This feature's ``config.json`` setting is ``"MaxUsersForStatistics": 2500`` with numerical input. |
 +---------------------------------------------------------------------------------------------------+
 
-.. config:setting:: batch-size
-  :displayname: Batch size (Experimental)
-  :systemconsole: N/A
-  :configjson: BatchSize
-  :environment: N/A
-  :description: Determines how many new posts are batched together to a compliance export file. Default is **10000** posts.
-
-Batch size
-~~~~~~~~~~
-
-.. include:: ../_static/badges/ent-only.rst
-  :start-after: :nosearch:
-
-This setting isn't available in the System Console and can only be set in ``config.json``.
-
-Determines how many new posts are batched together to a compliance export file.
-
-+----------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"BatchSize": 10000`` with numerical input. |
-+----------------------------------------------------------------------------------------+
 
 .. config:setting:: file-location
   :displayname: File location (Experimental)


### PR DESCRIPTION
Fixes ##8158

This PR moves the MessageExportSettings.BatchSize configuration setting from the experimental features section to the compliance configuration settings section, where it logically belongs as part of compliance export functionality.

## Changes
- Remove MessageExportSettings.BatchSize from experimental configuration settings
- Add MessageExportSettings.BatchSize to compliance export section
- Rename setting to message-export-batch-size for clarity
- Update JSON path to .MessageExportSettings.BatchSize
- Add proper environment variable MM_MESSAGEEXPORTSETTINGS_BATCHSIZE

Generated with [Claude Code](https://claude.ai/code)