### PR TITLE
Add warning for Outlook365 email configuration

### DIFF
--- a/source/administration-guide/configure/smtp-email.rst
+++ b/source/administration-guide/configure/smtp-email.rst
@@ -25,7 +25,7 @@ Any SMTP email service can be used. You need a copy of the following information
 
     If deploying Mattermost using :doc:`Docker </deployment-guide/server/deploy-containers>`, the standard docker ``172.16.0.0/12`` IP range isn't used. Specify the IP range ``192.168.0.0/24`` to the email service to avoid relay access errors. If using postfix, under ``/etc/postfix/main.cf``, specify ``mynetworks = 192.168.0.0/24``. This may vary depending on how Mattermost is deployed. Ensure that **Port 25** is open if a firewall is present.
 
-.. warning::
+.. note::
 	`Outlook365 no longer supports Basic Auth <https://support.microsoft.com/en-us/office/pop-imap-and-smtp-settings-for-outlook-com-d088b986-291d-42b8-9564-9c414e2aa040>`__ which is required by Mattermost. We recommend using an alternate Email service like AWS SES (Simple Email Service).
 
 Configure SMTP settings


### PR DESCRIPTION
Added warning about Outlook365 not supporting Basic Auth for Mattermost.

