### PR TITLE
fix nginx-controller deployment link

### DIFF
--- a/source/deployment-guide/server/kubernetes/deploy-k8s.rst
+++ b/source/deployment-guide/server/kubernetes/deploy-k8s.rst
@@ -25,7 +25,7 @@ The installation process involves setting up necessary operators and then deploy
 Step 1: Install the NGINX Ingress Controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Follow the instructions in the `Kubernetes deployment documentation <https://kubernetes.github.io/ingress-nginx/deployment-guide/>`_ to install the NGINX ingress controller on your Kubernetes cluster. Mattermost recommends installing the Nginx Operator via helm, regardless of platform you are installing to.
+Follow the instructions in the `Kubernetes deployment documentation <https://kubernetes.github.io/ingress-nginx/deploy/>`_ to install the NGINX ingress controller on your Kubernetes cluster. Mattermost recommends installing the Nginx Operator via helm, regardless of platform you are installing to.
 
 Step 2: Install the Mattermost Operator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fixed the broken link for Kubernetes nginx-controller deployment instructions.

#### Ticket Link
git checkout -b CLD-9512-fix-the-nginx-ingress-controller-deployment-link-in-the-docs

