### PR TITLE
v11.4: Added debug log to indicate the job is not running as the node is not a leader node

### DIFF
--- a/source/administration-guide/configure/experimental-configuration-settings.rst
+++ b/source/administration-guide/configure/experimental-configuration-settings.rst
@@ -1813,7 +1813,7 @@ When running Mattermost in :doc:`High Availablity mode </administration-guide/sc
 
 .. tip::
 
-   From Mattermost v11.4, debug-level log messages are available to help verify that cluster job execution is working correctly. Non-leader nodes log messages when they skip job execution, confirming that leader election is functioning as expected. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for details.
+   From Mattermost v11.4, debug-level log messages are available to help verify that specific Recurring Tasks (Scheduled Posts, Post Reminders, and DND Status Reset) are executing correctly in a cluster. Non-leader nodes log messages when they skip execution of these Recurring Tasks, confirming that leader election is functioning as expected. These debug messages do not apply to other job types such as Elasticsearch indexing, SAML sync, or LDAP sync. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for details.
 
 +-----------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"RunScheduler": true`` with options ``true`` and ``false``.                                 |

--- a/source/administration-guide/configure/experimental-configuration-settings.rst
+++ b/source/administration-guide/configure/experimental-configuration-settings.rst
@@ -1811,6 +1811,10 @@ When running Mattermost in :doc:`High Availablity mode </administration-guide/sc
 
    We strongly recommend that you not change this setting from the default setting of ``true`` as this prevents the ``ClusterLeader`` from being able to run the scheduler. As a result, recurring jobs such as LDAP sync, Compliance Export, and data retention will no longer be scheduled. In previous Mattermost Server versions, and this documentation, the instructions stated to run the Job Server with ``RunScheduler: false``. The cluster design has evolved and this is no longer the case.
 
+.. tip::
+
+   From Mattermost v11.4, debug-level log messages are available to help verify that cluster job execution is working correctly. Non-leader nodes log messages when they skip job execution, confirming that leader election is functioning as expected. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for details.
+
 +-----------------------------------------------------------------------------------------------------------------------------------------+
 | This feature's ``config.json`` setting is ``"RunScheduler": true`` with options ``true`` and ``false``.                                 |
 +-----------------------------------------------------------------------------------------------------------------------------------------+

--- a/source/administration-guide/configure/manage-user-surveys.rst
+++ b/source/administration-guide/configure/manage-user-surveys.rst
@@ -10,7 +10,7 @@ All user responses are stored in and remain within your self-hosted deployment, 
 
 .. important::
 
-The User Satisfaction Survey Plugin is the recommended approach for gathering user feedback, replacing the deprecated :doc:`User Satisfaction Survey Plugin </administration-guide/manage/user-satisfaction-surveys>` for new deployments. 
+  The User Satisfaction Survey Plugin is the recommended approach for gathering user feedback, replacing the deprecated :doc:`User Satisfaction Survey Plugin </administration-guide/manage/user-satisfaction-surveys>` for new deployments. 
 
 Setup
 ------
@@ -22,11 +22,7 @@ The User Survey integration is compatible with Mattermost v9.11.2 or later.
 Install
 --------
 
-
-
-.. note::
-
-  From Mattermost v9.11.2 (ESR) and Mattermost Cloud v10, this plugin is pre-packaged with the Mattermost Server. If your Mattermost deployment is on a release prior to v9.11.2, download the `latest plugin binary release <https://github.com/mattermost/mattermost-plugin-user-survey/releases>`_, and upload it to your server via **System Console > Plugin Management**.
+From Mattermost v9.11.2 (ESR) and Mattermost Cloud v10, this plugin is pre-packaged with the Mattermost Server. If your Mattermost deployment is on a prior release, download the `latest plugin binary release <https://github.com/mattermost/mattermost-plugin-user-survey/releases>`_, and upload it to your server via **System Console > Plugin Management**.
 
 Upgrade
 ~~~~~~~

