### PR TITLE
Docs listening: Ensure that recommended scrape_interval default is reflected in code examples

### DIFF
--- a/source/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring.rst
+++ b/source/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring.rst
@@ -27,9 +27,9 @@ Install Prometheus
 
       # my global config
       global:
-        scrape_interval:     60s # By default, scrape targets every 15 seconds.
-        evaluation_interval: 60s # By default, scrape targets every 15 seconds.
-        # scrape_timeout is set to the global default (10s).
+         scrape_interval:     5s # Set to 5 seconds for optimal performance monitoring.
+         evaluation_interval: 5s # Set to 5 seconds for optimal performance monitoring.
+         # scrape_timeout is set to the global default (10s).
 
         # Attach these labels to any time series or alerts when communicating with
         # external systems (federation, remote storage, Alertmanager).
@@ -47,8 +47,8 @@ Install Prometheus
         # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
         - job_name: 'prometheus'
 
-        # Override the global default and scrape targets from this job every five seconds.
-        # scrape_interval: 5s
+         # The scrape_interval can be overridden per job if needed (5s matches the global default).
+         # scrape_interval: 5s
 
         # metrics_path defaults to '/metrics'
         # scheme defaults to 'http'.


### PR DESCRIPTION
Updates performance monitoring documentation to use optimal 5-second scrape_interval defaults instead of 60-second values.

## Changes
- Changed scrape_interval from 60s to 5s for optimal performance monitoring
- Changed evaluation_interval from 60s to 5s to match scrape_interval
- Updated comments to reflect correct 5-second recommendation
- Fixed misleading comment about overriding global defaults

Fixes issue with customers getting suboptimal defaults when copying examples from documentation.

Closes #8240

Generated with [Claude Code](https://claude.ai/code)