### PR TITLE
Update Gossip encryption documentation for v10.11 GA release

### DIFF
--- a/source/collaborate/install-android-app.rst
+++ b/source/collaborate/install-android-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost Android mobile app
 =========================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your Android mobile device running Android 7.0 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ on your Android mobile device running Android 7.0 or later.
 
 1. On your device, visit the Play Store.
 2. Search for "Mattermost" and select **INSTALL** to download the app.

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost desktop app
 ==================================
 
-Download and install the Mattermost desktop app from the App Store (macOS), Microsoft Store (Windows), or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
+Download and install the Mattermost desktop app `for macOS from the App Store <https://apps.apple.com/us/app/mattermost-desktop/id1614666244?mt=12>`_, `for Windows from the Microsoft Store <https://apps.microsoft.com/detail/xp8br8mh3lpklt?hl=en-US&gl=US>`_, or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
 
 We strongly recommend installing the desktop app on a local drive. Network shares aren't supported. 
 

--- a/source/collaborate/install-ios-app.rst
+++ b/source/collaborate/install-ios-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost iOS mobile app
 =====================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your iOS mobile device running iOS 12.1 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://apps.apple.com/us/app/mattermost/id1257222717>`_ on your iOS mobile device running iOS 12.1 or later.
 
 1. On your device, visit the App Store. 
 2. Search for "Mattermost" and select **GET** to download the app.

--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -2771,8 +2771,8 @@ Use IP address
 |   hostname.                                                                  |                                                                        |
 +------------------------------------------------------------------------------+------------------------------------------------------------------------+
 
-.. config:setting:: enable-experimental-gossip-encryption
-  :displayname: Use gossip (High Availability)
+.. config:setting:: enable-gossip-encryption
+  :displayname: Enable gossip encryption (High Availability)
   :systemconsole: Environment > High Availability
   :configjson: .ClusterSettings.UseExperimentalGossip
   :environment: MM_CLUSTERSETTINGS_USEEXPERIMENTALGOSSIP
@@ -2780,13 +2780,23 @@ Use IP address
   - **true**: **(Default)** The server attempts to communicate via the gossip protocol over the gossip port specified.
   - **false**: The server attempts to communicate over the streaming port.
 
-Enable experimental gossip encryption
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Enable gossip encryption
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-----------------------------------------------------------------+----------------------------------------------------------------------------------------------+
-| Gossip encryption uses AES-256 by default, and this value isn’t | - System Config path: **Environment > High Availability**                                    |
-| configurable by design.                                         | - ``config.json`` setting: ``".ClusterSettings.EnableExperimentalGossipEncryption: false”,`` |
+| Gossip encryption uses AES-256 by default, and this value isn't | - System Config path: **Environment > High Availability**                                    |
+| configurable by design.                                         | - ``config.json`` setting: ``".ClusterSettings.EnableExperimentalGossipEncryption: false",`` |
 |                                                                 | - Environment variable: ``MM_CLUSTERSETTINGS_ENABLEEXPERIMENTALGOSSIPENCRYPTION``            |
+|                                                                 |                                                                                              |
+| Starting from Mattermost v10.11:                               |                                                                                              |
+| - **true**: **(Default for new deployments)**                   |                                                                                              |
+|   All communication through the cluster using the gossip        |                                                                                              |
+|   protocol will be encrypted.                                   |                                                                                              |
+| - **false**: Existing deployments maintain their current        |                                                                                              |
+|   configuration. All communication using gossip protocol        |                                                                                              |
+|   remains unencrypted.                                         |                                                                                              |
+|                                                                 |                                                                                              |
+| Prior to Mattermost v10.11:                                    |                                                                                              |
 | - **true**: **(Default for Cloud deployments)**                 |                                                                                              |
 |   All communication through the cluster using the gossip        |                                                                                              |
 |   protocol will be encrypted.                                   |                                                                                              |

