### PR TITLE
Add mobile security settings documentation for v10.11

### DIFF
--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -1808,6 +1808,50 @@ Allow file downloads on mobile
 |                                                                                                                | - Environment variable: ``MM_FILESETTINGS_ENABLEMOBILEDOWNLOAD``                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
 
+.. include:: ../_static/badges/ent-adv-cloud-selfhosted.rst
+  :start-after: :nosearch:
+
+*Available in Mattermost server v10.11 and later.*
+
+.. config:setting:: mobile-enable-secure-file-preview
+  :displayname: Enable secure file preview on mobile (File sharing)
+  :systemconsole: Site Configuration > File sharing and downloads
+  :configjson: .FileSettings.MobileEnableSecureFilePreview
+  :environment: MM_FILESETTINGS_MOBILEENABLESECUREFILEPREVIEW
+
+  - **true**: Prevents file downloads, previews, and sharing for most file types, even if the setting for Allow file downloads on mobile is enabled. Allows in-app previews for PDFs, videos, and images only. Files are stored temporarily in the app's cache and cannot be exported or shared.
+  - **false**: **(Default)** Secure file preview mode is disabled.
+
+Enable secure file preview on mobile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
+| - **true**: Prevents file downloads, previews, and sharing for most file types, even if the setting for Allow file downloads on mobile is enabled. Allows in-app previews for PDFs,  | - System Config path: **Site Configuration > File sharing and downloads**                         |
+| videos, and images only. Files are stored temporarily in the app's cache and cannot be exported or shared.                                                                              | - ``config.json`` setting: ``FileSettings`` > ``MobileEnableSecureFilePreview`` > ``false``      |
+| - **false**: **(Default)** Secure file preview mode is disabled.                                                                                                                        | - Environment variable: ``MM_FILESETTINGS_MOBILEENABLESECUREFILEPREVIEW``                        |
+|                                                                                                                                                                                          |                                                                                                   |
+| This setting improves an organization's mobile security posture by restricting file access while still allowing essential file viewing capabilities.                                     |                                                                                                   |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
+
+.. config:setting:: mobile-allow-pdf-link-navigation
+  :displayname: Allow PDF link navigation on mobile (File sharing)
+  :systemconsole: Site Configuration > File sharing and downloads
+  :configjson: .FileSettings.MobileAllowPdfLinkNavigation
+  :environment: MM_FILESETTINGS_MOBILEALLOWPDFLINKNAVIGATION
+
+  - **true**: **(Default)** Enables tapping links inside PDFs when Secure File Preview Mode is active. Links will open in the device browser or supported app.
+  - **false**: Disables link navigation in PDFs when Secure File Preview Mode is active.
+
+Allow PDF link navigation on mobile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| - **true**: **(Default)** Enables tapping links inside PDFs when Secure File Preview Mode is active. Links will open in the device browser or supported app. | - System Config path: **Site Configuration > File sharing and downloads**                     |
+| - **false**: Disables link navigation in PDFs when Secure File Preview Mode is active.                                                                     | - ``config.json`` setting: ``FileSettings`` > ``MobileAllowPdfLinkNavigation`` > ``true``    |
+|                                                                                                                                                             | - Environment variable: ``MM_FILESETTINGS_MOBILEALLOWPDFLINKNAVIGATION``                     |
+| This setting has no effect when Secure File Preview Mode is disabled.                                                                                      |                                                                                               |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
+
 ----
 
 Public Links

--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -1808,9 +1808,6 @@ Allow file downloads on mobile
 |                                                                                                                | - Environment variable: ``MM_FILESETTINGS_ENABLEMOBILEDOWNLOAD``                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
 
-.. include:: ../../_static/badges/ent-adv-cloud-selfhosted.rst
-  :start-after: :nosearch:
-
 .. config:setting:: mobile-enable-secure-file-preview
   :displayname: Enable secure file preview on mobile (File sharing)
   :systemconsole: Site Configuration > File sharing and downloads
@@ -1822,6 +1819,9 @@ Allow file downloads on mobile
 
 Enable secure file preview on mobile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../../_static/badges/ent-adv-cloud-selfhosted.rst
+  :start-after: :nosearch:
 
 This setting improves an organization's mobile security posture by restricting file access while still allowing essential file viewing capabilities. 
 
