### PR TITLE
Fixes to tab processing code to stop hiding child pages

### DIFF
--- a/extensions/sphinx_inline_tabs/events.py
+++ b/extensions/sphinx_inline_tabs/events.py
@@ -82,10 +82,24 @@ def doctree_read(app: Sphinx, doctree: nodes.document):
         and len(app.env.sphinx_tabs[app.env.docname]) > 0
     ):
         logger.debug(f"{LOG_PREFIX} doctree_read: {app.env.docname} has tabs")
+        
+        # Store the original toctree structure before replacing it
+        original_toc = None
+        if (len(app.env.tocs[app.env.docname][0]) > 1 and 
+            app.env.tocs[app.env.docname][0][1] is not None):
+            original_toc = app.env.tocs[app.env.docname][0][1]
+            logger.debug(f"{LOG_PREFIX} doctree_read({app.env.docname}): preserving original toctree")
+        
         updated_tocs: nodes.list_item = sectiondata_to_toc(
             app.env.docname,
             collect_sections(app.env, doctree, app.env.docname, doctree),
         )
+        
+        # If we have an original toctree, use it instead of the tab-based one
+        if original_toc is not None:
+            logger.debug(f"{LOG_PREFIX} doctree_read({app.env.docname}): using original toctree instead of tab-based TOC")
+            updated_tocs = original_toc
+            
         logger.debug(
             f"{LOG_PREFIX} doctree_read({app.env.docname}): updated_tocs[0][1]={updated_tocs}"
         )

--- a/source/deploy/server/preparations.rst
+++ b/source/deploy/server/preparations.rst
@@ -4,15 +4,23 @@ Prepare your Mattermost Server environment
 This guide outlines the key preparation steps required before installing the Mattermost Server, focusing on setting up the database and file storage systems.
 
 .. toctree::
-  :maxdepth: 1
-  :hidden:
-  :titlesonly:
+    :maxdepth: 1
+    :hidden:
+    :titlesonly:
 
-   Review software and hardware requirements </deploy/software-hardware-requirements>
-   Set up an NGINX proxy </deploy/server/setup-nginx-proxy>
-   Configure Mattermost Calls </configure/calls-deployment>
-   Set up TLS </deploy/server/setup-tls>
-   Use an image proxy </deploy/server/image-proxy>
+    Review software and hardware requirements </deploy/software-hardware-requirements>
+    Set up an NGINX proxy </deploy/server/setup-nginx-proxy>
+    Configure Mattermost Calls </configure/calls-deployment>
+    Set up TLS </deploy/server/setup-tls>
+    Use an image proxy </deploy/server/image-proxy>
+
+Before installing Mattermost Server, review the following preparation requirements:
+
+* :doc:`Review software and hardware requirements </deploy/software-hardware-requirements>` - Ensure your system meets the minimum requirements for Mattermost deployment.
+* :doc:`Set up an NGINX proxy </deploy/server/setup-nginx-proxy>` - Configure NGINX as a reverse proxy for enhanced security and performance.
+* :doc:`Configure Mattermost Calls </configure/calls-deployment>` - Set up real-time communication capabilities for voice and video calls.
+* :doc:`Set up TLS </deploy/server/setup-tls>` - Enable secure communication with SSL/TLS encryption.
+* :doc:`Use an image proxy </deploy/server/image-proxy>` - Configure image proxy for enhanced privacy and security.
 
 Database preparation
 --------------------

--- a/source/deploy/server/server-deployment-planning.rst
+++ b/source/deploy/server/server-deployment-planning.rst
@@ -2,8 +2,7 @@ Server deployment planning
 ==========================
 
 .. toctree::
-    :maxdepth: 1
-    :hidden:
+    :maxdepth: 4
     :titlesonly:
 
     Preparations </deploy/server/preparations>

--- a/source/guides/deployment-guide.rst
+++ b/source/guides/deployment-guide.rst
@@ -6,7 +6,7 @@ Welcome to deployment guidance for Mattermost. This guide is organized into sect
 Whether you're deploying the server application, desktop application, or mobile application, or troubleshooting deployments, this guide has you covered. Use the navigation below to access detailed information about each topic.
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 3
     :hidden:
     :titlesonly:
 


### PR DESCRIPTION
Any page that had both tabs AND child pages defined were building with the child pages hidden due to recent changes to the tab processing code.