### PR TITLE
v11: Update SAML signature algorithm default from SHA1 to SHA256

### DIFF
--- a/source/administration-guide/configure/authentication-configuration-settings.rst
+++ b/source/administration-guide/configure/authentication-configuration-settings.rst
@@ -1499,7 +1499,7 @@ Sign request
   :systemconsole: Authentication > SAML 2.0
   :configjson: .SamlSettings.SignatureAlgorithm
   :environment: MM_SAMLSETTINGS_SIGNATUREALGORITHM
-  :description: This setting determines the signature algorithm used to sign the SAML request. Options are: ``RSAwithSHA1``, ``RSAwithSHA256``, ``RSAwithSHA512``. Default is ``RSAwithSHA256`` starting from v11 (previously ``RSAwithSHA1``).
+  :description: This setting determines the signature algorithm used to sign the SAML request. Options are: ``RSAwithSHA1``, ``RSAwithSHA256``, ``RSAwithSHA512``. From v11, default is ``RSAwithSHA256``. Previously ``RSAwithSHA1``.
 
 Signature algorithm
 ~~~~~~~~~~~~~~~~~~~
@@ -1514,7 +1514,7 @@ Signature algorithm
 |                                                                                                                                                    |                                                                          |
 | .. note::                                                                                                                                          |                                                                          |
 |                                                                                                                                                    |                                                                          |
-|   Starting from Mattermost v11, the default signature algorithm has been updated from ``RSAwithSHA1`` to ``RSAwithSHA256`` for improved security.|                                                                          |
+|   From Mattermost v11, the default signature algorithm has been updated from ``RSAwithSHA1`` to ``RSAwithSHA256`` for improved security.           |                                                                          |
 |   Existing configurations will continue to work, but new installations will default to ``RSAwithSHA256``.                                          |                                                                          |
 +----------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------+
 

--- a/source/administration-guide/configure/authentication-configuration-settings.rst
+++ b/source/administration-guide/configure/authentication-configuration-settings.rst
@@ -1499,7 +1499,7 @@ Sign request
   :systemconsole: Authentication > SAML 2.0
   :configjson: .SamlSettings.SignatureAlgorithm
   :environment: MM_SAMLSETTINGS_SIGNATUREALGORITHM
-  :description: This setting determines the signature algorithm used to sign the SAML request. Options are: ``RSAwithSHA1``, ``RSAwithSHA256``, ``RSAwithSHA512``.
+  :description: This setting determines the signature algorithm used to sign the SAML request. Options are: ``RSAwithSHA1``, ``RSAwithSHA256``, ``RSAwithSHA512``. Default is ``RSAwithSHA256`` starting from v11 (previously ``RSAwithSHA1``).
 
 Signature algorithm
 ~~~~~~~~~~~~~~~~~~~
@@ -1511,6 +1511,11 @@ Signature algorithm
 | This setting determines the signature algorithm used to sign the SAML request. Options are: ``RSAwithSHA1``, ``RSAwithSHA256``, ``RSAwithSHA512``. | - System Config path: **Authentication > SAML 2.0**                      |
 |                                                                                                                                                    | - ``config.json`` setting: ``SamlSettings`` > ``SignatureAlgorithm``     |
 | String input.                                                                                                                                      | - Environment variable: ``MM_SAMLSETTINGS_SIGNATUREALGORITHM``           |
+|                                                                                                                                                    |                                                                          |
+| .. note::                                                                                                                                          |                                                                          |
+|                                                                                                                                                    |                                                                          |
+|   Starting from Mattermost v11, the default signature algorithm has been updated from ``RSAwithSHA1`` to ``RSAwithSHA256`` for improved security.|                                                                          |
+|   Existing configurations will continue to work, but new installations will default to ``RSAwithSHA256``.                                          |                                                                          |
 +----------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------+
 
 .. config:setting:: canonical-algorithm

--- a/source/administration-guide/onboard/sso-saml-technical.rst
+++ b/source/administration-guide/onboard/sso-saml-technical.rst
@@ -42,6 +42,9 @@ When Mattermost initiates an SP-initiated SAML request flow, it generates a **HT
 
 AuthNRequests can also be signed by Mattermost, in which case the XML payload is similar to:
 
+.. note::
+  Starting from Mattermost v11, the default signature algorithm has been updated from SHA-1 to SHA-256 for improved security. The example below reflects the new default SHA-256 algorithm.
+
 .. code-block:: XML
 
   <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlsig="https://www.w3.org/2000/09/xmldsig#" ID="_u5mpjadp1fdozfih4cj8ap4brh" Version="2.0" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="http://localhost:8065/login/sso/saml" IssueInstant="2019-06-08T16:00:31Z">
@@ -49,12 +52,12 @@ AuthNRequests can also be signed by Mattermost, in which case the XML payload is
       <samlsig:Signature Id="Signature1">
           <samlsig:SignedInfo>
               <samlsig:CanonicalizationMethod Algorithm="https://www.w3.org/2001/10/xml-exc-c14n#"></samlsig:CanonicalizationMethod>
-              <samlsig:SignatureMethod Algorithm="https://www.w3.org/2000/09/xmldsig#rsa-sha1"></samlsig:SignatureMethod>
+              <samlsig:SignatureMethod Algorithm="https://www.w3.org/2000/09/xmldsig#rsa-sha256"></samlsig:SignatureMethod>
               <samlsig:Reference URI="#_u5mpjadp1fdozfih4cj8ap4brh">
                   <samlsig:Transforms>
                       <samlsig:Transform Algorithm="https://www.w3.org/2000/09/xmldsig#enveloped-signature"></samlsig:Transform>
                   </samlsig:Transforms>
-                  <samlsig:DigestMethod Algorithm="https://www.w3.org/2000/09/xmldsig#sha1"></samlsig:DigestMethod>
+                  <samlsig:DigestMethod Algorithm="https://www.w3.org/2000/09/xmldsig#sha256"></samlsig:DigestMethod>
                   <samlsig:DigestValue></samlsig:DigestValue>
               </samlsig:Reference>
           </samlsig:SignedInfo>

--- a/source/administration-guide/onboard/sso-saml-technical.rst
+++ b/source/administration-guide/onboard/sso-saml-technical.rst
@@ -43,7 +43,7 @@ When Mattermost initiates an SP-initiated SAML request flow, it generates a **HT
 AuthNRequests can also be signed by Mattermost, in which case the XML payload is similar to:
 
 .. note::
-  Starting from Mattermost v11, the default signature algorithm has been updated from SHA-1 to SHA-256 for improved security. The example below reflects the new default SHA-256 algorithm.
+  From Mattermost v11, the default signature algorithm has been updated from SHA-1 to SHA-256 for improved security. The example below reflects the new default SHA-256 algorithm.
 
 .. code-block:: XML
 


### PR DESCRIPTION
- Updated authentication configuration settings to document the default change from RSAwithSHA1 to RSAwithSHA256 starting in Mattermost v11
- Added version-specific note explaining the security improvement and backward compatibility
- Updated SAML technical documentation examples to use SHA-256 algorithms instead of SHA-1
- Added explanatory note about the v11 default change in the technical documentation

Addresses improved security for user provisioning workflows as documented in mattermost/mattermost#33492.

🤖 Generated with [Claude Code](https://claude.ai/code)