@@ -1845,6 +1845,9 @@ This setting improves an organization's mobile security posture by restricting f
 
 Allow PDF link navigation on mobile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../../_static/badges/ent-adv-cloud-selfhosted.rst
+  :start-after: :nosearch:
 
 +---------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
 | - **true**: **(Default)** Enables tapping links inside PDFs               | - System Config path: **Site Configuration > File sharing and downloads**                     |

--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -1808,10 +1808,8 @@ Allow file downloads on mobile
 |                                                                                                                | - Environment variable: ``MM_FILESETTINGS_ENABLEMOBILEDOWNLOAD``                    |
 +----------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
 
-.. include:: ../_static/badges/ent-adv-cloud-selfhosted.rst
+.. include:: ../../_static/badges/ent-adv-cloud-selfhosted.rst
   :start-after: :nosearch:
-
-*Available in Mattermost server v10.11 and later.*
 
 .. config:setting:: mobile-enable-secure-file-preview
   :displayname: Enable secure file preview on mobile (File sharing)
@@ -1819,19 +1817,22 @@ Allow file downloads on mobile
   :configjson: .FileSettings.MobileEnableSecureFilePreview
   :environment: MM_FILESETTINGS_MOBILEENABLESECUREFILEPREVIEW
 
-  - **true**: Prevents file downloads, previews, and sharing for most file types, even if the setting for Allow file downloads on mobile is enabled. Allows in-app previews for PDFs, videos, and images only. Files are stored temporarily in the app's cache and cannot be exported or shared.
+  - **true**: Prevents file downloads, previews, and sharing for most file types. Allows in-app previews for PDFs, videos, and images only. Files are stored temporarily in the app's cache and cannot be exported or shared.
   - **false**: **(Default)** Secure file preview mode is disabled.
 
 Enable secure file preview on mobile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
-| - **true**: Prevents file downloads, previews, and sharing for most file types, even if the setting for Allow file downloads on mobile is enabled. Allows in-app previews for PDFs,  | - System Config path: **Site Configuration > File sharing and downloads**                         |
-| videos, and images only. Files are stored temporarily in the app's cache and cannot be exported or shared.                                                                              | - ``config.json`` setting: ``FileSettings`` > ``MobileEnableSecureFilePreview`` > ``false``      |
-| - **false**: **(Default)** Secure file preview mode is disabled.                                                                                                                        | - Environment variable: ``MM_FILESETTINGS_MOBILEENABLESECUREFILEPREVIEW``                        |
-|                                                                                                                                                                                          |                                                                                                   |
-| This setting improves an organization's mobile security posture by restricting file access while still allowing essential file viewing capabilities.                                     |                                                                                                   |
-+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
+This setting improves an organization's mobile security posture by restricting file access while still allowing essential file viewing capabilities. 
+
++---------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
+| - **true**: Prevents file downloads, previews, and sharing for most file types,                                                       | - System Config path: **Site Configuration > File sharing and downloads**                         |
+|   even when the                                                                                                                       | - ``config.json`` setting: ``FileSettings`` > ``MobileEnableSecureFilePreview`` > ``false``       |
+|   :ref:`Allow file downloads on mobile <administration-guide/configure/site-configuration-settings:allow file downloads on mobile>`   | - Environment variable: ``MM_FILESETTINGS_MOBILEENABLESECUREFILEPREVIEW``                         |
+|   configuration setting is enabled. Allows in-app previews for PDFs,                                                                  |                                                                                                   |
+|   videos, and images only. Files are stored temporarily in the app's cache and cannot be exported or shared.                          |                                                                                                   |
+| - **false**: **(Default)** Secure file preview mode is disabled.                                                                      |                                                                                                   |
++---------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
 
 .. config:setting:: mobile-allow-pdf-link-navigation
   :displayname: Allow PDF link navigation on mobile (File sharing)
@@ -1845,12 +1846,17 @@ Enable secure file preview on mobile
 Allow PDF link navigation on mobile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
