### PR TITLE
Update database connection pool defaults for MM-63726

### DIFF
--- a/source/configure/deprecated-configuration-settings.rst
+++ b/source/configure/deprecated-configuration-settings.rst
@@ -391,17 +391,6 @@ The port used for streaming data between servers.
 | This feature's ``config.json`` setting is ``"StreamingPort": ":8075"`` with string input. |
 +-------------------------------------------------------------------------------------------+
 
-Maximum idle database connections
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-*Deprecated. Not used in Mattermost v7.0 and later*
-
-+--------------------------------------------------------+------------------------------------------------------------------+
-| The maximum number of idle connections held open       | - System Config path: **Environment > Database**                 |
-| to the database.                                       | - ``config.json`` setting: ``".SqlSettings.MaxIdleConns": 20,``  |
-|                                                        | - Environment variable: ``MM_SQLSETTINGS_MAXIDLECONNS``          |
-| Numerical input. Default is **20**.                    |                                                                  |
-+--------------------------------------------------------+------------------------------------------------------------------+
 
 Maximum idle connections for high availability
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/configure/environment-configuration-settings.rst
+++ b/source/configure/environment-configuration-settings.rst
@@ -800,17 +800,35 @@ Mattermost doesn't need to manage this. See the :ref:`high availablility databas
   :systemconsole: Environment > Database
   :configjson: .SqlSettings.MaxOpenConns
   :environment: MM_SQLSETTINGS_MAXOPENCONNS
-  :description: The maximum number of idle connections held open to the database. Default is **300**.
+  :description: The maximum number of open connections to the database. Default is **100**.
 
 Maximum open connections
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 +--------------------------------------------------------+------------------------------------------------------------------+
 | The maximum number of open connections to the          | - System Config path: **Environment > Database**                 |
-| database.                                              | - ``config.json`` setting: ``".SqlSettings.MaxOpenConns": 300,`` |
+| database.                                              | - ``config.json`` setting: ``".SqlSettings.MaxOpenConns": 100,`` |
 |                                                        | - Environment variable: ``MM_SQLSETTINGS_MAXOPENCONNS``          |
-| Numerical input. Default is **300** for self-hosted    |                                                                  |
-| deployments, and **100** for Cloud deployments.        |                                                                  |
+| Numerical input. Default is **100**.                   |                                                                  |
+|                                                        |                                                                  |
++--------------------------------------------------------+------------------------------------------------------------------+
+
+.. config:setting:: maximum-idle-connections
+  :displayname: Maximum idle connections (Database)
+  :systemconsole: Environment > Database
+  :configjson: .SqlSettings.MaxIdleConns
+  :environment: MM_SQLSETTINGS_MAXIDLECONNS
+  :description: The maximum number of idle connections held open to the database. Default is **50**.
+
+Maximum idle connections
+~~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------------------------------------------------+------------------------------------------------------------------+
+| The maximum number of idle connections held open      | - System Config path: **Environment > Database**                 |
+| to the database.                                       | - ``config.json`` setting: ``".SqlSettings.MaxIdleConns": 50,``  |
+|                                                        | - Environment variable: ``MM_SQLSETTINGS_MAXIDLECONNS``          |
+| Numerical input. Default is **50**.                   |                                                                  |
+|                                                        |                                                                  |
 +--------------------------------------------------------+------------------------------------------------------------------+
 
 .. config:setting:: query-timeout

--- a/source/scale/high-availability-cluster-based-deployment.rst
+++ b/source/scale/high-availability-cluster-based-deployment.rst
@@ -314,8 +314,8 @@ Here's an example ``SqlSettings`` block for one master and two read replicas:
         "DataSource": "master_user:master_password@tcp(master.server)/mattermost?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s",
         "DataSourceReplicas": ["slave_user:slave_password@tcp(replica1.server)/mattermost?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s","slave_user:slave_password@tcp(replica2.server)/mattermost?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"],
         "DataSourceSearchReplicas": [],
-        "MaxIdleConns": 20,
-        "MaxOpenConns": 300,
+        "MaxIdleConns": 50,
+        "MaxOpenConns": 100,
         "Trace": false,
         "AtRestEncryptKey": "",
         "QueryTimeout": 30


### PR DESCRIPTION
## Summary

Updates documentation to reflect the v11 breaking changes from MM-63726:
- MaxOpenConns default changed from 300 to 100
- MaxIdleConns default changed from 20 to 50 (implementing 2:1 ratio)
- Moved MaxIdleConns from deprecated back to active configuration settings

This also corrects https://github.com/mattermost/docs/pull/7122 which incorrectly marked the MaxIdleConns setting as deprecated.

## Test plan

- [x] Updated environment configuration settings documentation
- [x] Removed deprecated MaxIdleConns section
- [x] Updated high availability deployment example
- [x] Verified no other references to old default values remain