### PR TITLE
MM-64925 - prevent slack import email auto validation for non admin users

### DIFF
--- a/source/administration-guide/onboard/migrate-from-slack.rst
+++ b/source/administration-guide/onboard/migrate-from-slack.rst
@@ -172,6 +172,31 @@ Use the imported team
 ^^^^^^^^^^^^^^^^^^^^^
 
 * During the import process, the emails and usernames from Slack are used to create new Mattermost accounts. If emails are not present in the Slack export archive, then placeholder values will be generated and the system admin will need to update these manually. We recommend administrators search the final import ``jsonl`` file for ``user`` lines for with ``@example.com`` in the email property to address and resolve the missing information prior to import.
-* Slack users can activate their new Mattermost accounts by using Mattermost's **Password Reset** screen with their email addresses from Slack to set new passwords for their Mattermost accounts.
+
+Email verification behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The email verification process during Slack import depends on who performs the import:
+
+**System administrator imports:**
+
+* Email addresses are automatically verified during the import process
+* Users can immediately use the Password Reset feature to set their password
+* No email verification step required before password reset
+
+**Non-administrator imports:**
+
+* Email addresses remain unverified after import
+* Users must first verify their email addresses before they can reset their password
+* Additional email verification step required before account access
+
+Account activation
+~~~~~~~~~~~~~~~~~~
+
+* Slack users activate their new Mattermost accounts by using Mattermost's **Password Reset** screen with their email addresses from Slack to set new passwords for their Mattermost accounts.
+
+  * For imports performed by system administrators: Users can immediately use the Password Reset feature (no email verification required)
+  * For imports performed by non-administrators: Users must first verify their email addresses, then use the Password Reset feature
+
 * Once logged in, Mattermost users will have access to previous Slack messages in the public channels imported from Slack.
 * Instructions on how to migrate user authenticatation to LDAP or SAML can be found :ref:`here <administration-guide/manage/mmctl-command-line-tool:mmctl user migrate-auth>`.


### PR DESCRIPTION
#### Summary
This PR clarifies how the email validation will work during the slack import process making clear that for imports performed by system admins the imported user emails will be automatically validated and users will be able to reset password directly as opposite than migrations performed by non-admins users where imported users will have to validate their emails first before being able to reset the password for getting into the workspace.

#### Ticket Link
https://github.com/mattermost/mattermost/pull/33609