-| - **true**: **(Default)** Enables tapping links inside PDFs when Secure File Preview Mode is active. Links will open in the device browser or supported app. | - System Config path: **Site Configuration > File sharing and downloads**                     |
-| - **false**: Disables link navigation in PDFs when Secure File Preview Mode is active.                                                                     | - ``config.json`` setting: ``FileSettings`` > ``MobileAllowPdfLinkNavigation`` > ``true``    |
-|                                                                                                                                                             | - Environment variable: ``MM_FILESETTINGS_MOBILEALLOWPDFLINKNAVIGATION``                     |
-| This setting has no effect when Secure File Preview Mode is disabled.                                                                                      |                                                                                               |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| - **true**: **(Default)** Enables tapping links inside PDFs               | - System Config path: **Site Configuration > File sharing and downloads**                     |
+|   when Secure File Preview Mode is active. Links will open                | - ``config.json`` setting: ``FileSettings`` > ``MobileAllowPdfLinkNavigation`` > ``true``     |
+|   in the device browser or supported app.                                 | - Environment variable: ``MM_FILESETTINGS_MOBILEALLOWPDFLINKNAVIGATION``                      |
+| - **false**: Disables link navigation in PDFs                             |                                                                                               |
+|   when Secure File Preview Mode is active.                                |                                                                                               |
++---------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
+
+.. note::
+
+  This setting has no effect when the :ref:`Secure file preview on mobile <administration-guide/configure/site-configuration-settings:enable secure file preview on mobile>` configuration setting is disabled.
 
 ----
 

