### PR TITLE
mmctl: Add compliance export download cmd

### DIFF
--- a/source/collaborate/install-android-app.rst
+++ b/source/collaborate/install-android-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost Android mobile app
 =========================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your Android mobile device running Android 7.0 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ on your Android mobile device running Android 7.0 or later.
 
 1. On your device, visit the Play Store.
 2. Search for "Mattermost" and select **INSTALL** to download the app.

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost desktop app
 ==================================
 
-Download and install the Mattermost desktop app from the App Store (macOS), Microsoft Store (Windows), or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
+Download and install the Mattermost desktop app `for macOS from the App Store <https://apps.apple.com/us/app/mattermost-desktop/id1614666244?mt=12>`_, `for Windows from the Microsoft Store <https://apps.microsoft.com/detail/xp8br8mh3lpklt?hl=en-US&gl=US>`_, or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
 
 We strongly recommend installing the desktop app on a local drive. Network shares aren't supported. 
 

--- a/source/collaborate/install-ios-app.rst
+++ b/source/collaborate/install-ios-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost iOS mobile app
 =====================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your iOS mobile device running iOS 12.1 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://apps.apple.com/us/app/mattermost/id1257222717>`_ on your iOS mobile device running iOS 12.1 or later.
 
 1. On your device, visit the App Store. 
 2. Search for "Mattermost" and select **GET** to download the app.

--- a/source/comply/compliance-export.rst
+++ b/source/comply/compliance-export.rst
@@ -189,6 +189,11 @@ How do I export past history?
 
 Run the ``export`` :doc:`command line tool <../manage/command-line-tools>`. You can specify an ``exportFrom`` option to export data from a specified timestamp. All posts that were made after this timestamp will be exported.
 
+How do I download compliance export jobs using mmctl?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+From Mattermost Server v10.11, system administrators can download compliance export jobs using the :ref:`mmctl compliance_export download <manage/mmctl-command-line-tool:mmctl compliance_export download>` command. This provides a command-line interface for retrieving completed compliance export jobs by job ID.
+
 What happens if I export data manually?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -30,6 +30,7 @@ mmctl commands
 - `mmctl bot`_ - Bot Management
 - `mmctl channel`_ - Channel Management
 - `mmctl command`_ - Command Management
+- `mmctl compliance_export`_ - Compliance Export Management
 - `mmctl completion`_ - Generate autocompletion scripts for bash and zsh
 - `mmctl config`_ - Configuration Management
 - `mmctl docs`_ - Generate mmctl documentation
@@ -1705,6 +1706,63 @@ Show a custom slash command. Commands can be specified by command ID. Returns co
 .. code-block:: sh
 
    -h, --help   help for show
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
+   --disable-pager                disables paged output
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+   --json                         the output format will be in json format
+   --local                        allows communicating with the server through a unix socket
+   --quiet                        prevent mmctl to generate output for the commands
+   --strict                       will only run commands if the mmctl version matches the server one
+   --suppress-warnings            disables printing warning messages
+
+mmctl compliance_export
+------------------------
+
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
+  :start-after: :nosearch:
+
+Manage compliance export jobs.
+
+   Child Commands
+      -  `mmctl compliance_export download`_ - Download compliance export job
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for compliance_export
+
+mmctl compliance_export download
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Description**
+
+Download a compliance export job by job ID. Available from Mattermost Server v10.11.
+
+**Format**
+
+.. code-block:: sh
+
+  mmctl compliance_export download [jobID] [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   # Download a compliance export job by job ID
+   $ mmctl compliance_export download j1k9s8d7f6g5h4j3k2l1m9n8
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for download
 
 **Options inherited from parent commands**
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -1724,8 +1724,6 @@ Show a custom slash command. Commands can be specified by command ID. Returns co
 mmctl compliance_export
 ------------------------
 
-.. include:: ../_static/badges/ent-cloud-selfhosted.rst
-  :start-after: :nosearch:
 
 Manage compliance export jobs.
 

--- a/source/manage/mmctl-command-line-tool.rst
+++ b/source/manage/mmctl-command-line-tool.rst
@@ -1743,7 +1743,7 @@ mmctl compliance_export download
 
 **Description**
 
-Download a compliance export job by job ID. Available from Mattermost Server v10.11.
+Download a compliance export job by job ID.
 
 **Format**
 


### PR DESCRIPTION
Add documentation for the new mmctl compliance_export download command available from Mattermost Server v10.11.

## Changes
- Add new mmctl compliance_export command with download sub-command to mmctl documentation
- Update compliance export documentation with new FAQ section for mmctl download capability
- Cross-referenced documentation between mmctl and compliance export sections

Addresses compliance export download functionality from https://github.com/mattermost/mattermost/pull/30576

Closes #8216

Generated with [Claude Code](https://claude.ai/code)