### PR TITLE
Fix dots in environment variables

### DIFF
--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -821,7 +821,7 @@ Enable last active time
   :displayname: Enable custom user groups (Users and Teams)
   :systemconsole: Site Configuration > Users and Teams
   :configjson: ServiceSettings.EnableCustomGroups
-  :environment: MM_SERVICESETTINGS.ENABLECUSTOMGROUPS
+  :environment: MM_SERVICESETTINGS_ENABLECUSTOMGROUPS
   :description: This setting controls whether users with appropriate permissions can create custom user groups, and whether users can @mention custom user groups in Mattermost conversations. Default is **true**.
 
   - **true**: **(Default)** Users with appropriate permissions can create custom user groups, and users can @mention custom user groups in Mattermost conversations.
@@ -833,14 +833,14 @@ Enable custom user groups
 +---------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
 | - **true**: **(Default)** Users with appropriate permissions can create custom user groups,       | - System Config path: **Site Configuration > Users and Teams**                     |
 |   and users can @mention custom user groups in Mattermost conversations.                          | - ``config.json`` setting: ``ServiceSettings`` > ``EnableCustomGroups`` > ``true`` |
-| - **false**: Custom user groups cannot be created.                                                | - Environment variable: ``MM_SERVICESETTINGS.ENABLECUSTOMGROUPS``                  |
+| - **false**: Custom user groups cannot be created.                                                | - Environment variable: ``MM_SERVICESETTINGS_ENABLECUSTOMGROUPS``                  |
 +---------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
 
 .. config:setting:: user-statistics-update-time
   :displayname: User statistics update time (Users and Teams)
   :systemconsole: Site Configuration > Users and Teams
   :configjson: .ServiceSettings.RefreshPostStatsRunTime
-  :environment: MM_SERVICESETTINGS.REFRESHPOSTSTATSRUNTIME
+  :environment: MM_SERVICESETTINGS_REFRESHPOSTSTATSRUNTIME
   :description: Set the server time for updating the user post statistics, including each user's total message count, and the timestamp of each user's most recently sent message. Default is **00:00**.
 
 User statistics update time
@@ -849,7 +849,7 @@ User statistics update time
 +--------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+
 | Set the server time for updating the user post statistics, including each user's total     | - System Config path: **Site Configuration > Users and Teams**                           |
 | message count, and the timestamp of each user's most recently sent message.                | - ``config.json`` setting: ``ServiceSettings`` > ``RefreshPostStatsRunTime`` > ``00:00`` |
-|                                                                                            | - Environment variable: ``MM_SERVICESETTINGS.REFRESHPOSTSTATSRUNTIME``                   |
+|                                                                                            | - Environment variable: ``MM_SERVICESETTINGS_REFRESHPOSTSTATSRUNTIME``                   |
 | Must be a 24-hour time stamp in the form ``HH:MM`` based on the local time of the server.  |                                                                                          |
 | Default is **00:00**.                                                                      |                                                                                          |
 +--------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+
@@ -2088,7 +2088,7 @@ The following self-hosted deployment settings are only configurable in the ``con
   :displayname: Enable cross-team search
   :systemconsole: N/A
   :configjson: ServiceSettings.EnableCrossTeamSearch
-  :environment: SERVICESETTINGS.ENABLECROSSTEAMSEARCH
+  :environment: SERVICESETTINGS_ENABLECROSSTEAMSEARCH
   :description: Disable the ability to search all channels the user is a member of across all teams or a specific team, and search all channels the user is a member of within the current team only. Enabled by default.
 
 Cross-team search


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Some environment variables in the docs were wrong (had a `.` instead of a `_` in it).  
I tested them on v11, and fixed them.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