--- a/source/deployment-guide/mobile/mobile-security-features.rst
+++ b/source/deployment-guide/mobile/mobile-security-features.rst
@@ -46,6 +46,13 @@ See the :ref:`prevent screen capture configuration setting <administration-guide
 
   This feature prevents screen recording and screenshot capture on the mobile device where the Mattermost app is running. It cannot control or prevent recording from external devices, such as another phone or camera pointed at the screen. Mattermost provides these protections through mobile OS-level capabilities but cannot guarantee absolute prevention of visual data capture through other means.  
 
+Secure file previews
+---------------------
+
+Preventing file downloads protects sensitive information from being inadvertently or maliciously shared. This control is essential in ensuring that confidential documents and media remain within the secure confines of the app. By enabling in-app previews for supported file types and restricting downloads, Mattermost significantly reduces the risk of data leakage while maintaining essential file-viewing capabilities.
+
+See the :ref:`secure file preview <administration-guide/configure/site-configuration-settings:enable secure file preview on mobile>` and :ref:`managing PDF link navigation <administration-guide/configure/site-configuration-settings:allow pdf link navigation on mobile>` configuration settings documentation for details on enabling these features.
+
 Mobile data isolation
 ------------------------
 

--- a/source/security-guide/security/mobile-security.rst
+++ b/source/security-guide/security/mobile-security.rst
@@ -63,17 +63,15 @@ Environments with strict data loss prevention (DLP) policies or where sensitive 
 
 Disabling file uploads adds an additional layer of security by reducing the risk of malware or malicious files being introduced into the system, ensuring tighter control over sensitive corporate data, and preventing accidental leaks from unsecure mobile networks. 
 
-Similarly, by disabling downloads, Mattermost ensures that files cannot be saved locally on the device, reducing the risk of unauthorized access or data leakage. Learn more about :ref:`disabling mobile uploads <configure/site-configuration-settings:allow file downloads on mobile>` and :ref:`disabling mobile downloads <configure/site-configuration-settings:allow file uploads on mobile>` in the Mattermost mobile app.
+Similarly, by disabling downloads, Mattermost ensures that files cannot be saved locally on the device, reducing the risk of unauthorized access or data leakage. Learn more about :ref:`disabling mobile uploads <administration-guide/configure/site-configuration-settings:allow file downloads on mobile>` and :ref:`disabling mobile downloads <administration-guide/configure/site-configuration-settings:allow file uploads on mobile>` in the Mattermost mobile app.
 
 Secure file preview
 -------------------
 
-*Available in Mattermost server v10.11 and later.*
-
-For organizations requiring even stricter control over file access on mobile devices, Mattermost provides secure file preview capabilities. This advanced security feature allows administrators to prevent file downloads, previews, and sharing for most file types while still enabling in-app viewing of essential content such as PDFs, videos, and images.
+For organizations requiring even stricter control over file access on mobile devices, Mattermost provides secure file preview capabilities from Mattermost v10.11. This advanced security feature allows administrators to prevent file downloads, previews, and sharing for most file types while still enabling in-app viewing of essential content such as PDFs, videos, and images.
 
 When secure file preview is enabled, files are stored temporarily in the app's cache and cannot be exported or shared externally. This approach provides a balance between security and usability, ensuring that users can view necessary content without creating potential data leakage pathways.
 
 Additionally, administrators can control link navigation within PDF files when secure file preview mode is active, allowing links to open in the device browser or supported applications as needed.
 
-Learn more about :ref:`enabling secure file preview <configure/site-configuration-settings:enable secure file preview on mobile>` and :ref:`managing PDF link navigation <configure/site-configuration-settings:allow pdf link navigation on mobile>` in the Mattermost mobile app.
+Learn more about :ref:`enabling secure file preview <administration-guide/configure/site-configuration-settings:enable secure file preview on mobile>` and :ref:`managing PDF link navigation <administration-guide/configure/site-configuration-settings:allow pdf link navigation on mobile>` in the Mattermost mobile app.

--- a/source/security-guide/security/mobile-security.rst
+++ b/source/security-guide/security/mobile-security.rst
@@ -63,4 +63,17 @@ Environments with strict data loss prevention (DLP) policies or where sensitive 
 
 Disabling file uploads adds an additional layer of security by reducing the risk of malware or malicious files being introduced into the system, ensuring tighter control over sensitive corporate data, and preventing accidental leaks from unsecure mobile networks. 
 
-Similarly, by disabling downloads, Mattermost ensures that files cannot be saved locally on the device, reducing the risk of unauthorized access or data leakage. Learn more about :ref:`disabling mobile uploads <administration-guide/configure/site-configuration-settings:allow file downloads on mobile>` and :ref:`disabling mobile downloads <administration-guide/configure/site-configuration-settings:allow file uploads on mobile>` in the Mattermost mobile app.
+Similarly, by disabling downloads, Mattermost ensures that files cannot be saved locally on the device, reducing the risk of unauthorized access or data leakage. Learn more about :ref:`disabling mobile uploads <configure/site-configuration-settings:allow file downloads on mobile>` and :ref:`disabling mobile downloads <configure/site-configuration-settings:allow file uploads on mobile>` in the Mattermost mobile app.
+
+Secure file preview
+-------------------
+
+*Available in Mattermost server v10.11 and later.*
+
+For organizations requiring even stricter control over file access on mobile devices, Mattermost provides secure file preview capabilities. This advanced security feature allows administrators to prevent file downloads, previews, and sharing for most file types while still enabling in-app viewing of essential content such as PDFs, videos, and images.
+
+When secure file preview is enabled, files are stored temporarily in the app's cache and cannot be exported or shared externally. This approach provides a balance between security and usability, ensuring that users can view necessary content without creating potential data leakage pathways.
+
+Additionally, administrators can control link navigation within PDF files when secure file preview mode is active, allowing links to open in the device browser or supported applications as needed.
+
+Learn more about :ref:`enabling secure file preview <configure/site-configuration-settings:enable secure file preview on mobile>` and :ref:`managing PDF link navigation <configure/site-configuration-settings:allow pdf link navigation on mobile>` in the Mattermost mobile app.

--- a/source/security-guide/security/mobile-security.rst
+++ b/source/security-guide/security/mobile-security.rst
@@ -74,4 +74,4 @@ When secure file preview is enabled, files are stored temporarily in the app's c
 
 Additionally, administrators can control link navigation within PDF files when secure file preview mode is active, allowing links to open in the device browser or supported applications as needed.
 
-Learn more about :ref:`enabling secure file preview <administration-guide/configure/site-configuration-settings:enable secure file preview on mobile>` and :ref:`managing PDF link navigation <administration-guide/configure/site-configuration-settings:allow pdf link navigation on mobile>` in the Mattermost mobile app.
+Learn more about :ref:`enabling secure file preview on mobile <administration-guide/configure/site-configuration-settings:enable secure file preview on mobile>` and :ref:`allow PDF link navigation on mobile <administration-guide/configure/site-configuration-settings:allow pdf link navigation on mobile>` in the Mattermost mobile app.


### PR DESCRIPTION
Add documentation for two new Enterprise Advanced mobile security settings for v10.11+:

- MobileEnableSecureFilePreview: Prevents file downloads, previews, and sharing for most file types while allowing in-app previews for PDFs, videos, and images only
- MobileAllowPdfLinkNavigation: Enables tapping links inside PDFs when Secure File Preview Mode is active

Resolves #8213

Generated with [Claude Code](https://claude.ai/code)