### PR TITLE
Channel Summarization - header icon pluggable + citation support

### DIFF
--- a/source/_generated/agents/docs/user_guide.md
+++ b/source/_generated/agents/docs/user_guide.md
@@ -77,7 +77,7 @@ To summarize unread Mattermost channels:
 2. Select **Ask AI**.
 3. Select **Summarize new messages**. 
 
-The channel summary is generated in the Agents pane, and only you can view the summary.
+The channel summary is generated in the Agents pane, and only you can view the summary. Channel summaries include citation links that reference specific messages from the channel. Select a citation link to open a popover preview of the referenced message without navigating away from the channel.
 
 ## Search with AI
 

--- a/source/integrations-guide/plugins.rst
+++ b/source/integrations-guide/plugins.rst
@@ -29,4 +29,6 @@ Building a custom plugin for your self-hosted deployment is a **software develop
 
 Plugins can authenticate and interact with Mattermost through `bot accounts <https://developers.mattermost.com/integrate/reference/bot-accounts/>`_, utilizing the `RESTful API <https://developers.mattermost.com/api-documentation/>`_.
 
+From Mattermost v11.5, plugins can register a Channel Header Icon component that places an icon next to the **Files** button in the channel header. This pluggable location is designed for channel-level actions such as custom workflows, analysis, or summarization tools.
+
 Learn more about `building your own plugin <https://developers.mattermost.com/integrate/plugins/>`_.


### PR DESCRIPTION
Document two new features from Mattermost server v11.5 (engineering PR #34687):

- Citation-style links in AI channel summaries: clicking a citation opens a popover preview of the referenced message inline
- Channel Header Icon pluggable location: plugins can now place an icon next to the Files button in the channel header for channel-level actions

Closes #8777

Generated with [Claude Code](https://claude.ai/code)