### PR TITLE
v11: Update certificate configuration settings with critical server startup requirement

### DIFF
--- a/source/administration-guide/configure/experimental-configuration-settings.rst
+++ b/source/administration-guide/configure/experimental-configuration-settings.rst
@@ -1065,13 +1065,11 @@ Enable client-side certification
 
 .. important::
 
-  **Certificate-based authentication has been removed in Mattermost v11.0 and later versions.** This setting must be set to ``false`` to start the server in Mattermost v11.0+. Setting this to ``true`` will prevent the server from starting.
-
-  This documentation is maintained for reference for users on Mattermost v10.12 and earlier versions.
+  **Certificate-based authentication has been deprecated from Mattermost v11.0.** This setting must be set to ``false`` to start the server from v11. Setting this to ``true`` will prevent the server from starting.
 
 **True**: Enables client-side certification for your Mattermost server. See :doc:`the documentation </administration-guide/onboard/certificate-based-authentication>` to learn more.
 
-**False**: Client-side certification is disabled.
+**False**: **(Default)** Client-side certification is disabled.
 
 +------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"ClientSideCertEnable": false`` with options ``true`` and ``false``. |
@@ -1094,15 +1092,13 @@ Client-side certification login method
 
 .. important::
 
-  **Certificate-based authentication has been removed in Mattermost v11.0 and later versions.** This setting is no longer functional in Mattermost v11.0+ and should be left at the default value.
+  **Certificate-based authentication has been deprecated from Mattermost v11.0.** This setting is no longer functional from Mattermost v11.0 and should be left at the default value.
 
-  This documentation is maintained for reference for users on Mattermost v10.12 and earlier versions.
-
-Used in combination with the ``ClientSideCertEnable`` configuration setting.
+This configuration setting is used in combination with the ``ClientSideCertEnable`` configuration setting and has the following possible values:
 
 **Primary**: After the client side certificate is verified, user's email is retrieved from the certificate and is used to log in without a password.
 
-**Secondary**: After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
+**Secondary**: **(Default)** After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
 
 +----------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"ClientSideCertCheck": "secondary"`` with options ``"primary"`` and ``"secondary"``. |

--- a/source/administration-guide/onboard/certificate-based-authentication.rst
+++ b/source/administration-guide/onboard/certificate-based-authentication.rst
@@ -4,25 +4,30 @@ Certificate-based authentication (Experimental)
 .. include:: ../../_static/badges/ent-selfhosted.rst
   :start-after: :nosearch:
 
-Certificate-based authentication (CBA) is available as an experimental feature to identify a user or a device before granting access to Mattermost and provide an additional layer of security to access the system.
+.. important::
+  **Experimental certificate-based authentication has been deprecated from Mattermost v11.0.** From Mattermost v11, you must :ref:`disable this feature <administration-guide/configure/experimental-configuration-settings:enable client-side certification>` to start the server. Enabling this setting will prevent the server from starting.
 
-Follow these steps to configure user CBA for your browser and Mattermost Desktop Apps. Support for the Mattermost iOS and Android Apps is planned. It is expected that you can manage certificate distribution for each personal device (BYOD) and their life cycle management with a service like `OpenSSL <https://www.openssl.org/>`__.
+Prior to v11, certificate-based authentication (CBA) is available as an experimental feature to identify a user or a device before granting access to Mattermost and provide an additional layer of security to access the system.
 
 Before you begin, follow the :doc:`official guides to install Mattermost </deployment-guide/deployment-guide-index>` on your system, including NGINX configuration as a proxy with SSL and HTTP/2, and a valid SSL certificate such as Let's Encrypt.
 
-Set up mutual TLS authentication for the Web App
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Then, follow the steps below to configure user CBA for your browser and Mattermost Desktop Apps. You can manage certificate distribution for each personal device (BYOD) and their life cycle management with a service like `OpenSSL <https://www.openssl.org/>`__.
 
-This is the first step for setting up certificate-based authentication. If you haven't set up mutual TLS authentication yet, :doc:`see our documentation to learn more </administration-guide/onboard/ssl-client-certificate>`.
+Set up mutual TLS authentication for the Web App
+-------------------------------------------------
+
+:doc:`Setting up mutual TLS authentication </administration-guide/onboard/ssl-client-certificate>` is the first step to set up certificate-based authentication. 
 
 Set up Mattermost server to log in with a client certificate
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------------------
 
 1. Make sure your Mattermost server is licensed with a valid Enterprise license.
 2. In ``ExperimentalSettings`` of the ``config.json`` file, set ``ClientSideCertEnable`` to ``true`` and ``ClientSideCertCheck`` to one of the following values:
 
 - ``primary`` - After the client side certificate is verified, user's email is retrieved from the certificate and is used to log in without a password.
-- ``secondary`` - After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. If they match, the user logs in with regular email/password credentials.
+- ``secondary`` - After the client side certificate is verified, user's email is retrieved from the certificate and matched against the one supplied by the user. 
+
+If they match, the user logs in with regular email/password credentials.
 
 The ``config.json`` file should then have the following lines
 
@@ -34,17 +39,5 @@ The ``config.json`` file should then have the following lines
   },
 
 3. Restart the Mattermost server.
-
-On Ubuntu 14.04 and RHEL 6:
-
-.. code-block:: sh
-
-  sudo restart mattermost
-
-On Ubuntu 16.04, Debian Stretch, and RHEL 7:
-
-.. code-block:: sh
-
-  sudo systemctl restart mattermost
 
 4. Go to ``https://example.mattermost.com`` and try to log in. The server should require the x.509 cert to have an ``emailAddress`` equal to the Mattermost user's email.


### PR DESCRIPTION

- Add important warning that ClientSideCertEnable must be false to start server in v11.0+
- Clarify that ClientSideCertCheck is no longer functional in v11.0+
- Emphasize that setting ClientSideCertEnable to true will prevent server startup

Created with AI