### PR TITLE
Secure Files and preview PDF inline

### DIFF
--- a/source/collaborate/install-android-app.rst
+++ b/source/collaborate/install-android-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost Android mobile app
 =========================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your Android mobile device running Android 7.0 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ on your Android mobile device running Android 7.0 or later.
 
 1. On your device, visit the Play Store.
 2. Search for "Mattermost" and select **INSTALL** to download the app.

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost desktop app
 ==================================
 
-Download and install the Mattermost desktop app from the App Store (macOS), Microsoft Store (Windows), or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
+Download and install the Mattermost desktop app `for macOS from the App Store <https://apps.apple.com/us/app/mattermost-desktop/id1614666244?mt=12>`_, `for Windows from the Microsoft Store <https://apps.microsoft.com/detail/xp8br8mh3lpklt?hl=en-US&gl=US>`_, or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
 
 We strongly recommend installing the desktop app on a local drive. Network shares aren't supported. 
 

--- a/source/collaborate/install-ios-app.rst
+++ b/source/collaborate/install-ios-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost iOS mobile app
 =====================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your iOS mobile device running iOS 12.1 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://apps.apple.com/us/app/mattermost/id1257222717>`_ on your iOS mobile device running iOS 12.1 or later.
 
 1. On your device, visit the App Store. 
 2. Search for "Mattermost" and select **GET** to download the app.

--- a/source/collaborate/share-files-in-messages.rst
+++ b/source/collaborate/share-files-in-messages.rst
@@ -105,3 +105,19 @@ The following media formats are supported on most browsers:
 -  Files: PDF, TXT
 
 Other document previews (such as Word, Excel, or PPT) are not yet supported.
+
+Secure PDF viewer on mobile
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. include:: ../_static/badges/ent-adv-only.rst
+  :start-after: :nosearch:
+
+From Mattermost v10.11 onward, Enterprise Advanced customers have access to a secure PDF viewer on mobile devices. When enabled by your system administrator, this feature provides enhanced security for viewing PDF documents:
+
+- **Secure inline viewing:** View password-protected and regular PDF files directly within the mobile app without external applications
+- **Content protection:** Advanced security measures prevent unauthorized sharing, extraction, or copying of PDF content
+- **Controlled navigation:** Navigate internal PDF links when permitted, while external links are blocked for security
+- **Restricted file access:** When the secure file preview feature is active, only images, videos, and PDFs are available for preview; all other file types are restricted
+
+.. note::
+   The secure PDF viewer is designed for high-security environments where strict content control and data loss prevention are required. Contact your system administrator to enable this feature.

--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -4287,6 +4287,66 @@ Prevent screen capture
 |   blocking is disabled.                       |                                                                                         |
 +-----------------------------------------------+-----------------------------------------------------------------------------------------+
 
+.. config:setting:: mobile-enable-secure-file-preview
+  :displayname: Enable Secure File Preview
+  :systemconsole: Environment > Mobile Security
+  :configjson: .NativeAppSettings.MobileEnableSecureFilePreview
+  :environment: MM_NATIVEAPPSETTINGS_MOBILEENABLESECUREFILEPREVIEW
+  :description: Enable the secure file preview feature on mobile devices. When enabled, only supported images, videos, and PDFs are previewed. All other file types are restricted from preview, and downloads and sharing are disabled across all file types.
+    - **true**: Secure file preview is enabled.
+    - **false**: **(Default)** Secure file preview is disabled.
+
+Enable secure file preview
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../_static/badges/ent-adv-only.rst
+  :start-after: :nosearch:
+
++-----------------------------------------------+--------------------------------------------------------------------------------------------+
+| Enable the secure file preview feature on     | - System Config path: **Environment > Mobile Security**                                    |
+| mobile devices. When enabled, only supported  | - ``config.json setting``: ``".NativeAppSettings.MobileEnableSecureFilePreview": false",`` |
+| images, videos, and PDFs are previewed.       | - Environment variable: ``MM_NATIVEAPPSETTINGS_MOBILEENABLESECUREFILEPREVIEW``             |
+| All other file types are restricted from      |                                                                                            |
+| preview, and downloads and sharing are        |                                                                                            |
+| disabled across all file types.               |                                                                                            |
+|                                               |                                                                                            |
+| - **true**: Secure file preview is enabled.   |                                                                                            |
+| - **false**: **(Default)** Secure file        |                                                                                            |
+|   preview is disabled.                        |                                                                                            |
++-----------------------------------------------+--------------------------------------------------------------------------------------------+
+
+.. note::
+  This feature enables the secure PDF viewer for Enterprise Advanced customers. When enabled, PDF documents can be viewed securely inline within the app with enhanced content protection and controlled access.
+
+.. config:setting:: mobile-allow-pdf-link-navigation
+  :displayname: Allow PDF Link Navigation  
+  :systemconsole: Environment > Mobile Security
+  :configjson: .NativeAppSettings.MobileAllowPdfLinkNavigation
+  :environment: MM_NATIVEAPPSETTINGS_MOBILEALLOWPDFLINKNAVIGATION
+  :description: Allow navigation of internal links within PDF documents when using the secure PDF viewer. External links are blocked for security reasons.
+    - **true**: PDF link navigation is enabled.
+    - **false**: **(Default)** PDF link navigation is disabled.
+
+Allow PDF link navigation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../_static/badges/ent-adv-only.rst
+  :start-after: :nosearch:
+
++-----------------------------------------------+--------------------------------------------------------------------------------------------+
+| Allow navigation of internal links within PDF | - System Config path: **Environment > Mobile Security**                                    |
+| documents when using the secure PDF viewer.   | - ``config.json setting``: ``".NativeAppSettings.MobileAllowPdfLinkNavigation": false",`` |
+| External links are blocked for security       | - Environment variable: ``MM_NATIVEAPPSETTINGS_MOBILEALLOWPDFLINKNAVIGATION``             |
+| reasons.                                       |                                                                                            |
+|                                               |                                                                                            |
+| - **true**: PDF link navigation is enabled.   |                                                                                            |
+| - **false**: **(Default)** PDF link           |                                                                                            |
+|   navigation is disabled.                     |                                                                                            |
++-----------------------------------------------+--------------------------------------------------------------------------------------------+
+
+.. note::
+  This setting only applies when the secure file preview feature is enabled. It allows users to navigate internal PDF links while maintaining security by blocking external links that could lead to potentially unsafe websites.
+
 config.json-only settings
 -------------------------
 

