### PR TITLE
v11: Consolidate PBKDF2 password security documentation

### DIFF
--- a/source/administration-guide/configure/authentication-configuration-settings.rst
+++ b/source/administration-guide/configure/authentication-configuration-settings.rst
@@ -245,6 +245,10 @@ Password
 
 Access the following configuration settings in the System Console by going to **Authentication > Password**.
 
+.. note::
+
+  **Password Security Enhancement (v11.0+)**: Starting in Mattermost v11.0, password hashing uses PBKDF2 for enhanced security. User passwords are automatically migrated when they log in after upgrading to v11.0+. This migration is progressive and happens transparently when users authenticate.
+
 .. config:setting:: minimum-password-length
   :displayname: Minimum password length (Password)
   :systemconsole: Authentication > Password

--- a/source/administration-guide/configure/authentication-configuration-settings.rst
+++ b/source/administration-guide/configure/authentication-configuration-settings.rst
@@ -247,7 +247,7 @@ Access the following configuration settings in the System Console by going to **
 
 .. note::
 
-  **Password Security Enhancement (v11.0+)**: Starting in Mattermost v11.0, password hashing uses PBKDF2 for enhanced security. User passwords are automatically migrated when they log in after upgrading to v11.0+. This migration is progressive and happens transparently when users authenticate.
+  From Mattermost v11.0, password hashing uses PBKDF2 for enhanced security. User passwords are automatically migrated when they log in after upgrading to v11.0 or later. This migration is progressive and happens transparently when users authenticate.
 
 .. config:setting:: minimum-password-length
   :displayname: Minimum password length (Password)

--- a/source/administration-guide/onboard/connected-workspaces.rst
+++ b/source/administration-guide/onboard/connected-workspaces.rst
@@ -19,7 +19,7 @@ The process of connecting Mattermost workspaces involves the following 5 steps:
 
 2. `Enable the connected workflows functionality <#enable-connected-workflows>`__ for each Mattermost Enterprise instance you want to connect.
 
-3. System admins must `create a secure and trusted connection <#create-a-secure-connection>`__ with other Mattermost Enterprise instances using the System Console or slash commands. This process involves creating a password-protected, encrypted invitation, creating a strong decryption password, then sending the invitation and password to the system admin of a remote Mattermost instance.
+3. System admins must `create a secure and trusted connection <#create-a-secure-connection>`__ with other Mattermost Enterprise instances using the System Console or slash commands. This process involves creating a password-protected, encrypted invitation, creating a strong decryption password, then sending the invitation and password to the system admin of a remote Mattermost instance. From Mattermost v11.0+, remote cluster invitations use PBKDF2 key derivation for enhanced security.
 
 4. When a remote system admin receives the invitation, they must `accept the invitation <#accept-a-secure-connection-invitation>`__ using the System Console or slash commands.
 
@@ -58,7 +58,7 @@ Create a secure connection
     4. Select the **Destination Team** as the default team where shared channels will be added. This team will be used as the default location for organizing shared channels from this connected workspace.
     5. Select **Save**.
 
-    An invitation consisting of a password-protected AES 256-bit encrypted code blob is generated. The connection is labeled as **Connection Pending** until the remote system admin accepts the invitation.
+    An invitation consisting of a password-protected AES 256-bit encrypted code blob is generated. From Mattermost v11.0+, password protection uses PBKDF2 key derivation for enhanced security. The connection is labeled as **Connection Pending** until the remote system admin accepts the invitation.
 
 .. tab:: Slash Commands
 
@@ -72,7 +72,7 @@ Create a secure connection
 
     ``/secure-connection create --name AcmeUS --displayname "AcmeUSA" --password examplepassword``
 
-    This slash command creates an invitation consisting of a password-protected AES 256-bit encrypted code blob for a remote Mattermost entity known locally as ``AcmeUS`` with a password of ``examplepassword``. Within Mattermost, this shared connection displays to the local system admin based on the ``name`` and ``displayname`` provided.
+    This slash command creates an invitation consisting of a password-protected AES 256-bit encrypted code blob for a remote Mattermost entity known locally as ``AcmeUS`` with a password of ``examplepassword``. From Mattermost v11.0+, password protection uses PBKDF2 key derivation for enhanced security. Within Mattermost, this shared connection displays to the local system admin based on the ``name`` and ``displayname`` provided.
 
 Extend the invitation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration-guide/onboard/connected-workspaces.rst
+++ b/source/administration-guide/onboard/connected-workspaces.rst
@@ -19,7 +19,7 @@ The process of connecting Mattermost workspaces involves the following 5 steps:
 
 2. `Enable the connected workflows functionality <#enable-connected-workflows>`__ for each Mattermost Enterprise instance you want to connect.
 
-3. System admins must `create a secure and trusted connection <#create-a-secure-connection>`__ with other Mattermost Enterprise instances using the System Console or slash commands. This process involves creating a password-protected, encrypted invitation, creating a strong decryption password, then sending the invitation and password to the system admin of a remote Mattermost instance. From Mattermost v11.0+, remote cluster invitations use PBKDF2 key derivation for enhanced security.
+3. System admins must `create a secure and trusted connection <#create-a-secure-connection>`__ with other Mattermost Enterprise instances using the System Console or slash commands. This process involves creating a password-protected, encrypted invitation, creating a strong decryption password, then sending the invitation and password to the system admin of a remote Mattermost instance. From Mattermost v11.0, remote cluster invitations use PBKDF2 key derivation for enhanced security.
 
 4. When a remote system admin receives the invitation, they must `accept the invitation <#accept-a-secure-connection-invitation>`__ using the System Console or slash commands.
 
