### PR TITLE
Add mmctl license get command

### DIFF
--- a/source/administration-guide/manage/mmctl-command-line-tool.rst
+++ b/source/administration-guide/manage/mmctl-command-line-tool.rst
@@ -4610,6 +4610,7 @@ mmctl license
 Manage the Mattermost license.
 
    Child Commands
+      -  `mmctl license get`_ - Get the current license
       -  `mmctl license remove`_ - Remove the current license
       -  `mmctl license upload`_ - Upload a new license
       -  `mmctl license upload-string`_ - Upload a license from a string
@@ -4619,6 +4620,45 @@ Manage the Mattermost license.
 .. code-block:: sh
 
    -h, --help   help for license
+
+mmctl license get
+~~~~~~~~~~~~~~~~~
+
+**Description**
+
+Get the current Mattermost license.
+
+**Format**
+
+.. code-block:: sh
+
+   mmctl license get [flags]
+
+**Examples**
+
+.. code-block:: sh
+
+   mmctl license get
+
+**Options**
+
+.. code-block:: sh
+
+   -h, --help   help for get
+
+**Options inherited from parent commands**
+
+.. code-block:: sh
+
+   --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
+   --disable-pager                disables paged output
+   --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+   --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+   --json                         the output format will be in json format
+   --local                        allows communicating with the server through a unix socket
+   --quiet                        prevent mmctl to generate output for the commands
+   --strict                       will only run commands if the mmctl version matches the server one
+   --suppress-warnings            disables printing warning messages
 
 mmctl license remove
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Documents the new `mmctl license get` command available from Mattermost server v11.5 onward.

Adds the command to the mmctl command reference page following existing style and formatting conventions.

Closes #8782

Generated with [Claude Code](https://claude.ai/code)