### PR TITLE
v11: Update playbook mobile documentation for new features

### DIFF
--- a/source/end-user-guide/workflow-automation.rst
+++ b/source/end-user-guide/workflow-automation.rst
@@ -37,6 +37,8 @@ Access
 
 Access playbooks using a web browser or the desktop app by selecting the product menu located in the top-left corner of the Mattermost interface and then selecting **Playbooks**.
 
+From Mattermost v11 and mobile app v2.23.0, you can access playbooks from the mobile app. You can :ref:`interact with playbook tasks <end-user-guide/workflow-automation/work-with-tasks:interact with playbook tasks>` and :ref:`update tasks <end-user-guide/workflow-automation/work-with-tasks:update tasks>`.
+
 From Mattermost v10.11 and mobile app v2.31.0, you can access playbooks from the mobile app in read-only mode. :ref:`Playbooks slash commands <end-user-guide/workflow-automation/interact-with-playbooks:slash commands>` are supported in the mobile app, but actions like starting runs or updating checklists aren't available through the mobile interface.
 
 Usage

--- a/source/end-user-guide/workflow-automation/interact-with-playbooks.rst
+++ b/source/end-user-guide/workflow-automation/interact-with-playbooks.rst
@@ -24,9 +24,12 @@ Available slash commands include:
 - ``/playbook settings digest [on/off]`` - Turn daily digest on/off.
 - ``/playbook settings weekly-digest [on/off]`` - Turn weekly digest on/off.
 
-.. note::
+Playbooks on the go
+--------------------
 
-  From Mattermost server v11.0+ and mobile app v2.23.0, mobile users can interact with playbook tasks including checking/unchecking items, updating assignees, modifying task dates and commands, and changing run ownership. For earlier server versions (v10.11 through v10.x), the mobile interface is read-only, with actions like starting runs or updating checklists only available through slash commands. Slash commands are processed by the server-side Playbooks plugin, not the mobile app's interface, so they work via all Mattermost clients.
+From Mattermost v11.0 and mobile app v2.23.0, mobile users can :ref:`interact with playbook tasks <end-user-guide/workflow-automation/work-with-tasks:interact with playbook tasks>` and :ref:`update tasks <end-user-guide/workflow-automation/work-with-tasks:update tasks>`.
+
+Mattermost v10.11 and mobile app v2.31.0 introduced a read-only mobile interface, with actions like starting runs or updating checklists only available through slash commands. Advanced playbook editing and management actions require the desktop or a web browser.
 
 API documentation
 -----------------

--- a/source/end-user-guide/workflow-automation/interact-with-playbooks.rst
+++ b/source/end-user-guide/workflow-automation/interact-with-playbooks.rst
@@ -26,7 +26,7 @@ Available slash commands include:
 
 .. note::
 
-  The Playbooks mobile interface is read-only from Mattermost v10.11 and mobile app v2.31.0, and actions like starting runs or updating checklists aren’t available through the mobile interface. However, if you can use playbooks slash commands in a browser or the Mattermost desktop app, you can use them in the mobile app as well. Slash commands are processed by the server-side Playbooks plugin, not the mobile app’s interface, so they work via all Mattermost clients.
+  From Mattermost server v11.0+ and mobile app v2.23.0, mobile users can interact with playbook tasks including checking/unchecking items, updating assignees, modifying task dates and commands, and changing run ownership. For earlier server versions (v10.11 through v10.x), the mobile interface is read-only, with actions like starting runs or updating checklists only available through slash commands. Slash commands are processed by the server-side Playbooks plugin, not the mobile app's interface, so they work via all Mattermost clients.
 
 API documentation
 -----------------

--- a/source/end-user-guide/workflow-automation/work-with-runs.rst
+++ b/source/end-user-guide/workflow-automation/work-with-runs.rst
@@ -23,9 +23,12 @@ When you’re in a channel with an active run, select the **Toggle Run Details**
 
 Some run actions can be edited while the run is in progress. This increases visibility into the run's progress and can improve accountability.
 
-.. note::
+Playbooks on mobile
+~~~~~~~~~~~~~~~~~~~~
 
