### PR TITLE
Add back offline user help for messagging

### DIFF
--- a/source/end-user-guide/collaborate/channel-types.rst
+++ b/source/end-user-guide/collaborate/channel-types.rst
@@ -46,7 +46,7 @@ Direct messages update the numbered badge count and trigger a notification unles
 
 .. note::
 
-  - From Mattermost v10, when sending a direct message, Mattermost warns you that the recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>`, and when the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field. From Mattermost v11.5, this warning also displays when the recipient's availability is set to :ref:`Offline <end-user-guide/preferences/set-your-status-availability:set your availability>`.
+  - From Mattermost v10, when sending a direct message, Mattermost warns you that the recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>`, and when the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field.
   - When a Mattermost user is deactivated in the system, your :ref:`direct message channel <end-user-guide/collaborate/channel-types:direct message channels>` with that user are `archived <#archived-channels>`__ and marked as read-only. An **Archived** icon |file-box| displays next to archived channels.
 
 Group message channels

--- a/source/end-user-guide/collaborate/channel-types.rst
+++ b/source/end-user-guide/collaborate/channel-types.rst
@@ -46,7 +46,7 @@ Direct messages update the numbered badge count and trigger a notification unles
 
 .. note::
 
-  - From Mattermost v10, when sending a direct message, Mattermost warns you that the recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>`, and when the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field.
+  - From Mattermost v10, when sending a direct message, Mattermost warns you that the recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>`, and when the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field. From Mattermost v11.5, this warning also displays when the recipient's availability is set to :ref:`Offline <end-user-guide/preferences/set-your-status-availability:set your availability>`.
   - When a Mattermost user is deactivated in the system, your :ref:`direct message channel <end-user-guide/collaborate/channel-types:direct message channels>` with that user are `archived <#archived-channels>`__ and marked as read-only. An **Archived** icon |file-box| displays next to archived channels.
 
 Group message channels

--- a/source/end-user-guide/collaborate/send-messages.rst
+++ b/source/end-user-guide/collaborate/send-messages.rst
@@ -6,7 +6,7 @@ Send messages
 
 You can send messages in public and private channels as well as to other users in Mattermost. Depending on when you compose a message, you can send it immediately, :doc:`schedule it for later </end-user-guide/collaborate/schedule-messages>`, or :doc:`set its priority </end-user-guide/collaborate/message-priority>`. 
 
-Mattermost may notify you when a recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>`, and the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field.
+Mattermost may notify you when a recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>` or :ref:`Offline <end-user-guide/preferences/set-your-status-availability:set your availability>`, and when the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field.
 
 .. tab:: Web/Desktop
 

--- a/source/end-user-guide/collaborate/send-messages.rst
+++ b/source/end-user-guide/collaborate/send-messages.rst
@@ -10,7 +10,7 @@ Mattermost may notify you when a recipient's availability is set to :ref:`Do Not
 
 .. note::
 
-  From Mattermost v11.5, you can access Mattermost help resources by selecting the **Help** button in the message text field, even when your client is offline.
+  From Mattermost v11.5, you can access help resources for message formatting by selecting the **Help** link below the message text field.
 
 .. tab:: Web/Desktop
 

--- a/source/end-user-guide/collaborate/send-messages.rst
+++ b/source/end-user-guide/collaborate/send-messages.rst
@@ -6,7 +6,11 @@ Send messages
 
 You can send messages in public and private channels as well as to other users in Mattermost. Depending on when you compose a message, you can send it immediately, :doc:`schedule it for later </end-user-guide/collaborate/schedule-messages>`, or :doc:`set its priority </end-user-guide/collaborate/message-priority>`. 
 
-Mattermost may notify you when a recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>` or :ref:`Offline <end-user-guide/preferences/set-your-status-availability:set your availability>`, and when the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field.
+Mattermost may notify you when a recipient's availability is set to :ref:`Do Not Disturb <end-user-guide/preferences/set-your-status-availability:set your availability>`, and the recipient's local time is outside of regular business hours (between 10PM and 6AM). This warning displays directly above the message text field.
+
+.. note::
+
+  From Mattermost v11.5, you can access Mattermost help resources by selecting the **Help** button in the message text field, even when your client is offline.
 
 .. tab:: Web/Desktop
 


### PR DESCRIPTION
From Mattermost v11.5, Mattermost displays a warning above the message text field when a direct message recipient's availability is set to Offline, consistent with the existing Do Not Disturb and out-of-hours warnings.

Updates:
- `send-messages.rst`: extend notification sentence to include Offline status
- `channel-types.rst`: add v11.5 note for Offline recipient warning

Closes #8780

Generated with [Claude Code](https://claude.ai/code)