### PR TITLE
Fix typo: "formally" -> "formerly"

### DIFF
--- a/source/end-user-guide/agents.rst
+++ b/source/end-user-guide/agents.rst
@@ -6,7 +6,7 @@ AI Agents
 
 .. note::
 
-  Mattermost Agents is formally known as Mattermost Copilot.
+  Mattermost Agents is formerly known as Mattermost Copilot.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
I'm not going to follow a process for this, just letting you know of this prominent public-facing typo. Feel free to close.