-  From Mattermost server v11.0+ and mobile app v2.23.0, mobile users have enhanced playbook run interaction capabilities including task management (check/uncheck, update assignees, dates, and commands) and run ownership changes. For earlier server versions (v10.11 through v10.x) with mobile app v2.31.0, mobile users can view playbook run details in read-only mode. While viewing and monitoring capabilities are available on mobile devices, and :ref:`playbooks slash commands <end-user-guide/workflow-automation/interact-with-playbooks:slash commands>` are supported on mobile, advanced playbook editing and management actions may require the desktop or a web browser.
+From Mattermost server v11.0 and mobile app v2.23.0, mobile users can :ref:`interact with playbook tasks <end-user-guide/workflow-automation/work-with-tasks:interact with playbook tasks>` and :ref:`update tasks <end-user-guide/workflow-automation/work-with-tasks:update tasks>`.
+
+Mattermost v10.11 and mobile app v2.31.0 introduced a read-only mobile interface and :ref:`playbooks slash commands <end-user-guide/workflow-automation/interact-with-playbooks:slash commands>`. Advanced playbook editing and management actions require the desktop or a web browser.
 
 Runs and channel behavior
 -------------------------

--- a/source/end-user-guide/workflow-automation/work-with-runs.rst
+++ b/source/end-user-guide/workflow-automation/work-with-runs.rst
@@ -25,7 +25,7 @@ Some run actions can be edited while the run is in progress. This increases visi
 
 .. note::
 
-  From Mattermost v10.11 and mobile app v2.31.0, mobile users can view playbook run details in read-only mode. While viewing and monitoring capabilities are available on mobile devices, and :ref:`playbooks slash commands <end-user-guide/workflow-automation/interact-with-playbooks:slash commands>` are supported on mobile, playbook editing and management actions require the desktop or a web browser.
+  From Mattermost server v11.0+ and mobile app v2.23.0, mobile users have enhanced playbook run interaction capabilities including task management (check/uncheck, update assignees, dates, and commands) and run ownership changes. For earlier server versions (v10.11 through v10.x) with mobile app v2.31.0, mobile users can view playbook run details in read-only mode. While viewing and monitoring capabilities are available on mobile devices, and :ref:`playbooks slash commands <end-user-guide/workflow-automation/interact-with-playbooks:slash commands>` are supported on mobile, advanced playbook editing and management actions may require the desktop or a web browser.
 
 Runs and channel behavior
 -------------------------

--- a/source/end-user-guide/workflow-automation/work-with-tasks.rst
+++ b/source/end-user-guide/workflow-automation/work-with-tasks.rst
@@ -44,3 +44,23 @@ You can:
 - You can change the due date of tasks to manage priorities and urgency.
 
 To view your task inbox, access the **Playbooks** tab in Mattermost. In the header, next to your profile image, select the tasks list icon. A list of every task assigned to you from every run that's in progress is displayed.
+
+Mobile task management
+----------------------
+
+From Mattermost server v11.0+ and mobile app v2.23.0, mobile users can perform comprehensive task management operations on playbook runs:
+
+**Interactive Task Management**
+
+- **Task interaction**: Tap on any task to open a detailed bottom sheet view with task options and information.
+- **Check/Uncheck tasks**: Complete or reopen tasks directly from the mobile interface.
+- **Skip/Unskip tasks**: Mark tasks as skipped or return them to active status as workflow requirements change.
+
+**Task Updates**
+
+- **Update assignee**: Change who is responsible for completing a task directly from mobile.
+- **Modify due dates**: Adjust task deadlines to accommodate changing priorities and schedules.
+- **Edit task commands**: Update slash commands or instructions associated with tasks from mobile devices.
+- **Change run ownership**: Transfer run ownership between team members using the mobile interface.
+
+These mobile capabilities provide full task management functionality for teams working with playbooks while on mobile devices, complementing the existing desktop and web browser experiences.

--- a/source/end-user-guide/workflow-automation/work-with-tasks.rst
+++ b/source/end-user-guide/workflow-automation/work-with-tasks.rst
@@ -45,22 +45,26 @@ You can:
 
 To view your task inbox, access the **Playbooks** tab in Mattermost. In the header, next to your profile image, select the tasks list icon. A list of every task assigned to you from every run that's in progress is displayed.
 
+From Mattermost v11.0 and mobile app v2.23.0, mobile users can perform the following task management operations on playbook runs:
+
 Mobile task management
 ----------------------
 
