### PR TITLE
Add configurable account deletion documentation for v10.11

### DIFF
--- a/source/collaborate/install-android-app.rst
+++ b/source/collaborate/install-android-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost Android mobile app
 =========================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your Android mobile device running Android 7.0 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ on your Android mobile device running Android 7.0 or later.
 
 1. On your device, visit the Play Store.
 2. Search for "Mattermost" and select **INSTALL** to download the app.

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost desktop app
 ==================================
 
-Download and install the Mattermost desktop app from the App Store (macOS), Microsoft Store (Windows), or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
+Download and install the Mattermost desktop app `for macOS from the App Store <https://apps.apple.com/us/app/mattermost-desktop/id1614666244?mt=12>`_, `for Windows from the Microsoft Store <https://apps.microsoft.com/detail/xp8br8mh3lpklt?hl=en-US&gl=US>`_, or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
 
 We strongly recommend installing the desktop app on a local drive. Network shares aren't supported. 
 

--- a/source/collaborate/install-ios-app.rst
+++ b/source/collaborate/install-ios-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost iOS mobile app
 =====================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your iOS mobile device running iOS 12.1 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://apps.apple.com/us/app/mattermost/id1257222717>`_ on your iOS mobile device running iOS 12.1 or later.
 
 1. On your device, visit the App Store. 
 2. Search for "Mattermost" and select **GET** to download the app.

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -228,6 +228,34 @@ Enable account deactivation
 | This feature's ``config.json`` setting is ``"EnableUserDeactivation": false`` with options ``true`` and ``false``. |
 +--------------------------------------------------------------------------------------------------------------------+
 
+.. config:setting:: enable-account-deletion
+  :displayname: Enable account deletion (Experimental)
+  :systemconsole: Experimental > Features
+  :configjson: EnableUserDeletion
+  :environment: N/A
+
+  - **true**: Ability for users to permanently delete their own account from **Settings > Advanced** is enabled.
+  - **false**: **(Default)** Ability for users to permanently delete their own account is disabled.
+
+Enable account deletion
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**True**: Ability for users to permanently delete their own account from **Settings > Advanced > Delete Account**. When a user deletes their account, all their personal data, messages, and file uploads are permanently removed and cannot be recovered. Available only when authentication is set to use email/password. Not available when authentication uses SAML or AD/LDAP.
+
+**False**: Ability for users to permanently delete their own account is disabled.
+
+.. warning::
+
+  Account deletion is permanent and irreversible. Once deleted, all user data including messages, files, and account information cannot be recovered. This action will also remove the user from all teams and channels.
+
+.. note::
+
+  This feature is available in Mattermost Server v10.11 and later.
+
++------------------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"EnableUserDeletion": false`` with options ``true`` and ``false``. |
++------------------------------------------------------------------------------------------------------------------+
+
 .. config:setting:: enable-automatic-replies
   :displayname: Enable automatic replies
   :systemconsole: Experimental > Features

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -228,27 +228,6 @@ Enable account deactivation
 | This feature's ``config.json`` setting is ``"EnableUserDeactivation": false`` with options ``true`` and ``false``. |
 +--------------------------------------------------------------------------------------------------------------------+
 
-.. config:setting:: delete-account-link
-  :displayname: Delete account link
-  :systemconsole: Site Configuration > Users and Teams
-  :configjson: DeleteAccountLink
-  :environment: N/A
-
-Delete account link
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Define the URL for a Delete Account link that users can access by going to their profile and selecting **Security > Delete Your Account**. Leave this field blank to hide the the abiltiy for users to delete their account. 
-
-.. important::
-
-  - This feature is available from Mattermost v10.11.
-  - When a user deletes their account, all their personal data, messages, and file uploads are permanently removed and cannot be recovered. This action will also remove the user from all teams and channels they're a member of.
-  - Available only when authentication is set to use email/password. Not available when authentication uses SAML or AD/LDAP.
-
-+-----------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"ServiceSettings.DeleteAccountLink": ""`` with string input.  |
-+-----------------------------------------------------------------------------------------------------------+
-
 .. config:setting:: enable-automatic-replies
   :displayname: Enable automatic replies
   :systemconsole: Experimental > Features

--- a/source/configure/experimental-configuration-settings.rst
+++ b/source/configure/experimental-configuration-settings.rst
@@ -228,33 +228,26 @@ Enable account deactivation
 | This feature's ``config.json`` setting is ``"EnableUserDeactivation": false`` with options ``true`` and ``false``. |
 +--------------------------------------------------------------------------------------------------------------------+
 
-.. config:setting:: enable-account-deletion
-  :displayname: Enable account deletion (Experimental)
-  :systemconsole: Experimental > Features
-  :configjson: EnableUserDeletion
+.. config:setting:: delete-account-link
+  :displayname: Delete account link
+  :systemconsole: Site Configuration > Users and Teams
+  :configjson: DeleteAccountLink
   :environment: N/A
 
