### PR TITLE
Update minimum RHEL requirements to RHEL9 for Mattermost v10.10+

### DIFF
--- a/source/deploy/software-hardware-requirements.rst
+++ b/source/deploy/software-hardware-requirements.rst
@@ -84,8 +84,12 @@ Server software
 Mattermost server operating system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Ubuntu, Debian Buster, CentOS 6+, CentOS 7+, RedHat Enterprise Linux 7+, Oracle Linux 6+, Oracle Linux 7+.
+- Ubuntu, Debian Buster, CentOS 6+, CentOS 7+, RedHat Enterprise Linux 9+, Oracle Linux 6+, Oracle Linux 7+.
 - Using the Mattermost `Docker deployment <https://github.com/mattermost/docker>`__ on a Docker-compatible operating system (Linux-based OS) is still recommended.
+
+.. important::
+
+    Starting with Mattermost v10.10, the minimum supported RedHat Enterprise Linux version is RHEL9 due to the upgrade to Go 1.24, which requires Linux kernel 3.2 or later. Customers running RHEL8 or earlier should upgrade to RHEL9 or later before upgrading to Mattermost v10.10 or later. Note that Extended Update Support for RHEL8 ended on May 31, 2025.
 
 While community support exists for Fedora, FreeBSD, and Arch Linux, Mattermost does not currently include production support for these platforms.
 


### PR DESCRIPTION
Updates the minimum RHEL requirements documentation to reflect RHEL9 minimum due to Go 1.24 upgrade in Mattermost v10.10.

## Changes
- Updated minimum RHEL version from 7+ to 9+
- Added important note about Linux kernel 3.2+ requirement
- Mentioned RHEL8 EUS end date (May 31, 2025)
- Referenced Go 1.24 requirement and kernel compatibility

Fixes #8198

Generated with [Claude Code](https://claude.ai/code)