--- a/source/administration-guide/manage/logging.rst
+++ b/source/administration-guide/manage/logging.rst
@@ -435,7 +435,6 @@ Define advanced log output
             }
         }
 
-
     v10.12 or earlier
     ^^^^^^^^^^^^^^^^^^
 
@@ -707,7 +706,7 @@ Cluster job execution debug messages
 .. include:: ../../_static/badges/ent-plus.rst
   :start-after: :nosearch:
 
-From Mattermost v11.4, debug-level log messages are available to help system admins understand cluster job execution behavior in high availability deployments for specific Recurring Tasks.
+From Mattermost v11.4, debug-level log messages are available to help system admins understand cluster job execution behavior in :doc:`high availability </administration-guide/scale/high-availability-cluster-based-deployment>` deployments for specific Recurring Tasks.
 
 These debug messages apply only to the following Recurring Tasks:
 
@@ -717,13 +716,9 @@ These debug messages apply only to the following Recurring Tasks:
 
 .. important::
 
-  These debug messages are **not** available for other job types such as Elasticsearch indexing, SAML sync, LDAP sync, data retention, or compliance exports. The absence of these debug messages for other job types does not indicate a problem with job execution.
-
-In a cluster deployment, only the leader node executes these Recurring Tasks. Non-leader nodes skip these specific jobs and log debug messages to indicate this is expected behavior.
-
-.. note::
-
-  These messages are only visible when debug logging is enabled. See `How do I enable debug logging? <#how-do-i-enable-debug-logging>`__ for details.
+  - These debug messages aren't available for other job types such as Elasticsearch indexing, SAML sync, LDAP sync, data retention, or compliance exports. The absence of these debug messages for other job types doesn't indicate a problem with job execution.
+  - These messages are only visible when debug logging is enabled. See `How do I enable debug logging? <#how-do-i-enable-debug-logging>`__ for details.
+  - In a cluster deployment, only the leader node executes these Recurring Tasks. Non-leader nodes skip these specific jobs and log debug messages to indicate this is expected behavior.
 
 Debug messages for job startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -752,10 +747,10 @@ Troubleshooting with cluster job debug messages
 
 If you're investigating why Recurring Tasks (Scheduled Posts, Post Reminders, or DND Status Reset) aren't running on a specific node:
 
-1. Enable debug logging if not already enabled
-2. Check the logs for the debug messages listed above
-3. If you see these messages, the node is correctly identified as a non-leader and is behaving as expected
-4. These Recurring Tasks will be running on the leader node instead
+1. Enable debug logging if not already enabled.
+2. Check the logs for the debug messages listed above.
+3. If you see these messages, the node is correctly identified as a non-leader and is behaving as expected.
+4. These Recurring Tasks will be running on the leader node instead.
 
 .. note::
 

--- a/source/administration-guide/manage/logging.rst
+++ b/source/administration-guide/manage/logging.rst
@@ -701,6 +701,56 @@ The TCP socket targets can be configured with an IP address or domain name, port
 
 ---- 
 