--- a/source/deploy/mobile/secure-mobile-file-storage.rst
+++ b/source/deploy/mobile/secure-mobile-file-storage.rst
@@ -22,9 +22,19 @@ iOS – app sandbox
 
 - **Secure file viewing:**
 
-  - Non-image and non-video files are rendered using secure frameworks such as QLPreviewController. This controller displays file previews within the app’s sandbox, ensuring that raw file data isn’t exposed to external processes.
+  - Non-image and non-video files are rendered using secure frameworks such as QLPreviewController. This controller displays file previews within the app's sandbox, ensuring that raw file data isn't exposed to external processes.
   - Supported image and video files are previewed directly within the app, with the files downloaded to the app's cache folder located within its secure sandbox. For unsupported image and video formats, the Mattermost mobile app uses the QLPreviewController framework, just as it does for other file types.
   - If the file format is also unsupported by QLPreviewController and :ref:`mobile downloads are enabled <configure/site-configuration-settings:allow file downloads on mobile>` on the server, users can download the file to a location of their choosing. However, if mobile downloads are disabled, these files become unavailable to the user.
+
+- **Secure PDF viewer (Mattermost v10.11+):**
+
+  Available for Enterprise Advanced customers, the secure PDF viewer provides enhanced security for viewing PDF documents within the mobile app:
+
+  - **Inline PDF viewing:** Password-protected and regular PDF documents can be viewed securely inline within the app without requiring external applications.
+  - **Content protection:** Prevents unauthorized sharing, extraction, or copying of PDF content through advanced security measures.
+  - **Link navigation control:** When enabled via server configuration, users can navigate internal PDF links while external links are blocked for security reasons.
+  - **Restricted file access:** When the secure file preview feature is enabled, only supported images, videos, and PDFs are previewed. All other file types are restricted from preview, and downloads/sharing are disabled across all file types.
+  - **Enterprise security:** Designed specifically for high-security use cases requiring strict content control and data loss prevention.
 
 - **Official references:**
 
@@ -41,9 +51,19 @@ Android – scoped storage
 
 - **Secure file viewing:**
 
-  - When users attempt to view non-image/video files, Mattermost uses an ``Intent.ACTION_VIEW`` to open the file. This intent delegates rendering to an external app only if the user explicitly triggers the action, while the file remains securely stored within Mattermost’s cache folder.
+  - When users attempt to view non-image/video files, Mattermost uses an ``Intent.ACTION_VIEW`` to open the file. This intent delegates rendering to an external app only if the user explicitly triggers the action, while the file remains securely stored within Mattermost's cache folder.
   - Viewing non-image/video files is available only if :ref:`mobile downloads are enabled <configure/site-configuration-settings:allow file downloads on mobile>` on the server.
   - Image and video files with supported formats are previewed directly within the app, with the files downloaded to the app's cache folder located within its secure sandbox. For unsupported image and video formats, the Mattermost mobile app uses ``Intent.ACTION_VIEW`` to open the file with an external application, just as it does for other file types.
+
+- **Secure PDF viewer (Mattermost v10.11+):**
+
+  Available for Enterprise Advanced customers, the secure PDF viewer provides enhanced security for viewing PDF documents within the mobile app:
+
+  - **Inline PDF viewing:** Password-protected and regular PDF documents can be viewed securely inline within the app without delegating to external applications.
+  - **Content protection:** Prevents unauthorized sharing, extraction, or copying of PDF content through advanced security measures.
+  - **Link navigation control:** When enabled via server configuration, users can navigate internal PDF links while external links are blocked for security reasons.
+  - **Restricted file access:** When the secure file preview feature is enabled, only supported images, videos, and PDFs are previewed. All other file types are restricted from preview, and downloads/sharing are disabled across all file types.
+  - **Enterprise security:** Designed specifically for high-security use cases requiring strict content control and data loss prevention.
 
 - **Official reference:**
 


### PR DESCRIPTION
Add comprehensive documentation for the new secure PDF file viewer feature available from Mattermost server v10.11 onward.

## Changes
- Add secure PDF viewer documentation to mobile file storage security docs
- Document MobileEnableSecureFilePreview configuration setting
- Document MobileAllowPdfLinkNavigation configuration setting
- Add user-facing secure PDF viewer documentation to file sharing guide
- Mark feature as Enterprise Advanced only with appropriate badges

Closes #(issue)

References https://github.com/mattermost/mattermost-mobile/pull/8844

🤖 Generated with [Claude Code](https://claude.ai/code)