### PR TITLE
docs: Add deprecation notices for mmctl commands in v11

### DIFF
--- a/source/administration-guide/manage/mmctl-command-line-tool.rst
+++ b/source/administration-guide/manage/mmctl-command-line-tool.rst
@@ -832,6 +832,7 @@ mmctl channel
 Manage channels.
 
    Child Commands
+      -  `mmctl channel add`_ - (Deprecated) Add a user to a channel
       -  `mmctl channel archive`_ - Archive a channel
       -  `mmctl channel create`_ - Create a channel
       -  `mmctl channel delete`_ - Delete a channel
@@ -839,6 +840,7 @@ Manage channels.
       -  `mmctl channel make-private`_ - (Deprecated) Set a channel's type to "private" 
       -  `mmctl channel modify`_ - Modify a channel's type (private/public)
       -  `mmctl channel move`_ - Move channels to the specified team
+      -  `mmctl channel remove`_ - (Deprecated) Remove a user from a channel
       -  `mmctl channel rename`_ - Rename a channel
       -  `mmctl channel restore`_ - (Deprecated) Restore a channel from the archive
       -  `mmctl channel search`_ - Search a channel by name
@@ -877,6 +879,47 @@ Archive channels along with all related information including posts from the dat
 .. code-block:: sh
 
    -h, --help   help for archive
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
+   --disable-pager                disables paged output
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+   --json                         the output format will be in json format
+   --local                        allows communicating with the server through a unix socket
+   --quiet                        prevent mmctl to generate output for the commands
+   --strict                       will only run commands if the mmctl version matches the server one
+   --suppress-warnings            disables printing warning messages
+
+mmctl channel add
+~~~~~~~~~~~~~~~~~
+
+This command is deprecated in favor of :ref:`mmctl channel users add <administration-guide/manage/mmctl-command-line-tool:mmctl channel users add>`.
+
+**Description**
+
+Add a user to a channel.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl channel add [channel] [users] [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   mmctl channel add myteam:mychannel user@example.com username
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for add
 
 **Options inherited from parent commands**
 
@@ -1171,6 +1214,47 @@ Rename an existing channel.
    --display_name string   Channel Display Name
    -h, --help              help for rename
    --name string           Channel Name
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
+   --disable-pager                disables paged output
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+   --json                         the output format will be in json format
+   --local                        allows communicating with the server through a unix socket
+   --quiet                        prevent mmctl to generate output for the commands
+   --strict                       will only run commands if the mmctl version matches the server one
+   --suppress-warnings            disables printing warning messages
+
+mmctl channel remove
+~~~~~~~~~~~~~~~~~~~~
+
+This command is deprecated in favor of :ref:`mmctl channel users remove <administration-guide/manage/mmctl-command-line-tool:mmctl channel users remove>`.
+
+**Description**
+
+Remove a user from a channel.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl channel remove [channel] [users] [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   mmctl channel remove myteam:mychannel user@example.com username
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for remove
 
 **Options inherited from parent commands**
 
@@ -4739,7 +4823,7 @@ Show all the information about a role.
 
 .. code-block:: sh
 
-   mmctl permissions show system_user
+   mmctl permissions role show system_user
 
 **Options**
 


### PR DESCRIPTION
- Add deprecated channel add command with reference to channel users add
- Add deprecated channel remove command with reference to channel users remove
- Fix permissions show example to use correct permissions role show syntax
- Update child commands list to include deprecated commands

Addresses https://github.com/mattermost/docs/issues/8397

🤖 Generated with [Claude Code](https://claude.ai/code)