+Cluster job execution debug messages
+-------------------------------------
+
+.. include:: ../../_static/badges/ent-plus.rst
+  :start-after: :nosearch:
+
+From Mattermost v11.4, debug-level log messages are available to help system admins understand cluster job execution behavior in high availability deployments.
+
+In a cluster deployment, only the leader node executes scheduled jobs such as scheduled posts, DND status reset, and post reminders. Non-leader nodes skip these jobs and log debug messages to indicate this is expected behavior.
+
+.. note::
+
+  These messages are only visible when debug logging is enabled. See `How do I enable debug logging? <#how-do-i-enable-debug-logging>`__ for details.
+
+Debug messages for job startup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a non-leader node starts up, it skips job initialization and logs one of the following debug messages:
+
+- ``Skipping scheduled posts job startup since this is not the leader node``
+- ``Skipping unset DND status job startup since this is not the leader node``
+- ``Skipping post reminder job startup since this is not the leader node``
+
+These messages indicate normal operation. In a high availability cluster, jobs should only run on the leader node to prevent duplicate execution.
+
+Debug messages for leadership changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a node loses leadership status while jobs are running, it cancels the running jobs and logs:
+
+- ``This is no longer leader node. Cancelling the [job name] task``
+
+Where ``[job name]`` is one of: ``scheduled posts``, ``DND status reset``, or ``post reminder``.
+
+This indicates the cluster is performing leader election correctly. The new leader node will take over job execution.
+
+Troubleshooting with cluster job debug messages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you're investigating why jobs aren't running on a specific node:
+
+1. Enable debug logging if not already enabled
+2. Check the logs for the debug messages listed above
+3. If you see these messages, the node is correctly identified as a non-leader and is behaving as expected
+4. Jobs will be running on the leader node instead
+
+For more information about leader election and cluster configuration, see :doc:`High Availability cluster-based deployment </administration-guide/scale/high-availability-cluster-based-deployment>`.
+
+----
+
 Frequently asked questions
 --------------------------
 

--- a/source/administration-guide/manage/logging.rst
+++ b/source/administration-guide/manage/logging.rst
@@ -707,9 +707,19 @@ Cluster job execution debug messages
 .. include:: ../../_static/badges/ent-plus.rst
   :start-after: :nosearch:
 
-From Mattermost v11.4, debug-level log messages are available to help system admins understand cluster job execution behavior in high availability deployments.
+From Mattermost v11.4, debug-level log messages are available to help system admins understand cluster job execution behavior in high availability deployments for specific Recurring Tasks.
 
-In a cluster deployment, only the leader node executes scheduled jobs such as scheduled posts, DND status reset, and post reminders. Non-leader nodes skip these jobs and log debug messages to indicate this is expected behavior.
+These debug messages apply only to the following Recurring Tasks:
+
+- Scheduled Posts
+- Post Reminders
+- DND Status Reset
+
+.. important::
+
+  These debug messages are **not** available for other job types such as Elasticsearch indexing, SAML sync, LDAP sync, data retention, or compliance exports. The absence of these debug messages for other job types does not indicate a problem with job execution.
+
+In a cluster deployment, only the leader node executes these Recurring Tasks. Non-leader nodes skip these specific jobs and log debug messages to indicate this is expected behavior.
 
 .. note::
 
@@ -718,34 +728,38 @@ In a cluster deployment, only the leader node executes scheduled jobs such as sc
 Debug messages for job startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a non-leader node starts up, it skips job initialization and logs one of the following debug messages:
+When a non-leader node starts up, it skips initialization for these specific Recurring Tasks and logs one of the following debug messages:
 
 - ``Skipping scheduled posts job startup since this is not the leader node``
 - ``Skipping unset DND status job startup since this is not the leader node``
 - ``Skipping post reminder job startup since this is not the leader node``
 
-These messages indicate normal operation. In a high availability cluster, jobs should only run on the leader node to prevent duplicate execution.
+These messages indicate normal operation. In a high availability cluster, these Recurring Tasks should only run on the leader node to prevent duplicate execution.
 
 Debug messages for leadership changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a node loses leadership status while jobs are running, it cancels the running jobs and logs:
+When a node loses leadership status while these Recurring Tasks are running, it cancels the running tasks and logs:
 
 - ``This is no longer leader node. Cancelling the [job name] task``
 
 Where ``[job name]`` is one of: ``scheduled posts``, ``DND status reset``, or ``post reminder``.
 
-This indicates the cluster is performing leader election correctly. The new leader node will take over job execution.
+This indicates the cluster is performing leader election correctly. The new leader node will take over execution of these Recurring Tasks.
 
 Troubleshooting with cluster job debug messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you're investigating why jobs aren't running on a specific node:
+If you're investigating why Recurring Tasks (Scheduled Posts, Post Reminders, or DND Status Reset) aren't running on a specific node:
 
 1. Enable debug logging if not already enabled
 2. Check the logs for the debug messages listed above
 3. If you see these messages, the node is correctly identified as a non-leader and is behaving as expected
