### PR TITLE
Add missing prerequisite for performance monitoring

### DIFF
--- a/source/administration-guide/scale/collect-performance-metrics.rst
+++ b/source/administration-guide/scale/collect-performance-metrics.rst
@@ -26,6 +26,7 @@ For a self-hosted Mattermost deployment, a Mattermost system admin must perform 
 3. Go to **System Console > Plugins > Plugin Management**. In the **Installed Plugins** section, scroll to **Mattermost Metrics Plugin**, and select **Enable Plugin**.
 4. Specify the path of the time-series database, and select **Save**.
 5. Go to **System Console > Environment > Performance Monitoring**, and set **Enable Performance Monitoring** to **true**. Select **Save**.
+6. Go to **System Console > Environment > Performance Monitoring**, and set **Enable Client Performance Monitoring** to **true**. This setting is required for the system administrator's performance monitoring product experience. Select **Save**.
 
 .. note::
 


### PR DESCRIPTION
Added "Enable Client Performance Monitoring" server configuration setting as a required step for the system administrator's performance monitoring product experience.

Fixes #8437

🤖 Generated with [Claude Code](https://claude.ai/code)