--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -2774,8 +2774,8 @@ Use IP address
 .. config:setting:: enable-gossip-encryption
   :displayname: Enable gossip encryption (High Availability)
   :systemconsole: Environment > High Availability
-  :configjson: .ClusterSettings.UseExperimentalGossip
-  :environment: MM_CLUSTERSETTINGS_USEEXPERIMENTALGOSSIP
+  :configjson: .ClusterSettings.EnableGossipEncryption
+  :environment: MM_CLUSTERSETTINGS_ENABLEGOSSIPENCRYPTION
 
   - **true**: **(Default)** The server attempts to communicate via the gossip protocol over the gossip port specified.
   - **false**: The server attempts to communicate over the streaming port.
@@ -2783,32 +2783,21 @@ Use IP address
 Enable gossip encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-----------------------------------------------------------------+----------------------------------------------------------------------------------------------+
-| Gossip encryption uses AES-256 by default, and this value isn't | - System Config path: **Environment > High Availability**                                    |
-| configurable by design.                                         | - ``config.json`` setting: ``".ClusterSettings.EnableExperimentalGossipEncryption: false",`` |
-|                                                                 | - Environment variable: ``MM_CLUSTERSETTINGS_ENABLEEXPERIMENTALGOSSIPENCRYPTION``            |
-|                                                                 |                                                                                              |
-| Starting from Mattermost v10.11:                               |                                                                                              |
-| - **true**: **(Default for new deployments)**                   |                                                                                              |
-|   All communication through the cluster using the gossip        |                                                                                              |
-|   protocol will be encrypted.                                   |                                                                                              |
-| - **false**: Existing deployments maintain their current        |                                                                                              |
-|   configuration. All communication using gossip protocol        |                                                                                              |
-|   remains unencrypted.                                         |                                                                                              |
-|                                                                 |                                                                                              |
-| Prior to Mattermost v10.11:                                    |                                                                                              |
-| - **true**: **(Default for Cloud deployments)**                 |                                                                                              |
-|   All communication through the cluster using the gossip        |                                                                                              |
-|   protocol will be encrypted.                                   |                                                                                              |
-| - **false**: **(Default for self-hosted deployments)**          |                                                                                              |
-|   All communication using gossip protocol remains unchanged.    |                                                                                              |
-|   protocol remains unencrypted.                                 |                                                                                              |
-+-----------------------------------------------------------------+----------------------------------------------------------------------------------------------+
++-----------------------------------------------------------------+----------------------------------------------------------------------------------+
+| Gossip encryption uses AES-256 by default, and this value isn't | - System Config path: **Environment > High Availability**                        |
+| configurable by design.                                         | - ``config.json`` setting: ``".ClusterSettings.EnableGossipEncryption: true",``  |
+|                                                                 | - Environment variable: ``MM_CLUSTERSETTINGS_ENABLEGOSSIPENCRYPTION``            |
+| - **true**: **(Default)** The server attempts to communicate    |                                                                                  |
+|   via the gossip protocol over the gossip port specified.       |                                                                                  |
+| - **false**: The server attempts to communicate over the        |                                                                                  |
+|   streaming port.                                               |                                                                                  |
++-----------------------------------------------------------------+----------------------------------------------------------------------------------+
 
 .. note::
 
   - The Gossip protocol is based on principles outlined in the `SWIM protocol developed by researchers at Cornell University <https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf>`_. The gossip protocol is a communication mechanism in distributed systems where nodes randomly exchange information to ensure data consistency across the network. It is decentralized, scalable, and fault-tolerant, making it ideal for systems with numerous nodes. Information is spread in a manner similar to social gossip, with nodes periodically "gossiping" updates to random peers until the network converges to a consistent state. Widely used in distributed databases, blockchain networks, and peer-to-peer systems, the protocol is simple to implement and resilient to node failures. However, it can suffer from redundancy and propagation delays in large networks.
   - Alternatively, you can manually set the ``ClusterEncryptionKey`` row value in the **Systems** table. A key is a byte array converted to base64. Set this value to either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 respectively. 
