### PR TITLE
Add sitemap exclusions for Playwright test generator, healer, planner, and E2E testing skill

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -496,6 +496,10 @@ sitemap_excludes = [
     "agents/CLAUDE.html",
     "agents/README.html",
     "agents/interpluginclient/README.html",
+    "agents/.claude/agents/playwright-test-generator.html",
+    "agents/.claude/agents/playwright-test-healer.html",
+    "agents/.claude/agents/playwright-test-planner.html",
+    "agents/.claude/skills/e2e-testing-skill/SKILL.html",
 ]
 
 # -- Page redirects -------------------------------------------------


### PR DESCRIPTION
agents repo content is causing issues with the sitemap again. this pr fixes it.