### PR TITLE
Require signatures for prepackaged plugins from v10.11 onward

### DIFF
--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -88,7 +88,7 @@ Require plugin signature
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
 
 .. note::
-  - **Mattermost server v10.11 and later**: Pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins must configure custom public keys via ``PluginSettings.SignaturePublicKeyFiles`` to validate their signatures.
+  From Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins must configure custom public keys via ``PluginSettings.SignaturePublicKeyFiles`` to validate their signatures.
   - **Mattermost server v10.10 and earlier**: Pre-packaged plugins are not subject to signature validation.
   - Plugins installed through the Marketplace are always subject to signature validation at the time of download.
   - Enabling this configuration will result in `plugin file uploads <#upload-plugin>`__ being disabled in the System Console.

--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -2218,7 +2218,7 @@ In addition to the Mattermost plugin signing key built into the server, each pub
   When bundling custom plugins:
   
   - Drop both the plugin files and their corresponding ``.sig`` signature files into the ``prepackaged_plugins`` directory.
-  - Add your custom public key using this configuration setting to validate the signatures
+  - Add your custom public key using this configuration setting to validate the signatures.
 
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"SignaturePublicKeyFiles": {}`` with string array input consisting of contents that are relative or absolute paths to signature files.              |

--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -112,7 +112,7 @@ Automatic prepackaged plugins
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------+
 
 .. note::
-  **Prepackaged Plugin Installation Behavior**: When system administrators drop plugin files (with their ``.sig`` signature files) into the ``prepackaged_plugins`` directory, the plugins won't install automatically. Prepackaging makes the plugin available for "offline" installation. The plugin will automatically install only when the system administrator pre-configures the ``config.json`` with that plugin enabled.
+  **Prepackaged Plugin Installation Behavior**: When system administrators drop plugin files (with their ``.sig`` signature files) into the ``prepackaged_plugins`` directory, the plugins won't install automatically. Prepackaging makes the plugin available for "offline" installation. The plugin will automatically install only when a system admin pre-configures the ``config.json`` with that plugin enabled.
 
 .. config:setting:: upload-plugin
   :displayname: Upload Plugin (Plugins - Management)

--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -2217,7 +2217,7 @@ In addition to the Mattermost plugin signing key built into the server, each pub
 
   When bundling custom plugins:
   
-  - Drop both the plugin files and their corresponding ``.sig`` signature files into the ``prepackaged_plugins`` directory
+  - Drop both the plugin files and their corresponding ``.sig`` signature files into the ``prepackaged_plugins`` directory.
   - Add your custom public key using this configuration setting to validate the signatures
 
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -88,7 +88,9 @@ Require plugin signature
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
 
 .. note::
-  - Pre-packaged plugins are not subject to signature validation. Plugins installed through the Marketplace are always subject to signature validation at the time of download.
+  - **Mattermost server v10.11 and later**: Pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins must configure custom public keys via ``PluginSettings.SignaturePublicKeyFiles`` to validate their signatures.
+  - **Mattermost server v10.10 and earlier**: Pre-packaged plugins are not subject to signature validation.
+  - Plugins installed through the Marketplace are always subject to signature validation at the time of download.
   - Enabling this configuration will result in `plugin file uploads <#upload-plugin>`__ being disabled in the System Console.
 
 .. config:setting:: automatic-prepackaged-plugins
@@ -2206,6 +2208,9 @@ Signature public key files
 This setting isn't available in the System Console and can only be set in ``config.json``.
 
 In addition to the Mattermost plugin signing key built into the server, each public key specified here is trusted to validate plugin signatures.
+
+.. important::
+  Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins **must** configure this setting with their custom public keys to ensure proper validation of their signed plugins.
 
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"SignaturePublicKeyFiles": {}`` with string array input consisting of contents that are relative or absolute paths to signature files.              |

--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -111,6 +111,9 @@ Automatic prepackaged plugins
 |                                                                                                                                                                                 | - Environment variable: ``MM_PLUGINSETTINGS_AUTOMATICPREPACKAGEDPLUGINS``                  |
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------+
 
+.. note::
+  **Prepackaged Plugin Installation Behavior**: When system administrators drop plugin files (with their ``.sig`` signature files) into the ``prepackaged_plugins`` directory, the plugins won't install automatically. Prepackaging makes the plugin available for "offline" installation. The plugin will automatically install only when the system administrator pre-configures the ``config.json`` with that plugin enabled.
+
 .. config:setting:: upload-plugin
   :displayname: Upload Plugin (Plugins - Management)
   :systemconsole: Plugins > Plugin Management
@@ -2210,7 +2213,12 @@ This setting isn't available in the System Console and can only be set in ``conf
 In addition to the Mattermost plugin signing key built into the server, each public key specified here is trusted to validate plugin signatures.
 
 .. important::
