### PR TITLE
Added missing redirect to subsection

### DIFF
--- a/source/redirects.py
+++ b/source/redirects.py
@@ -2864,6 +2864,8 @@ redirects_map = {
 # The integrations directory and its contents have been archived in FY23 Q2 and all applicable content has been moved from docs.mm.com to developers.mm.com.
 "integrate/github.html":
         "https://docs.mattermost.com/integrations-guide/github.html",
+"integrate/github-interoperability.html#configuration":
+        "https://docs.mattermost.com/integrations-guide/github.html#mattermost-configuration",
 "integrate/gitlab.html":
         "https://docs.mattermost.com/integrations-guide/gitlab.html",
 "integrate/jira.html":


### PR DESCRIPTION
Partially addresses https://mattermost.atlassian.net/browse/MM-65100. Full fix needs to include updated PL destination URL.