+  - From Mattermost v10.11, gossip encryption is enabled by default for all new deployments. For existing deployments, all communication using the gossip protocol remains unencrypted unless you manually enable encryption. Prior to v10.11, gossip encryption is enabled by default for Cloud deployments and disabled by default for self-hosted deployments.
 
 .. config:setting:: enable-gossip-compression
   :displayname: Enable gossip compression (High Availability)

--- a/source/deploy/encryption-options.rst
+++ b/source/deploy/encryption-options.rst
@@ -21,10 +21,12 @@ Connections to calls are secured with a combination of:
   - DTLS v1.2 (mandatory): Used for initial key exchange. Supports ``TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`` and ``TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`` algorithms.
   - SRTP (mandatory): Used to encrypt all media packets (i.e. those containing voice or screen share). Supports ``AEAD_AES_128_GCM`` and ``AES128_CM_HMAC_SHA1_80`` algorithms.
 
-Gossip encryption (experimental)
---------------------------------
+Gossip encryption 
+------------------
 
 In a High Availability mode, Mattermost supports encryption of cluster data in-transit when using the gossip protocol, which is based on principles outlined in the `SWIM protocol developed by researchers at Cornell University <https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf>`_. The gossip protocol is a communication mechanism in distributed systems where nodes randomly exchange information to ensure data consistency across the network. It is decentralized, scalable, and fault-tolerant, making it ideal for systems with numerous nodes. Information is spread in a manner similar to social gossip, with nodes periodically "gossiping" updates to random peers until the network converges to a consistent state. Widely used in distributed databases, blockchain networks, and peer-to-peer systems, the protocol is simple to implement and resilient to node failures. However, it can suffer from redundancy and propagation delays in large networks.
+
+Starting from Mattermost v10.11, gossip encryption is enabled by default for new deployments while existing deployments maintain their current configuration.
 
 The encryption uses AES-256 by default, and it is not configurable. However, it is possible to manually set the value in the ``Systems`` table for the ``ClusterEncryptionKey`` row. A key is a byte array converted to base64. It can be set to a length of 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 respectively.
 

--- a/source/deploy/encryption-options.rst
+++ b/source/deploy/encryption-options.rst
@@ -26,7 +26,7 @@ Gossip encryption
 
 In a High Availability mode, Mattermost supports encryption of cluster data in-transit when using the gossip protocol, which is based on principles outlined in the `SWIM protocol developed by researchers at Cornell University <https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf>`_. The gossip protocol is a communication mechanism in distributed systems where nodes randomly exchange information to ensure data consistency across the network. It is decentralized, scalable, and fault-tolerant, making it ideal for systems with numerous nodes. Information is spread in a manner similar to social gossip, with nodes periodically "gossiping" updates to random peers until the network converges to a consistent state. Widely used in distributed databases, blockchain networks, and peer-to-peer systems, the protocol is simple to implement and resilient to node failures. However, it can suffer from redundancy and propagation delays in large networks.
 
-Starting from Mattermost v10.11, gossip encryption is enabled by default for new deployments while existing deployments maintain their current configuration.
+Starting from Mattermost v10.11, :ref:`gossip encryption <configure/environment-configuration-settings:enable gossip encryption>` is enabled by default for new deployments while existing deployments maintain their current configuration.
 
 The encryption uses AES-256 by default, and it is not configurable. However, it is possible to manually set the value in the ``Systems`` table for the ``ClusterEncryptionKey`` row. A key is a byte array converted to base64. It can be set to a length of 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256 respectively.
 


### PR DESCRIPTION
Updates Mattermost Product Documentation to reflect Gossip encryption functionality transitioning to GA and being enabled by default for new deployments from Mattermost server v10.11 onward.

## Changes
- Remove "experimental" label from Gossip encryption documentation
- Update default behavior to enabled for new deployments starting v10.11
- Add version-specific notes clarifying behavior change
- Update configuration setting references

Closes #8210

Generated with [Claude Code](https://claude.ai/code)