### PR TITLE
Add distinct archive icon for private channels

### DIFF
--- a/source/end-user-guide/collaborate/archive-unarchive-channels.rst
+++ b/source/end-user-guide/collaborate/archive-unarchive-channels.rst
@@ -53,7 +53,7 @@ Delete :ref:`public channels <end-user-guide/collaborate/channel-types:public ch
 
 .. note::
 
-  - When a Mattermost user is deactivated in the system, your :ref:`direct message channel <end-user-guide/collaborate/channel-types:direct message channels>` with that user are archived and marked as read-only. An **Archived** icon |file-box| displays next to archived channels.
+  - When a Mattermost user is deactivated in the system, your :ref:`direct message channel <end-user-guide/collaborate/channel-types:direct message channels>` with that user are archived and marked as read-only. An **Archived** icon |file-box| displays next to archived channels. From Mattermost v11.5, archived private channels display a distinct **Archive Lock** icon to differentiate them from other archived channels.
   - :ref:`Group message channels <end-user-guide/collaborate/channel-types:group message channels>` can't be archived, but they can be closed to hide them from the channel sidebar.
   - The default **Town Square** channel can't be archived.
   - System admins can archive channels without needing to be a channel member by using the System Console.

--- a/source/end-user-guide/collaborate/channel-types.rst
+++ b/source/end-user-guide/collaborate/channel-types.rst
@@ -65,6 +65,6 @@ Want to have a group conversation with more than 7 people? :doc:`Create a privat
 Archived channels
 -----------------
 
-Archived channels are deactivated public, private, direct message, or group message channels that are no longer used. Archived channels are identified with a **File Box** |file-box| icon. 
+Archived channels are deactivated public, private, direct message, or group message channels that are no longer used. Archived channels are identified with a **File Box** |file-box| icon. From Mattermost v11.5, archived private channels are identified with a distinct **Archive Lock** icon to visually differentiate them from archived public channels.
 
 :ref:`Archiving a channel <end-user-guide/collaborate/archive-unarchive-channels:archive a channel>` marks it read-only to prevent new messages from being sent and preserve channel history. You can continue to access archived channels, unless your system admin has :ref:`disabled <administration-guide/configure/site-configuration-settings:allow users to view archived channels>` your ability to do so.


### PR DESCRIPTION
From Mattermost v11.5, archived private channels display a distinct Archive Lock icon, differentiating them from archived public channels. This PR updates the channel types and archive/unarchive channels pages to reflect this UI change.

Resolves #8779

Generated with [Claude Code](https://claude.ai/code)