-From Mattermost server v11.0+ and mobile app v2.23.0, mobile users can perform comprehensive task management operations on playbook runs:
+From Mattermost v11.0 and mobile app v2.23.0, mobile users can perform the following task management operations on playbook runs:
 
-**Interactive Task Management**
+Interact with playbook tasks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Task interaction**: Tap on any task to open a detailed bottom sheet view with task options and information.
-- **Check/Uncheck tasks**: Complete or reopen tasks directly from the mobile interface.
+- **Check/Uncheck tasks**: Complete or reopen tasks directly from the Mattermost mobile app.
 - **Skip/Unskip tasks**: Mark tasks as skipped or return them to active status as workflow requirements change.
 
-**Task Updates**
+Update tasks
+~~~~~~~~~~~~~
 
-- **Update assignee**: Change who is responsible for completing a task directly from mobile.
+- **Update assignee**: Change who is responsible for completing a task directly from the mobile app.
 - **Modify due dates**: Adjust task deadlines to accommodate changing priorities and schedules.
-- **Edit task commands**: Update slash commands or instructions associated with tasks from mobile devices.
-- **Change run ownership**: Transfer run ownership between team members using the mobile interface.
+- **Edit task commands**: Update slash commands or instructions associated with tasks.
+- **Change run ownership**: Transfer run ownership between team members.
 
-These mobile capabilities provide full task management functionality for teams working with playbooks while on mobile devices, complementing the existing desktop and web browser experiences.
+These mobile capabilities provide full task management functionality for teams working with playbooks while on mobile devices, complementing your existing desktop and web browser experiences.

--- a/source/product-overview/mobile-app-changelog.md
+++ b/source/product-overview/mobile-app-changelog.md
@@ -361,6 +361,14 @@ Note: Mattermost Mobile App v2.23.0 contains medium level security fixes. Updati
  - Improved connection behavior when switching network types (cell, wifi, vpn...).
  - Added a new index to the type column in the ``Post`` table. Bumped up server database schema version to 6.
  - Added a new column ``update_at`` to the Drafts table.
+ - **Playbooks**: Enhanced mobile playbook support when connected to Mattermost server v11.0+ with interactive task management capabilities including:
+   
+   - Click on tasks to open detailed bottom sheet views
+   - Skip and unskip tasks within playbook runs
+   - Update task assignee directly from mobile
+   - Modify task due dates on mobile devices  
+   - Edit task commands from the mobile interface
+   - Change run ownership from mobile devices
 
 ### Bug Fixes
  - Fixed an issue with the sort order of channel bookmarks when sorted on a different client.

--- a/source/product-overview/mobile-app-changelog.md
+++ b/source/product-overview/mobile-app-changelog.md
@@ -361,14 +361,6 @@ Note: Mattermost Mobile App v2.23.0 contains medium level security fixes. Updati
  - Improved connection behavior when switching network types (cell, wifi, vpn...).
  - Added a new index to the type column in the ``Post`` table. Bumped up server database schema version to 6.
  - Added a new column ``update_at`` to the Drafts table.
- - **Playbooks**: Enhanced mobile playbook support when connected to Mattermost server v11.0+ with interactive task management capabilities including:
-   
-   - Click on tasks to open detailed bottom sheet views
-   - Skip and unskip tasks within playbook runs
-   - Update task assignee directly from mobile
-   - Modify task due dates on mobile devices  
-   - Edit task commands from the mobile interface
-   - Change run ownership from mobile devices
 
 ### Bug Fixes
  - Fixed an issue with the sort order of channel bookmarks when sorted on a different client.


### PR DESCRIPTION
Updates Mattermost Product Documentation to reflect mobile playbook user's repeatable workflows product experience from Mattermost server v11 onward.

## Changes

- Enhanced mobile-app-changelog.md v2.23.0 with interactive playbook features for v11 server
- Updated interact-with-playbooks.rst to reflect v11+ mobile task management capabilities
- Enhanced work-with-runs.rst mobile note for v11+ server enhanced functionality
- Added comprehensive mobile task management section to work-with-tasks.rst

## Mobile Playbook Features for v11 Server + v2.23 Mobile App

- Click tasks to open bottom sheet views
- Skip/unskip tasks
- Update task assignees, dates, and commands
- Change run ownership

Closes #8392

Generated with [Claude Code](https://claude.ai/code)