### PR TITLE
Allow Item renaming and add-edit description (v2.38)

### DIFF
--- a/source/end-user-guide/workflow-automation/work-with-tasks.rst
+++ b/source/end-user-guide/workflow-automation/work-with-tasks.rst
@@ -103,6 +103,10 @@ Update tasks
 - **Modify due dates**: Adjust task deadlines to accommodate changing priorities and schedules.
 - **Edit task commands**: Update slash commands or instructions associated with tasks.
 - **Change run ownership**: Transfer run ownership between team members.
+- **Rename tasks**: Update a task's name to reflect evolving scope or priorities.
+- **Add or edit task descriptions**: Add context to a task or update an existing description.
+
+From Mattermost mobile v2.38.0, you can rename tasks and add or edit task descriptions directly from the mobile app.
 
 Delete tasks
 ~~~~~~~~~~~~~

--- a/source/end-user-guide/workflow-automation/work-with-tasks.rst
+++ b/source/end-user-guide/workflow-automation/work-with-tasks.rst
@@ -82,8 +82,6 @@ You can:
 
 To view your task inbox, access the **Playbooks** tab in Mattermost. In the header, next to your profile image, select the tasks list icon. A list of every task assigned to you from every run that's in progress is displayed.
 
-From Mattermost v11.0 and mobile app v2.23.0, mobile users can perform the following task management operations on playbook runs:
-
 Mobile playbooks task management
 ----------------------------------
 
@@ -103,14 +101,8 @@ Update tasks
 - **Modify due dates**: Adjust task deadlines to accommodate changing priorities and schedules.
 - **Edit task commands**: Update slash commands or instructions associated with tasks.
 - **Change run ownership**: Transfer run ownership between team members.
-- **Rename tasks**: Update a task's name to reflect evolving scope or priorities.
-- **Add or edit task descriptions**: Add context to a task or update an existing description.
-
-From Mattermost mobile v2.38.0, you can rename tasks and add or edit task descriptions directly from the mobile app.
-
-Delete tasks
-~~~~~~~~~~~~~
-
-From Mattermost mobile v2.37.0, you can delete playbook tasks on mobile devices. Tap the task, select **Delete task**, and confirm. This action cannot be undone.
+- **Rename tasks**: Update a task's name to reflect evolving scope or priorities. (From Mattermost mobile v2.38.0)
+- **Add or edit task descriptions**: Add context to a task or update an existing description. (From Mattermost mobile v2.38.0)
+- **Delete a task**: This action cannot be undone. (From Mattermost mobile v2.37.0)
 
 These mobile capabilities provide full task management functionality for teams working with playbooks while on mobile devices, complementing your existing desktop and web browser experiences.

--- a/source/product-overview/plans.md
+++ b/source/product-overview/plans.md
@@ -120,10 +120,6 @@
       <td><strong><a href="https://docs.mattermost.com/administration-guide/configure/plugins-configuration-settings.html#enable-llm-trace">Optional full trace mode</a></strong>: Optional full trace mode for detailed monitoring and to verify Responsible AI/LLM assurances by recording every prompt, question, AI request and response across users, systems and LLM-backends and platform source code into specialized audit logs for analysis.</td>
       <td></td><td><img src="../_static/images/check-circle-green.svg"></td><td></td><td><img src="../_static/images/check-circle-green.svg"></td><td><img src="../_static/images/check-circle-green.svg"></td><td>v9.11+</td>
     </tr>
-    <tr>
-      <td><strong>Enterprise LLM Management</strong>: <a href="https://docs.mattermost.com/administration-guide/configure/agents-admin-guide.html#token-usage-tracking">Track LLM token usage</a> across users, teams, and agents to support billing, cost tracking, and usage analytics. Administrators gain visibility into input tokens, output tokens, and total token consumption per user, team, and bot to manage LLM spend and resource allocation across all major LLM providers.</td>
-      <td></td><td></td><td></td><td><img src="../_static/images/check-circle-green.svg"></td><td><img src="../_static/images/check-circle-green.svg"></td><td>v11.4+</td>
-    </tr>
     <!-- Operational & technical collaboration -->
     <tr class="section"><td colspan="7"><strong>Operational &amp; technical collaboration</strong></td></tr>
     <tr class="subsection"><td colspan="7"><strong>Accelerate operational and technical success with a collaboration platform integrating with mainstream and customer toolchains, with information rich visualizations of systems and processes, prioritized message broadcasting, and conversational interoperability with technical systems through platform-level Markdown support.</strong></td></tr>

--- a/source/product-overview/plans.md
+++ b/source/product-overview/plans.md
@@ -120,6 +120,10 @@
       <td><strong><a href="https://docs.mattermost.com/administration-guide/configure/plugins-configuration-settings.html#enable-llm-trace">Optional full trace mode</a></strong>: Optional full trace mode for detailed monitoring and to verify Responsible AI/LLM assurances by recording every prompt, question, AI request and response across users, systems and LLM-backends and platform source code into specialized audit logs for analysis.</td>
       <td></td><td><img src="../_static/images/check-circle-green.svg"></td><td></td><td><img src="../_static/images/check-circle-green.svg"></td><td><img src="../_static/images/check-circle-green.svg"></td><td>v9.11+</td>
     </tr>
+    <tr>
+      <td><strong>Enterprise LLM Management</strong>: <a href="https://docs.mattermost.com/administration-guide/configure/agents-admin-guide.html#token-usage-tracking">Track LLM token usage</a> across users, teams, and agents to support billing, cost tracking, and usage analytics. Administrators gain visibility into input tokens, output tokens, and total token consumption per user, team, and bot to manage LLM spend and resource allocation across all major LLM providers.</td>
+      <td></td><td></td><td></td><td><img src="../_static/images/check-circle-green.svg"></td><td><img src="../_static/images/check-circle-green.svg"></td><td>v11.4+</td>
+    </tr>
     <!-- Operational & technical collaboration -->
     <tr class="section"><td colspan="7"><strong>Operational &amp; technical collaboration</strong></td></tr>
     <tr class="subsection"><td colspan="7"><strong>Accelerate operational and technical success with a collaboration platform integrating with mainstream and customer toolchains, with information rich visualizations of systems and processes, prioritized message broadcasting, and conversational interoperability with technical systems through platform-level Markdown support.</strong></td></tr>


### PR DESCRIPTION
Document new mobile capabilities available from Mattermost mobile v2.38.0: task renaming and add/edit task descriptions in the work-with-tasks page.

Closes #8798

Generated with [Claude Code](https://claude.ai/code)