-  Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins **must** configure this setting with their custom public keys to ensure proper validation of their signed plugins.
+  Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins **must** configure this setting with their custom public keys to ensure proper validation of their signed plugins. Use ``PluginSettings.SignaturePublicKeyFiles`` to define custom plugin signing keys.
+
+  When bundling custom plugins:
+  
+  - Drop both the plugin files and their corresponding ``.sig`` signature files into the ``prepackaged_plugins`` directory
+  - Add your custom public key using this configuration setting to validate the signatures
 
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"SignaturePublicKeyFiles": {}`` with string array input consisting of contents that are relative or absolute paths to signature files.              |

--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -2213,7 +2213,7 @@ This setting isn't available in the System Console and can only be set in ``conf
 In addition to the Mattermost plugin signing key built into the server, each public key specified here is trusted to validate plugin signatures.
 
 .. important::
-  Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins **must** configure this setting with their custom public keys to ensure proper validation of their signed plugins. Use ``PluginSettings.SignaturePublicKeyFiles`` to define custom plugin signing keys.
+  From Mattermost v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins **must** configure this setting with their custom public keys to ensure proper validation of their signed plugins. Use ``PluginSettings.SignaturePublicKeyFiles`` to define custom plugin signing keys.
 
   When bundling custom plugins:
   

--- a/source/product-overview/mattermost-v10-changelog.md
+++ b/source/product-overview/mattermost-v10-changelog.md
@@ -4,6 +4,24 @@
 ```{include} common-esr-support-upgrade.md
 ```
 
+(release-v10.11-feature-release)=
+## Release v10.11 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+
+- **10.11.0, released TBD**
+  - Original 10.11.0 release.
+
+### Important Upgrade Notes
+- **Plugin Signature Requirements**: Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins must configure custom public keys via `PluginSettings.SignaturePublicKeyFiles` to validate their signatures. See the [plugins configuration settings](https://docs.mattermost.com/configure/plugins-configuration-settings.html#signature-public-key-files) for more details.
+
+```{Important}
+If you upgrade from a release earlier than v10.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
+```
+
+### Improvements
+
+#### Administration
+- Pre-packaged plugins now require signature validation on startup, enhancing security by ensuring all plugins are properly signed and validated.
+
 (release-v10.10-feature-release)=
 ## Release v10.10 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
 

--- a/source/product-overview/mattermost-v10-changelog.md
+++ b/source/product-overview/mattermost-v10-changelog.md
@@ -4,28 +4,6 @@
 ```{include} common-esr-support-upgrade.md
 ```
 
-(release-v10.11-feature-release)=
-## Release v10.11 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
-
-- **10.11.0, released TBD**
-  - Original 10.11.0 release.
-
-### Important Upgrade Notes
-- **Plugin Signature Requirements**: Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins must:
-  - Drop both plugin files and their corresponding `.sig` signature files into the `prepackaged_plugins` directory
-  - Configure custom public keys via `PluginSettings.SignaturePublicKeyFiles` to validate their signatures
-  
-  See the [plugins configuration settings](https://docs.mattermost.com/configure/plugins-configuration-settings.html#signature-public-key-files) for more details.
-
-```{Important}
-If you upgrade from a release earlier than v10.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
-
-### Improvements
-
-#### Administration
-- Pre-packaged plugins now require signature validation on startup, enhancing security by ensuring all plugins are properly signed and validated.
-
 (release-v10.10-feature-release)=
 ## Release v10.10 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
 

--- a/source/product-overview/mattermost-v10-changelog.md
+++ b/source/product-overview/mattermost-v10-changelog.md
@@ -11,7 +11,11 @@
   - Original 10.11.0 release.
 
 ### Important Upgrade Notes
-- **Plugin Signature Requirements**: Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins must configure custom public keys via `PluginSettings.SignaturePublicKeyFiles` to validate their signatures. See the [plugins configuration settings](https://docs.mattermost.com/configure/plugins-configuration-settings.html#signature-public-key-files) for more details.
+- **Plugin Signature Requirements**: Starting with Mattermost server v10.11, pre-packaged plugins require signature validation on startup. Distributions that bundle custom pre-packaged plugins must:
+  - Drop both plugin files and their corresponding `.sig` signature files into the `prepackaged_plugins` directory
+  - Configure custom public keys via `PluginSettings.SignaturePublicKeyFiles` to validate their signatures
+  
+  See the [plugins configuration settings](https://docs.mattermost.com/configure/plugins-configuration-settings.html#signature-public-key-files) for more details.
 
 ```{Important}
 If you upgrade from a release earlier than v10.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).


### PR DESCRIPTION
Update documentation to reflect new signature requirement for pre-packaged plugins:

- Update plugins-configuration-settings.rst to clarify that pre-packaged plugins require signature validation starting in v10.11, with backward compatibility note
- Add v10.11 changelog entry documenting the signature requirement change
- Enhance SignaturePublicKeyFiles documentation to emphasize requirement for distributions with custom pre-packaged plugins

Closes #8238

Generated with [Claude Code](https://claude.ai/code)