### PR TITLE
Add audit logging for recap API endpoints

### DIFF
--- a/source/administration-guide/comply/embedded-json-audit-log-schema.rst
+++ b/source/administration-guide/comply/embedded-json-audit-log-schema.rst
@@ -911,6 +911,8 @@ Local Operations Events
 AI Recap Events
 ~~~~~~~~~~~~~~~
 
+Recap events include a ``channel_id`` in the event parameters, indicating which channel's content was accessed during the recap operation. Use this field when reviewing audit logs for compliance or access monitoring.
+
 +---------------------+-------------------------------------------------------------------+
 | **Event Name**      | **Description**                                                   |
 +=====================+===================================================================+
@@ -926,9 +928,6 @@ AI Recap Events
 +---------------------+-------------------------------------------------------------------+
 | ``regenerateRecap`` | Regenerating channel recaps                                       |
 +---------------------+-------------------------------------------------------------------+
-
-.. note::
-   Recap events include a ``channel_id`` in the event parameters, indicating which channel's content was accessed during the recap operation. Use this field when reviewing audit logs for compliance or access monitoring.
 
 .. note::
    This comprehensive list includes all audit events captured by Mattermost across all major system operations. Additional events may be logged depending on your Mattermost version, enabled features, and configuration settings. Enterprise and Enterprise Advanced features may generate additional audit events.

--- a/source/administration-guide/comply/embedded-json-audit-log-schema.rst
+++ b/source/administration-guide/comply/embedded-json-audit-log-schema.rst
@@ -908,6 +908,28 @@ Local Operations Events
 | ``localUpdateConfig``            | Local configuration update                                        |
 +----------------------------------+-------------------------------------------------------------------+
 
+AI Recap Events
+~~~~~~~~~~~~~~~
+
++---------------------+-------------------------------------------------------------------+
+| **Event Name**      | **Description**                                                   |
++=====================+===================================================================+
+| ``createRecap``     | Creating channel recaps                                           |
++---------------------+-------------------------------------------------------------------+
+| ``deleteRecap``     | Deleting channel recaps                                           |
++---------------------+-------------------------------------------------------------------+
+| ``getRecap``        | Retrieving channel recaps                                         |
++---------------------+-------------------------------------------------------------------+
+| ``getRecaps``       | Retrieving multiple channel recaps                                |
++---------------------+-------------------------------------------------------------------+
+| ``markRecapAsRead`` | Marking channel recaps as read                                    |
++---------------------+-------------------------------------------------------------------+
+| ``regenerateRecap`` | Regenerating channel recaps                                       |
++---------------------+-------------------------------------------------------------------+
+
+.. note::
+   Recap events include a ``channel_id`` in the event parameters, indicating which channel's content was accessed during the recap operation. Use this field when reviewing audit logs for compliance or access monitoring.
+
 .. note::
    This comprehensive list includes all audit events captured by Mattermost across all major system operations. Additional events may be logged depending on your Mattermost version, enabled features, and configuration settings. Enterprise and Enterprise Advanced features may generate additional audit events.
 


### PR DESCRIPTION
Documents the six new recap audit events (createRecap, getRecap, getRecaps, markRecapAsRead, regenerateRecap, deleteRecap) introduced in Mattermost server v11.5, including a note about the channel_id field for compliance and access monitoring use cases.

Closes #8783

Generated with [Claude Code](https://claude.ai/code)