### PR TITLE
Ensured BoR post actions matches those in webapp (v2.38)

### DIFF
--- a/source/end-user-guide/collaborate/send-messages.rst
+++ b/source/end-user-guide/collaborate/send-messages.rst
@@ -80,7 +80,7 @@ From Mattermost v11.3, burn-on-read messages stay concealed until recipients rev
 
 .. tab:: Mobile
 
-  Users can receive and interact with burn-on-read messages, but can't send them using the mobile app.
+  Users can receive burn-on-read messages on mobile but can't send them. From Mattermost mobile v2.38.0, the post-actions available for burn-on-read messages on mobile match those in the web and desktop app.
 
 Recipients see a concealed placeholder with **Reveal**. After revealing, a timer shows when the message will be deleted. 
 

--- a/source/product-overview/plans.md
+++ b/source/product-overview/plans.md
@@ -120,6 +120,10 @@
       <td><strong><a href="https://docs.mattermost.com/administration-guide/configure/plugins-configuration-settings.html#enable-llm-trace">Optional full trace mode</a></strong>: Optional full trace mode for detailed monitoring and to verify Responsible AI/LLM assurances by recording every prompt, question, AI request and response across users, systems and LLM-backends and platform source code into specialized audit logs for analysis.</td>
       <td></td><td><img src="../_static/images/check-circle-green.svg"></td><td></td><td><img src="../_static/images/check-circle-green.svg"></td><td><img src="../_static/images/check-circle-green.svg"></td><td>v9.11+</td>
     </tr>
+    <tr>
+      <td><strong>Enterprise LLM Management</strong>: <a href="https://docs.mattermost.com/administration-guide/configure/agents-admin-guide.html#token-usage-tracking">Track LLM token usage</a> across users, teams, and agents to support billing, cost tracking, and usage analytics. Administrators gain visibility into input tokens, output tokens, and total token consumption per user, team, and bot to manage LLM spend and resource allocation across all major LLM providers.</td>
+      <td></td><td></td><td></td><td><img src="../_static/images/check-circle-green.svg"></td><td><img src="../_static/images/check-circle-green.svg"></td><td>v11.4+</td>
+    </tr>
     <!-- Operational & technical collaboration -->
     <tr class="section"><td colspan="7"><strong>Operational &amp; technical collaboration</strong></td></tr>
     <tr class="subsection"><td colspan="7"><strong>Accelerate operational and technical success with a collaboration platform integrating with mainstream and customer toolchains, with information rich visualizations of systems and processes, prioritized message broadcasting, and conversational interoperability with technical systems through platform-level Markdown support.</strong></td></tr>


### PR DESCRIPTION
Updates the Mobile tab in the "Send burn-on-read messages" section of send-messages.rst to document that from Mattermost mobile v2.38.0, burn-on-read post-actions on mobile match those in the web and desktop app.

Closes #8799

Generated with [Claude Code](https://claude.ai/code)