### PR TITLE
Add GitLab Enable Code Previews configuration setting

### DIFF
--- a/source/integrations-guide/gitlab.rst
+++ b/source/integrations-guide/gitlab.rst
@@ -63,15 +63,13 @@ Install the GitLab integration from the in-product App Marketplace:
 
    **Supported Permalink Types:**
 
-   - File permalinks: Shows first 10 lines
    - Single line permalinks: Shows target line plus 3 lines of context
-   - Line range permalinks: Shows specified line range
+   - File permalinks: Shows file information (no code preview)
+   - Line range permalinks: Shows file information (no code preview)
 
    **Preview Limits:**
 
-   - Maximum 10 lines displayed per preview
-   - Line ranges exceeding 10 lines are truncated with an indicator
-   - Maximum 10 permalink replacements per message
+   - Maximum 10 lines displayed per preview (single line permalinks may show fewer preview lines due to context limits)
 
 Enable
 ------

--- a/source/integrations-guide/gitlab.rst
+++ b/source/integrations-guide/gitlab.rst
@@ -50,6 +50,27 @@ Install the GitLab integration from the in-product App Marketplace:
  - Generate a **Webhook Secret** and **At Rest Encryption Key** by selecting **Generate**.
  - (Optional) **GitLab Group**: Lock the integration to a single GitLab group.
  - (Optional) **Enable Private Repositories**: Enable the ability to work with private repositories. Affected users are notified once private repositories are enabled, and must reconnect their GitLab accounts to gain access to private repositories.
+ - (Optional) **Enable Code Previews**: Control automatic expansion of GitLab file permalinks with code previews. Options include:
+
+   - **Enable for public projects** (Default): Shows previews only for public GitLab repositories.
+   - **Enable for public and private projects**: Shows previews for both public and private repositories. 
+
+     .. warning::
+        This setting might leak confidential code into public channels when users with access to private GitLab repositories post permalinks in public Mattermost channels. The plugin automatically generates previews using the poster's GitLab permissions, allowing other channel members without access to view the confidential code.
+
+   - **Disable**: Completely disables code preview functionality.
+
+   **Supported Permalink Types:**
+
+   - File permalinks: Shows first 10 lines
+   - Single line permalinks: Shows target line plus 3 lines of context
+   - Line range permalinks: Shows specified line range
+
+   **Preview Limits:**
+
+   - Maximum 10 lines displayed per preview
+   - Line ranges exceeding 10 lines are truncated with an indicator
+   - Maximum 10 permalink replacements per message
 
 Enable
 ------

--- a/source/integrations-guide/gitlab.rst
+++ b/source/integrations-guide/gitlab.rst
@@ -56,7 +56,7 @@ Install the GitLab integration from the in-product App Marketplace:
    - **Enable for public and private projects**: Shows previews for both public and private repositories. 
 
      .. warning::
-        This setting might leak confidential code into public channels when users with access to private GitLab repositories post permalinks in public Mattermost channels. The plugin automatically generates previews using the poster's GitLab permissions, allowing other channel members without access to view the confidential code.
+        This setting has the potential to leak confidential code into public channels in cases where users with access to private GitLab repositories post permalinks in public Mattermost channels. The plugin automatically generates previews using the poster's GitLab permissions, allowing other channel members without access to view the confidential code.
 
    - **Disable**: Completely disables code preview functionality.
 


### PR DESCRIPTION
Add documentation for the new Enable Code Previews setting that controls automatic expansion of GitLab file permalinks with code previews.

Includes:
- Configuration options (public, private+public, disable)
- Security warning about potential code leaks in public channels
- Supported permalink types and preview limits

Closes ##8315

Generated with [Claude Code](https://claude.ai/code)