-  - **true**: Ability for users to permanently delete their own account from **Settings > Advanced** is enabled.
-  - **false**: **(Default)** Ability for users to permanently delete their own account is disabled.
-
-Enable account deletion
+Delete account link
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-**True**: Ability for users to permanently delete their own account from **Settings > Advanced > Delete Account**. When a user deletes their account, all their personal data, messages, and file uploads are permanently removed and cannot be recovered. Available only when authentication is set to use email/password. Not available when authentication uses SAML or AD/LDAP.
+Define the URL for a Delete Account link that users can access by going to their profile and selecting **Security > Delete Your Account**. Leave this field blank to hide the the abiltiy for users to delete their account. 
 
-**False**: Ability for users to permanently delete their own account is disabled.
+.. important::
 
-.. warning::
+  - This feature is available from Mattermost v10.11.
+  - When a user deletes their account, all their personal data, messages, and file uploads are permanently removed and cannot be recovered. This action will also remove the user from all teams and channels they're a member of.
+  - Available only when authentication is set to use email/password. Not available when authentication uses SAML or AD/LDAP.
 
-  Account deletion is permanent and irreversible. Once deleted, all user data including messages, files, and account information cannot be recovered. This action will also remove the user from all teams and channels.
-
-.. note::
-
-  This feature is available in Mattermost Server v10.11 and later.
-
-+------------------------------------------------------------------------------------------------------------------+
-| This feature's ``config.json`` setting is ``"EnableUserDeletion": false`` with options ``true`` and ``false``. |
-+------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ServiceSettings.DeleteAccountLink": ""`` with string input.  |
++-----------------------------------------------------------------------------------------------------------+
 
 .. config:setting:: enable-automatic-replies
   :displayname: Enable automatic replies

--- a/source/configure/user-management-configuration-settings.rst
+++ b/source/configure/user-management-configuration-settings.rst
@@ -97,6 +97,12 @@ From Mattermost v9.6, Mattermost Enterprise and Professional customers can expor
 2. `Filter <#filter-user-searches>`__ the user data as needed.
 3. Select **Export** located in the top right corner of the System Console interface, and then select **Export data**. You'll receive the report in CSV format as a direct message in Mattermost.
 
+.. config:setting:: deactivate-users
+  :displayname: Deactivate users
+  :systemconsole: Site Configuration > Users and Teams
+  :configjson: N/A
+  :environment: N/A
+
 Deactivate users
 ~~~~~~~~~~~~~~~~~
 
@@ -104,54 +110,54 @@ To delete a user from your Mattermost deployment, you can deactivate the user's 
 
 .. note::
 
-  From Mattermost v10.10, when a user account is deactivated, the account's :ref:`availability <preferences/set-your-status-availability:set your availability>` is automatically set to offline.
-
-.. note::
-
-  LDAP-managed users must be deactivated through LDAP, and can't be deactivated using the System Console or the API.
+  - From Mattermost v10.10, when a user account is deactivated, the account's :ref:`availability <preferences/set-your-status-availability:set your availability>` is automatically set to offline.
+  - LDAP-managed users must be deactivated through LDAP, and can't be deactivated using the System Console or the API.
 
 1. Go to **System Console > User Management > Users** to access all user accounts.
 2. Select a **User** that you wish to activate or deactivate.
 3. If the selected user is currently active, you can find the **Deactivate** button in the **User Configuration** page.
-4. Select **Deactivate**, and confirm the deactivation.
+4. Select **Deactivate**, and confirm the deactivation. You can re-activate a deactivated user by selecting **Activate**.
 
 .. image:: ../images/deactivate-user.png
   :alt: Deactivate a user in Mattermost using the System Console.
 
-.. tip::
-
-  Re-activate a deactivated user by selecting **Activate**.
-
 What happens to deactivated user integrations?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. important::
+If you deactivate a Mattermost user who has integrations tied to their user account, consider the following consequences and recommendations based on the integration type:
 