@@ -58,7 +58,7 @@ Create a secure connection
     4. Select the **Destination Team** as the default team where shared channels will be added. This team will be used as the default location for organizing shared channels from this connected workspace.
     5. Select **Save**.
 
-    An invitation consisting of a password-protected AES 256-bit encrypted code blob is generated. From Mattermost v11.0+, password protection uses PBKDF2 key derivation for enhanced security. The connection is labeled as **Connection Pending** until the remote system admin accepts the invitation.
+    An invitation consisting of a password-protected AES 256-bit encrypted code blob is generated. From Mattermost v11.0, password protection uses PBKDF2 key derivation for enhanced security. The connection is labeled as **Connection Pending** until the remote system admin accepts the invitation.
 
 .. tab:: Slash Commands
 
@@ -72,7 +72,7 @@ Create a secure connection
 
     ``/secure-connection create --name AcmeUS --displayname "AcmeUSA" --password examplepassword``
 
-    This slash command creates an invitation consisting of a password-protected AES 256-bit encrypted code blob for a remote Mattermost entity known locally as ``AcmeUS`` with a password of ``examplepassword``. From Mattermost v11.0+, password protection uses PBKDF2 key derivation for enhanced security. Within Mattermost, this shared connection displays to the local system admin based on the ``name`` and ``displayname`` provided.
+    This slash command creates an invitation consisting of a password-protected AES 256-bit encrypted code blob for a remote Mattermost entity known locally as ``AcmeUS`` with a password of ``examplepassword``. From Mattermost v11.0, password protection uses PBKDF2 key derivation for enhanced security. Within Mattermost, this shared connection displays to the local system admin based on the ``name`` and ``displayname`` provided.
 
 Extend the invitation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/end-user-guide/preferences/manage-your-security-preferences.rst
+++ b/source/end-user-guide/preferences/manage-your-security-preferences.rst
@@ -16,6 +16,14 @@ Select your profile picture, select **Profile**, and then select **Security** to
 |                      |                                                                                                            |
 |                      |   If you sign in to Mattermost using a single sign-on service, you must update your password through       |
 |                      |   your SSO service account.                                                                                |
+|                      |                                                                                                            |
+|                      | .. important::                                                                                             |
+|                      |                                                                                                            |
+|                      |   **Mattermost v11.0+ Password Security Enhancement**: Starting in v11.0, Mattermost uses PBKDF2         |
+|                      |   password hashing for improved security. When you log in after your server upgrades to v11.0+,          |
+|                      |   your password will be automatically migrated to the more secure format. If your server is later         |
+|                      |   downgraded to a version prior to v11.0, you may be unable to log in and will need to contact your      |
+|                      |   system administrator for a password reset.                                                               |
 +----------------------+------------------------------------------------------------------------------------------------------------+
 | Multi-factor         | If your system admin has enabled :ref:`multi-factor authentication                                         |
 | authentication (MFA) | <administration-guide/configure/authentication-configuration-settings:enable multi-factor authentication>` |

--- a/source/end-user-guide/preferences/manage-your-security-preferences.rst
+++ b/source/end-user-guide/preferences/manage-your-security-preferences.rst
@@ -12,18 +12,15 @@ Select your profile picture, select **Profile**, and then select **Security** to
 | Password             | You may change your password if you've logged in by email using Mattermost in                              |
 |                      | a web browser or using the desktop app.                                                                    |
 |                      |                                                                                                            |
-|                      | .. note::                                                                                                  |
-|                      |                                                                                                            |
-|                      |   If you sign in to Mattermost using a single sign-on service, you must update your password through       |
-|                      |   your SSO service account.                                                                                |
-|                      |                                                                                                            |
 |                      | .. important::                                                                                             |
 |                      |                                                                                                            |
-|                      |   **Mattermost v11.0+ Password Security Enhancement**: Starting in v11.0, Mattermost uses PBKDF2         |
-|                      |   password hashing for improved security. When you log in after your server upgrades to v11.0+,          |
-|                      |   your password will be automatically migrated to the more secure format. If your server is later         |
-|                      |   downgraded to a version prior to v11.0, you may be unable to log in and will need to contact your      |
-|                      |   system administrator for a password reset.                                                               |
+|                      |   - If you sign in to Mattermost using a single sign-on service, you must update your password through     |
+|                      |     your SSO service account.                                                                              |
+|                      |   - **Password Security Enhancement**: From v11.0, Mattermost uses PBKDF2 password hashing for improved    |
+|                      |     security. When you log in after your server upgrades to v11.0+, your password will be automatically    |
+|                      |     migrated to the more secure format. If your server is later downgraded to a version prior to v11.0,    |
+|                      |     you may be unable to log in and will need to contact your system administrator for a password reset.   |
+|                      |                                                                                                            |
 +----------------------+------------------------------------------------------------------------------------------------------------+
 | Multi-factor         | If your system admin has enabled :ref:`multi-factor authentication                                         |
 | authentication (MFA) | <administration-guide/configure/authentication-configuration-settings:enable multi-factor authentication>` |


### PR DESCRIPTION
- Add PBKDF2 key derivation information to Connected Workspaces remote cluster invitations
- Include end-user password migration warning for downgrade scenarios in security preferences
- Add authentication configuration note about PBKDF2 password security enhancement

Addresses password security improvements per:
- https://github.com/mattermost/mattermost/pull/33830
- https://github.com/mattermost/mattermost/pull/33493
