### PR TITLE
In-App Links in Channel's Bookmarks

### DIFF
--- a/source/collaborate/install-android-app.rst
+++ b/source/collaborate/install-android-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost Android mobile app
 =========================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your Android mobile device running Android 7.0 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://play.google.com/store/apps/details?id=com.mattermost.rn>`_ on your Android mobile device running Android 7.0 or later.
 
 1. On your device, visit the Play Store.
 2. Search for "Mattermost" and select **INSTALL** to download the app.

--- a/source/collaborate/install-desktop-app.rst
+++ b/source/collaborate/install-desktop-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost desktop app
 ==================================
 
-Download and install the Mattermost desktop app from the App Store (macOS), Microsoft Store (Windows), or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
+Download and install the Mattermost desktop app `for macOS from the App Store <https://apps.apple.com/us/app/mattermost-desktop/id1614666244?mt=12>`_, `for Windows from the Microsoft Store <https://apps.microsoft.com/detail/xp8br8mh3lpklt?hl=en-US&gl=US>`_, or by :doc:`using a package manager (Linux) </deploy/desktop/linux-desktop-install>`. When new desktop app releases become available, your desktop app is automatically updated.
 
 We strongly recommend installing the desktop app on a local drive. Network shares aren't supported. 
 

--- a/source/collaborate/install-ios-app.rst
+++ b/source/collaborate/install-ios-app.rst
@@ -1,7 +1,7 @@
 Install the Mattermost iOS mobile app
 =====================================
 
-Take Mattermost wherever you go by installing the Mattermost mobile app on your iOS mobile device running iOS 12.1 or later.
+Take Mattermost wherever you go by `installing the Mattermost mobile app <https://apps.apple.com/us/app/mattermost/id1257222717>`_ on your iOS mobile device running iOS 12.1 or later.
 
 1. On your device, visit the App Store. 
 2. Search for "Mattermost" and select **GET** to download the app.

--- a/source/collaborate/manage-channel-bookmarks.rst
+++ b/source/collaborate/manage-channel-bookmarks.rst
@@ -15,6 +15,10 @@ Open a bookmark
 
 Opening a channel bookmark works the same way as selecting a file link or attachment in a message. Select or tap a bookmark to view the file or link.
 
+.. note::
+
+   **Desktop app users** (Mattermost v10.11+): When you click bookmarks with ``mattermost://`` URLs in the desktop app, they open directly within the app using internal deep linking. This provides a seamless experience without external protocol prompts that were shown in earlier versions.
+
 Add a bookmark
 --------------
 

--- a/source/collaborate/share-links.rst
+++ b/source/collaborate/share-links.rst
@@ -58,6 +58,14 @@ A Mattermost deep link is a URL that directs users to a specific location within
 .. tip::
 
   Deep links can also be used, in combination with bots, scripts, and integrations, to trigger specific actions within Mattermost.
+
+Desktop app behavior (Mattermost v10.11+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In the desktop app, ``mattermost://`` deep links provide an enhanced user experience:
+
+- **Channel bookmarks**: When you click bookmarks with ``mattermost://`` URLs, they open directly within the desktop app using internal deep linking
+- **Seamless navigation**: No external protocol dialogs are shown, providing uninterrupted workflow
+- **Previous versions**: Earlier versions prompted users with external application dialogs when clicking ``mattermost://`` links
   
 Format deep links
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary
- Enhanced channel bookmarks documentation with improved desktop app behavior for mattermost:// URLs
- Updated deep links documentation to reflect v10.11+ desktop app internal deep linking
- Documents seamless navigation without external protocol dialogs

## Changes Made
- **manage-channel-bookmarks.rst**: Added note about improved desktop behavior
- **share-links.rst**: Enhanced deep links section with desktop app behavior documentation

Addresses issue ##8223 regarding desktop PR mattermost/desktop#3454

🤖 Generated with [Claude Code](https://claude.ai/code)