### PR TITLE
Added support for page-level metadata

### DIFF
--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -1,4 +1,7 @@
 {% extends "furo/page.html" %}
+{% block title -%}
+    {% if page_title_override %}{{ page_title_override }}{% else %}{{ super() }}{% endif %}
+{%- endblock title %}
 {% block extrahead -%}
     {% include "google-tag-manager.html" %}
     {% include "zendesk-crawler.html" %}

--- a/source/administration-guide/configure/push-notification-server-configuration-settings.rst
+++ b/source/administration-guide/configure/push-notification-server-configuration-settings.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/configure/rate-limiting-configuration-settings.rst
+++ b/source/administration-guide/configure/rate-limiting-configuration-settings.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/onboard/common-converting-oauth-to-openidconnect.rst
+++ b/source/administration-guide/onboard/common-converting-oauth-to-openidconnect.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/onboard/sso-saml-before-you-begin.rst
+++ b/source/administration-guide/onboard/sso-saml-before-you-begin.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/onboard/sso-saml-faq.rst
+++ b/source/administration-guide/onboard/sso-saml-faq.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/onboard/sso-saml-ldapsync.rst
+++ b/source/administration-guide/onboard/sso-saml-ldapsync.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
+++ b/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/scale/estimated-storage-per-user-per-month.rst
+++ b/source/administration-guide/scale/estimated-storage-per-user-per-month.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/administration-guide/scale/lifetime-storage.rst
+++ b/source/administration-guide/scale/lifetime-storage.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -6,6 +6,7 @@
 import sys
 import os
 from sphinx.application import Sphinx
+from docutils import nodes
 
 
 def find_duplicate_redirects(redirects_map: dict[str, str]) -> bool:
@@ -51,9 +52,48 @@ import redirects as redirects_py
 redirects = redirects_py.redirects_map
 
 
-def setup(_: Sphinx):
+def add_page_title_override(app: Sphinx, pagename: str, templatename: str, context: dict, doctree):
+    """Inject page_title_override into Jinja context if :page_title: meta is present.
+
+    Looks for a ``.. meta::`` entry with ``:page_title:`` first (reliable for HTML),
+    and falls back to ``env.metadata[pagename]['page_title']`` if present.
+    """
+    try:
+        override_value = None
+
+        # Prefer meta nodes in doctree (.. meta:: :page_title: ...)
+        if doctree is not None:
+            for meta_node in doctree.traverse(nodes.meta):
+                # The meta directive stores name/content attributes
+                name_attr = meta_node.get("name")
+                if name_attr == "page_title":
+                    override_value = meta_node.get("content")
+                    if override_value:
+                        break
+
+        # Fallback to env.metadata collected values
+        if not override_value and hasattr(app.env, "metadata"):
+            meta = app.env.metadata.get(pagename, {}) or {}
+            value = meta.get("page_title")
+            if isinstance(value, (list, tuple)):
+                override_value = value[0]
+            elif value:
+                override_value = value
+
+        if override_value:
+            context["page_title_override"] = override_value
+            # Also set the page title used by base templates
+            context["title"] = override_value
+    except Exception:
+        # Be resilient; do not break the build if anything unexpected occurs
+        pass
+
+
+def setup(app: Sphinx):
     # Check for duplicate redirects when Sphinx builds
     find_duplicate_redirects(redirects_py.redirects_map)
+    # Provide per-page HTML <title> override via RST .. meta:: :page_title:
+    app.connect("html-page-context", add_page_title_override)
     return
 
 

--- a/source/deployment-guide/server/kubernetes/deploy-k8s-aks.rst
+++ b/source/deployment-guide/server/kubernetes/deploy-k8s-aks.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/deployment-guide/server/kubernetes/deploy-k8s-oke.rst
+++ b/source/deployment-guide/server/kubernetes/deploy-k8s-oke.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/deployment-guide/server/kubernetes/deploy-k8s.rst
+++ b/source/deployment-guide/server/kubernetes/deploy-k8s.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/product-overview/cloud-supported-integrations.rst
+++ b/source/product-overview/cloud-supported-integrations.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 :orphan:
 :nosearch:
 

--- a/source/product-overview/common-esr-support-rst.rst
+++ b/source/product-overview/common-esr-support-rst.rst
@@ -1,7 +1,3 @@
-.. meta::
-   :name: robots
-   :content: noindex
-
 .. important::
 
    Support for Mattermost Server v10.5 :ref:`Extended Support Release <product-overview/release-policy:extended support releases>` is coming to the end of its life cycle on November 15, 2025. Upgrading to :doc:`Mattermost Server v10.11 or later </product-overview/mattermost-server-releases>` is recommended.

