### PR TITLE
Add GitLab child pipeline notification configuration setting

### DIFF
--- a/source/integrations-guide/gitlab.rst
+++ b/source/integrations-guide/gitlab.rst
@@ -50,6 +50,7 @@ Install the GitLab integration from the in-product App Marketplace:
  - Generate a **Webhook Secret** and **At Rest Encryption Key** by selecting **Generate**.
  - (Optional) **GitLab Group**: Lock the integration to a single GitLab group.
  - (Optional) **Enable Private Repositories**: Enable the ability to work with private repositories. Affected users are notified once private repositories are enabled, and must reconnect their GitLab accounts to gain access to private repositories.
+ - (Optional) **Enable Child Pipeline Notifications**: When enabled, allows notifications for child pipeline events in addition to parent pipeline events. When disabled, only parent pipeline notifications are sent. This setting helps reduce notification noise in environments with complex CI/CD pipeline structures that use child pipelines extensively.
 
 Enable
 ------
@@ -99,7 +100,7 @@ The following features are supported for channel subscriptions:
 - ``issue_comments`` - Get notified when comments are made on issues
 - ``merge_request_comments`` - Get notified when comments are made on merge requests
 - ``tag`` - Get notified when tags are created
-- ``pipeline`` - Get notified about pipeline events
+- ``pipeline`` - Get notified about pipeline events (includes child pipeline events if enabled in plugin configuration)
 - ``wiki`` - Get notified about wiki page events
 - ``releases`` - Get notified when releases are created
 - ``deployments`` - Get notified about deployment events


### PR DESCRIPTION
Update GitLab integration documentation to include the new optional "Enable Child Pipeline Notifications" setting that was added to the GitLab plugin. This setting allows system administrators to control whether child pipeline events generate notifications, helping reduce notification noise in complex CI/CD environments.

## Changes
- Added configuration documentation for child pipeline notifications
- Updated pipeline subscription feature description to clarify child pipeline behavior
- Provides clear guidance for system administrators on managing pipeline notification volume

Closes #8314

Generated with [Claude Code](https://claude.ai/code)