-4. Jobs will be running on the leader node instead
+4. These Recurring Tasks will be running on the leader node instead
+
+.. note::
+
+  These debug messages only apply to Recurring Tasks. For other job types (Elasticsearch indexing, SAML sync, LDAP sync, data retention, compliance exports), different logging mechanisms apply. The absence of these specific debug messages for other job types is expected and does not indicate a problem.
 
 For more information about leader election and cluster configuration, see :doc:`High Availability cluster-based deployment </administration-guide/scale/high-availability-cluster-based-deployment>`.
 

--- a/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
+++ b/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
@@ -452,7 +452,7 @@ The process is based on a widely used `bully leader election algorithm <https://
 
 .. note::
 
-  From Mattermost v11.4, debug-level log messages help identify which node is executing cluster jobs. Non-leader nodes log messages like "Skipping scheduled posts job startup since this is not the leader node" to indicate they are correctly deferring job execution to the leader. These are normal operational messages, not errors. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for details.
+  From Mattermost v11.4, debug-level log messages help identify which node is executing specific Recurring Tasks (Scheduled Posts, Post Reminders, and DND Status Reset). Non-leader nodes log messages like "Skipping scheduled posts job startup since this is not the leader node" to indicate they are correctly deferring execution of these Recurring Tasks to the leader. These are normal operational messages, not errors. These debug messages do not apply to other job types such as Elasticsearch indexing, SAML sync, or LDAP sync. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for details.
 
 Job server
 ^^^^^^^^^^^
@@ -475,7 +475,7 @@ Make sure you have set ``JobSettings.RunScheduler`` to ``true`` in ``config.json
 
 .. tip::
 
-  From Mattermost v11.4, you can verify that jobs are running on the correct node by enabling debug logging. Non-leader nodes will log messages indicating they are skipping job execution, which is expected behavior. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for more information.
+  From Mattermost v11.4, you can verify that Recurring Tasks (Scheduled Posts, Post Reminders, and DND Status Reset) are running on the correct node by enabling debug logging. Non-leader nodes will log messages indicating they are skipping execution of these specific Recurring Tasks, which is expected behavior. These debug messages do not apply to other job types. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for more information.
 
 In previous Mattermost Server versions, and this documentation, the instructions stated to run the Job Server with ``RunScheduler: false``. The cluster design has evolved and this is no longer the case.
 

--- a/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
+++ b/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
@@ -452,7 +452,7 @@ The process is based on a widely used `bully leader election algorithm <https://
 
 .. note::
 
-  From Mattermost v11.4, debug-level log messages help identify which node is executing specific Recurring Tasks (Scheduled Posts, Post Reminders, and DND Status Reset). Non-leader nodes log messages like "Skipping scheduled posts job startup since this is not the leader node" to indicate they are correctly deferring execution of these Recurring Tasks to the leader. These are normal operational messages, not errors. These debug messages do not apply to other job types such as Elasticsearch indexing, SAML sync, or LDAP sync. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for details.
+  From Mattermost v11.4, debug-level log messages help identify which node is executing specific Recurring Tasks (Scheduled Posts, Post Reminders, and DND Status Reset). Non-leader nodes log messages like ``Skipping scheduled posts job startup since this is not the leader node`` to indicate they are correctly deferring execution of these Recurring Tasks to the leader. These are normal operational messages, not errors. These debug messages do not apply to other job types such as Elasticsearch indexing, SAML sync, or LDAP sync. See :ref:`Cluster job execution debug messages <administration-guide/manage/logging:cluster job execution debug messages>` for details.
 
 Job server
 ^^^^^^^^^^^
@@ -471,13 +471,8 @@ Make sure you have set ``JobSettings.RunScheduler`` to ``true`` in ``config.json
 
 .. note::
 