--- a/source/product-overview/common-esr-support-upgrade.md
+++ b/source/product-overview/common-esr-support-upgrade.md
@@ -1,5 +1,4 @@
-<!-- Indicates to search engines not to index the page -->
-<meta name="robots" content="noindex">
+<!-- Snippet include; not intended to be a standalone page -->
 
 - Support for Mattermost Server v10.5 [Extended Support Release](https://docs.mattermost.com/product-overview/release-policy.html#extended-support-releases) is coming to the end of its life cycle on November 15, 2025. Upgrading to Mattermost Server v10.11 or later is recommended.
 - Upgrading from ESR-to-ESR (``major`` -> ``major_next``) is fully supported and tested. However, upgrading from ESR-to-ESR (``major`` to ``major+2``) is supported, but not tested. If you plan to upgrade across multiple releases, we strongly recommend upgrading from an ESR to another ESR. For example, if you're upgrading from the v8.1 ESR, upgrade to the [v9.5 ESR](https://docs.mattermost.com/about/mattermost-v9-changelog.html#release-v9-5-extended-support-release) or the [v9.11 ESR](https://docs.mattermost.com/about/mattermost-v9-changelog.html#release-v9-11-extended-support-release).

--- a/source/product-overview/common-esr-support.md
+++ b/source/product-overview/common-esr-support.md
@@ -1,4 +1,3 @@
-<!-- Indicates to search engines not to index the page -->
-<meta name="robots" content="noindex">
+<!-- Snippet include; not intended to be a standalone page -->
 
 Support for Mattermost Server v10.5 [Extended Support Release](https://docs.mattermost.com/product-overview/release-policy.html#extended-support-releases) is coming to the end of its life cycle on November 15, 2025. Upgrading to [Mattermost Server v10.11](https://docs.mattermost.com/product-overview/mattermost-v10-changelog.html#release-v10-11-extended-support-release) or later is recommended.

--- a/source/product-overview/desktop.rst
+++ b/source/product-overview/desktop.rst
@@ -1,6 +1,9 @@
 Desktop
 ========
 
+.. meta::
+	:page_title: Mattermost Desktop App
+
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 

--- a/source/product-overview/mattermost-server-releases.md
+++ b/source/product-overview/mattermost-server-releases.md
@@ -1,6 +1,11 @@
 (mattermost-server-releases)=
 # Server Releases
 
+```{eval-rst}
+.. meta::
+    :page_title: Mattermost Server Releases
+```
+
 ```{include} ../_static/badges/allplans-selfhosted.md
 ```
 

--- a/source/product-overview/mattermost-v10-changelog.md
+++ b/source/product-overview/mattermost-v10-changelog.md
@@ -1,5 +1,10 @@
 # v10 Changelog
 
+```{eval-rst}
+.. meta::
+  :page_title: Mattermost Server v10 Release Notes
+```
+
 ```{Important}
 ```{include} common-esr-support-upgrade.md
 ```

--- a/source/product-overview/mattermost-v9-changelog.md
+++ b/source/product-overview/mattermost-v9-changelog.md
@@ -1,10 +1,13 @@
 # v9 Changelog
 
+```{eval-rst}
+.. meta::
+  :page_title: Mattermost Server v9 Release Notes
+```
 
 ```{Important}
 ```{include} common-esr-support-upgrade.md
 ```
-
 
 (release-v9-11-extended-support-release)=
 ## Release v9.11 - [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#release-types)

--- a/source/product-overview/mobile.rst
+++ b/source/product-overview/mobile.rst
@@ -1,6 +1,9 @@
 Mobile
 ======
 
+.. meta::
+	:page_title: Mattermost Mobile App
+
 .. include:: ../_static/badges/allplans-cloud-selfhosted.rst
   :start-after: :nosearch:
 

--- a/source/product-overview/product-overview-index.rst
+++ b/source/product-overview/product-overview-index.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :page_title: Intelligent Mission Environment from Mattermost
+
 Overview
 =========
 

--- a/source/product-overview/server.rst
+++ b/source/product-overview/server.rst
@@ -1,6 +1,9 @@
 Server
 ======
 
+.. meta::
+	:page_title: Mattermost Server
+
 .. include:: ../_static/badges/allplans-selfhosted.rst
   :start-after: :nosearch:
 


### PR DESCRIPTION
Page-level metadata support allows us to control the web browser link preview text and SEO text output on demand per-page.