### PR TITLE
Include some thread context in AI Rewrites prompt

### DIFF
--- a/source/end-user-guide/collaborate/send-messages.rst
+++ b/source/end-user-guide/collaborate/send-messages.rst
@@ -64,6 +64,8 @@ From Mattermost v11.2, you can use AI to enhance your messages before sending th
 
   Messages that have been rewritten using AI are automatically marked as AI-generated content for transparency. Your system admin must :doc:`configure AI agents </administration-guide/configure/agents-admin-guide>` for the rewrite feature to be available.
 
+  From Mattermost v11.5, when you use AI Rewrite while composing a reply in a thread, the AI incorporates context from the thread to generate suggestions that better fit the ongoing conversation.
+
 Send burn-on-read messages
 ---------------------------
 

--- a/source/end-user-guide/collaborate/send-messages.rst
+++ b/source/end-user-guide/collaborate/send-messages.rst
@@ -36,7 +36,9 @@ Mattermost may notify you when a recipient's availability is set to :ref:`Do Not
 Rewrite messages with AI
 -------------------------
 
-From Mattermost v11.2, you can use AI to enhance your messages before sending them. This feature helps you improve writing quality, fix spelling, adjust message length, or transform your text based on specific needs.
+You can use AI to enhance your messages before sending them. This feature helps you improve writing quality, fix spelling, adjust message length, or transform your text based on specific needs.
+
+From Mattermost v11.5, when you use AI Rewrite while composing a reply in a thread, the AI incorporates context from the thread to generate suggestions that better fit the ongoing conversation.
 
 .. tab:: Web/Desktop
 
@@ -63,8 +65,6 @@ From Mattermost v11.2, you can use AI to enhance your messages before sending th
 .. note::
 
   Messages that have been rewritten using AI are automatically marked as AI-generated content for transparency. Your system admin must :doc:`configure AI agents </administration-guide/configure/agents-admin-guide>` for the rewrite feature to be available.
-
-  From Mattermost v11.5, when you use AI Rewrite while composing a reply in a thread, the AI incorporates context from the thread to generate suggestions that better fit the ongoing conversation.
 
 Send burn-on-read messages
 ---------------------------


### PR DESCRIPTION
From v11.5, AI Rewrite incorporates context from the surrounding thread when composing a reply, producing more contextually relevant suggestions. This adds a note to the "Rewrite messages with AI" section of send-messages.rst to reflect this change.

Closes #8784

Generated with [Claude Code](https://claude.ai/code)