### PR TITLE
Add Playbooks mobile read-only support documentation for v10.11+

### DIFF
--- a/source/collaborate/install-android-app.rst
+++ b/source/collaborate/install-android-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost Android mobile app
 =========================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your Android mobile device running Android 7.0 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ on your Android mobile device running Android 7.0 or later.
 
 1. On your device, visit the Play Store.
 2. Search for "Mattermost" and select **INSTALL** to download the app.

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost desktop app
 ==================================
 
-Download and install the Mattermost desktop app from the App Store (macOS), Microsoft Store (Windows), or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
+Download and install the Mattermost desktop app `for macOS from the App Store <https://apps.apple.com/us/app/mattermost-desktop/id1614666244?mt=12>`_, `for Windows from the Microsoft Store <https://apps.microsoft.com/detail/xp8br8mh3lpklt?hl=en-US&gl=US>`_, or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
 
 We strongly recommend installing the desktop app on a local drive. Network shares aren't supported. 
 

--- a/source/collaborate/install-ios-app.rst
+++ b/source/collaborate/install-ios-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost iOS mobile app
 =====================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your iOS mobile device running iOS 12.1 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://apps.apple.com/us/app/mattermost/id1257222717>`_ on your iOS mobile device running iOS 12.1 or later.
 
 1. On your device, visit the App Store. 
 2. Search for "Mattermost" and select **GET** to download the app.

--- a/source/repeatable-processes/interact-with-playbooks.rst
+++ b/source/repeatable-processes/interact-with-playbooks.rst
@@ -24,6 +24,21 @@ Available slash commands include:
 - ``/playbook settings digest [on/off]`` - Turn daily digest on/off.
 - ``/playbook settings weekly-digest [on/off]`` - Turn weekly digest on/off.
 
+Mobile read-only support
+------------------------
+
+.. include:: ../_static/badges/ent-cloud-selfhosted.rst
+  :start-after: :nosearch:
+
+Starting with Mattermost server v10.11, users can view playbook runs in read-only mode on mobile devices. This enables mobile users to:
+
+- View active and completed playbook run details
+- Review run progress and task completion status  
+- Access run timelines and retrospectives
+- Monitor key metrics and status updates
+
+Mobile users can participate in playbook run channels for discussion and collaboration, but playbook run management actions (such as starting runs, editing tasks, or updating run details) remain available only on desktop and web clients.
+
 API documentation
 -----------------
 

--- a/source/repeatable-processes/work-with-runs.rst
+++ b/source/repeatable-processes/work-with-runs.rst
@@ -19,9 +19,13 @@ You don't have to be in a run's channel to follow the run. You can:
 View run details
 ----------------
 
-When you’re in a channel with an active run, select the **Toggle Run Details** icon in the channel header to open the right-hand pane to view the run details. Information such as run name and description can be edited in-line, and the checklists can be collapsed and filtered based on their status.
+When you're in a channel with an active run, select the **Toggle Run Details** icon in the channel header to open the right-hand pane to view the run details. Information such as run name and description can be edited in-line, and the checklists can be collapsed and filtered based on their status.
 
 Some run actions can be edited while the run is in progress. This increases visibility into the run's progress and can improve accountability.
+
+.. note::
+
+  Starting with Mattermost server v10.11, mobile users can view playbook run details in read-only mode. This includes accessing run timelines, task completion status, and retrospectives. However, run management actions (such as editing tasks or updating run details) are only available on desktop and web clients.
 
 Runs and channel behavior
 -------------------------


### PR DESCRIPTION
Add mobile read-only support documentation for Mattermost Playbooks starting from server v10.11.

## Summary
This PR updates the Playbooks documentation to reflect the new mobile read-only support introduced in Mattermost server v10.11. Mobile users can now view playbook runs, monitor progress, and access retrospectives while management actions remain on desktop/web.

## Changes
- Added "Mobile read-only support" section to interact-with-playbooks.rst
- Enhanced "View run details" section in work-with-runs.rst with mobile viewing note
- Documents v10.11+ server requirement and read-only limitations

## Test plan
- [ ] Review documentation formatting and RST syntax
- [ ] Verify content accuracy with product team
- [ ] Ensure consistency with existing mobile documentation patterns

Closes #8219

Generated with [Claude Code](https://claude.ai/code)