-  If you deactivate a Mattermost user who has integrations tied to their user account, consider the following consequences and recommendations based on the integration type:
-
-  - **Slash commands** will continue to work after user deactivation. Consider deleting the existing slash command and creating a new slash command associated with a different user account to decouple sensitive token data from the deactivated user account. Alternatively, consider regenerating the token of the existing slash command. Check that the deactivated user doesn't have access to the slash command **Request URL** which is the callback URL to receive the HTTP POST or GET event request when the slash command is run.
-  - **Outgoing webhooks** will continue to work after user deactivation. Consider regenerating the webhook token and check that the deactivated user no longer has access to the callback URLs, as having access would result in the deactivating user receiving the outgoing webhooks.
-  - **Incoming webhooks** will continue to work after user deactivation. Because the `URL produced <https://developers.mattermost.com/integrate/webhooks/incoming/#create-an-incoming-webhook>`_ includes ``xxx-generatedkey-xxx``, anyone who has the URL can post messages to the Mattermost instance. We recommend removing the incoming webhook and creating a new one associated with a different user account. 
-  - **Bot accounts** won't continue to work after user deactivation when the :ref:`disable bot accounts when owner is deactivated <configure/integrations-configuration-settings:disable bot accounts when owner is deactivated>` is enabled. This configuration setting is enabled by default.
-  - **OAuth apps** won't continue to work after user deactivation, and associated tokens are deleted. Manual action is needed to keep these integrations running.
+- **Slash commands** will continue to work after user deactivation. Consider deleting the existing slash command and creating a new slash command associated with a different user account to decouple sensitive token data from the deactivated user account. Alternatively, consider regenerating the token of the existing slash command. Check that the deactivated user doesn't have access to the slash command **Request URL** which is the callback URL to receive the HTTP POST or GET event request when the slash command is run.
+- **Outgoing webhooks** will continue to work after user deactivation. Consider regenerating the webhook token and check that the deactivated user no longer has access to the callback URLs, as having access would result in the deactivating user receiving the outgoing webhooks.
+- **Incoming webhooks** will continue to work after user deactivation. Because the `URL produced <https://developers.mattermost.com/integrate/webhooks/incoming/#create-an-incoming-webhook>`_ includes ``xxx-generatedkey-xxx``, anyone who has the URL can post messages to the Mattermost instance. We recommend removing the incoming webhook and creating a new one associated with a different user account. 
+- **Bot accounts** won't continue to work after user deactivation when the :ref:`disable bot accounts when owner is deactivated <configure/integrations-configuration-settings:disable bot accounts when owner is deactivated>` is enabled. This configuration setting is enabled by default.
+- **OAuth apps** won't continue to work after user deactivation, and associated tokens are deleted. Manual action is needed to keep these integrations running.
 
 Delete users
 ~~~~~~~~~~~~~
 
-*Available in Mattermost Server v10.11 and later.*
+*Available from Mattermost Server v10.11*
 
-When the :ref:`account deletion feature <configure/experimental-configuration-settings:enable account deletion>` is enabled, users can permanently delete their own accounts through **Settings > Advanced > Delete Account**. As a system administrator, you should understand the implications of account deletion:
+When using email/password for authentication, you can enable users to permanently delete their own accounts, or you can delete user accounts as a system administrator.
 
-.. important::
+.. config:setting:: delete-users
+  :displayname: Delete users
+  :systemconsole: Site Configuration > Users and Teams
+  :configjson: DeleteAccountLink
+  :environment: N/A
 
-  - **Account deletion is permanent and cannot be undone.** Unlike deactivation, deleted accounts cannot be reactivated.
-  - The user's profile information and account data are permanently removed from the system.
-  - The user's message history and file uploads remain in channels but display as "Deleted User" instead of showing the user's name.
-  - The user is automatically removed from all teams and channels.
-  - Any integrations tied to the deleted user account will stop working (similar to deactivation consequences listed above).
+Enable account deletion
+^^^^^^^^^^^^^^^^^^^^^^^
 
-What data is removed when a user deletes their account?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Define the URL for a **Delete Account Link** that users can access by going to their profile and selecting **Security > Delete Your Account**. Leave this field blank to hide the abiltiy for users to delete their account. 
+
++-----------------------------------------------------------------------------------------------------------+
+| This feature's ``config.json`` setting is ``"ServiceSettings.DeleteAccountLink": ""`` with string input.  |
++-----------------------------------------------------------------------------------------------------------+
+
+When a user deletes their account, deleted accounts cannot be reactivated, and the user is automatically removed from all teams and channels.
+
+What data is removed?
+^^^^^^^^^^^^^^^^^^^^^
 
 When a user deletes their account, the following data is permanently removed:
 
@@ -162,19 +168,15 @@ When a user deletes their account, the following data is permanently removed:
 - Team and channel memberships
 - User session data
 
-What data is retained when a user deletes their account?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+What data is retained?
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The following data remains in the system after account deletion:
 
-- Message content in public and private channels (displayed as "Deleted User")
+- Message content in public and private channels (displayed as **Deleted User**)
 - File uploads and attachments shared in channels
 - Channel and team audit logs that reference the user's actions
 - Integration logs and webhook history