-  It is strongly recommended not to change this setting from the default setting of ``true`` as this prevents the ``ClusterLeader`` from being able to run the scheduler. As a result, recurring jobs such as LDAP sync, Compliance Export, and data retention will no longer be scheduled.
-
-.. tip::
-
-  From Mattermost v11.4, you can verify that Recurring Tasks (Scheduled Posts, Post Reminders, and DND Status Reset) are running on the correct node by enabling debug logging. Non-leader nodes will log messages indicating they are skipping execution of these specific Recurring Tasks, which is expected behavior. These debug messages do not apply to other job types. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for more information.
-
-In previous Mattermost Server versions, and this documentation, the instructions stated to run the Job Server with ``RunScheduler: false``. The cluster design has evolved and this is no longer the case.
+  - We strongly recommend not changing this setting from the default setting of ``true`` as this prevents the ``ClusterLeader`` from being able to run the scheduler. As a result, recurring jobs such as LDAP sync, Compliance Export, and data retention will no longer be scheduled. In previous Mattermost Server versions, and this documentation, the instructions stated to run the Job Server with ``RunScheduler: false``. The cluster design has evolved and this is no longer the case.
+  - From Mattermost v11.4, you can verify that Recurring Tasks (Scheduled Posts, Post Reminders, and DND Status Reset) are running on the correct node by enabling debug logging. Non-leader nodes will log messages indicating they are skipping execution of these specific Recurring Tasks, which is expected behavior. These debug messages don't apply to other job types. See :ref:`Cluster job execution debug messages <administration-guide/manage/logging:cluster job execution debug messages>` for more information.
 
 Plugins and High Availability
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
+++ b/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
@@ -450,6 +450,10 @@ A cluster leader election process assigns any scheduled task such as LDAP sync t
 
 The process is based on a widely used `bully leader election algorithm <https://en.wikipedia.org/wiki/Bully_algorithm>`__ where the process with the lowest node ID number from amongst the non-failed processes is selected as the leader.
 
+.. note::
+
+  From Mattermost v11.4, debug-level log messages help identify which node is executing cluster jobs. Non-leader nodes log messages like "Skipping scheduled posts job startup since this is not the leader node" to indicate they are correctly deferring job execution to the leader. These are normal operational messages, not errors. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for details.
+
 Job server
 ^^^^^^^^^^^
 
@@ -459,12 +463,19 @@ Mattermost runs periodic tasks via the :ref:`job server <administration-guide/co
 - Data retention
 - Compliance exports
 - Elasticsearch indexing
+- Scheduled posts
+- DND status reset
+- Post reminders
 
 Make sure you have set ``JobSettings.RunScheduler`` to ``true`` in ``config.json`` for all app and job servers in the cluster. The cluster leader will then be responsible for scheduling recurring jobs.
 
 .. note::
 
   It is strongly recommended not to change this setting from the default setting of ``true`` as this prevents the ``ClusterLeader`` from being able to run the scheduler. As a result, recurring jobs such as LDAP sync, Compliance Export, and data retention will no longer be scheduled.
+
+.. tip::
+
+  From Mattermost v11.4, you can verify that jobs are running on the correct node by enabling debug logging. Non-leader nodes will log messages indicating they are skipping job execution, which is expected behavior. See :doc:`Cluster job execution debug messages </administration-guide/manage/logging>` for more information.
 
 In previous Mattermost Server versions, and this documentation, the instructions stated to run the Job Server with ``RunScheduler: false``. The cluster design has evolved and this is no longer the case.
 


### PR DESCRIPTION
## Summary

Adds documentation for new debug log messages introduced in Mattermost v11.4.0 that help system admins understand cluster job execution behavior in high availability deployments.

## Changes

- Added new section in logging documentation for cluster job execution debug messages
- Updated high availability cluster documentation with references to debug messages
- Added tips in job configuration settings about verifying cluster behavior

These DEBUG-level messages indicate normal operation when non-leader nodes skip job execution, helping admins troubleshoot cluster behavior.

Resolves #8706

Generated with [Claude Code](https://claude.ai/code)