-
-.. note::
-
-  This feature is only available when users authenticate with email/password. Users who authenticate via SAML or AD/LDAP cannot delete their own accounts through the user interface and must contact system administrators for account deletion.
 
 Manage user's roles
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/configure/user-management-configuration-settings.rst
+++ b/source/configure/user-management-configuration-settings.rst
@@ -135,6 +135,47 @@ What happens to deactivated user integrations?
   - **Bot accounts** won't continue to work after user deactivation when the :ref:`disable bot accounts when owner is deactivated <configure/integrations-configuration-settings:disable bot accounts when owner is deactivated>` is enabled. This configuration setting is enabled by default.
   - **OAuth apps** won't continue to work after user deactivation, and associated tokens are deleted. Manual action is needed to keep these integrations running.
 
+Delete users
+~~~~~~~~~~~~~
+
+*Available in Mattermost Server v10.11 and later.*
+
+When the :ref:`account deletion feature <configure/experimental-configuration-settings:enable account deletion>` is enabled, users can permanently delete their own accounts through **Settings > Advanced > Delete Account**. As a system administrator, you should understand the implications of account deletion:
+
+.. important::
+
+  - **Account deletion is permanent and cannot be undone.** Unlike deactivation, deleted accounts cannot be reactivated.
+  - The user's profile information and account data are permanently removed from the system.
+  - The user's message history and file uploads remain in channels but display as "Deleted User" instead of showing the user's name.
+  - The user is automatically removed from all teams and channels.
+  - Any integrations tied to the deleted user account will stop working (similar to deactivation consequences listed above).
+
+What data is removed when a user deletes their account?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a user deletes their account, the following data is permanently removed:
+
+- User profile information (name, email, username)
+- User preferences and settings
+- User authentication credentials
+- Direct message channel memberships
+- Team and channel memberships
+- User session data
+
+What data is retained when a user deletes their account?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following data remains in the system after account deletion:
+
+- Message content in public and private channels (displayed as "Deleted User")
+- File uploads and attachments shared in channels
+- Channel and team audit logs that reference the user's actions
+- Integration logs and webhook history
+
+.. note::
+
+  This feature is only available when users authenticate with email/password. Users who authenticate via SAML or AD/LDAP cannot delete their own accounts through the user interface and must contact system administrators for account deletion.
+
 Manage user's roles
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/preferences/manage-advanced-options.rst
+++ b/source/preferences/manage-advanced-options.rst
@@ -74,9 +74,9 @@ You can deactivate your account if you access Mattermost using an email address 
 Delete account
 --------------
 
-*Available in Mattermost Server v10.11 and later.*
+*Available from Mattermost Server v10.11.*
 
-You can permanently delete your account if you access Mattermost using an email address and password, and when your system admin has :ref:`enabled your ability to do so <configure/experimental-configuration-settings:enable account deletion>`. Deleting your account permanently removes your user account and profile information from Mattermost. This action cannot be undone.
+You can permanently delete your account if you access Mattermost using an email address and password, and when your system admin has :ref:`enabled your ability to do so <configure/user-management-configuration-settings:delete users>`. Deleting your account permanently removes your user account and profile information from Mattermost. This action cannot be undone.
 
 .. important::
 

--- a/source/preferences/manage-advanced-options.rst
+++ b/source/preferences/manage-advanced-options.rst
@@ -71,6 +71,28 @@ You can deactivate your account if you access Mattermost using an email address 
 
     This option isn't applicable to the mobile app.
 
+Delete account
+--------------
+
+*Available in Mattermost Server v10.11 and later.*
+
+You can permanently delete your account if you access Mattermost using an email address and password, and when your system admin has :ref:`enabled your ability to do so <configure/experimental-configuration-settings:enable account deletion>`. Deleting your account permanently removes your user account and profile information from Mattermost. This action cannot be undone.
+
+.. important::
+
+    - **Account deletion is permanent and cannot be undone.** Once deleted, your account and profile data cannot be recovered.
+    - Your message history and file uploads will remain in channels but will show as "Deleted User" instead of your name.
+    - If you access Mattermost using another authentication method, such as AD/LDAP or SAML, this option may not be available. Contact your system admin for account deletion.
+    - Consider :ref:`deactivating your account <preferences/manage-advanced-options:deactivate account>` instead if you might want to reactivate it in the future.
+
+.. tab:: Web/Desktop
+
+    Select **Delete Account** to permanently delete your Mattermost user account. You'll be asked to confirm this action before proceeding.
+
+.. tab:: Mobile
+
+    This option isn't applicable to the mobile app.
+
 Performance debugging
 ---------------------
 


### PR DESCRIPTION
Updates Mattermost Product Documentation to reflect the configurable account deletion feature introduced in server v10.11 onward.

## Changes:
- Add new "Delete account" section to user preferences with clear warnings
- Add EnableUserDeletion configuration setting to experimental settings
- Add comprehensive admin guide section for account deletion
- Document data retention vs removal policies
- Include authentication method restrictions

Closes #8212

Generated with [Claude Code](https://claude.ai/code)