### PR TITLE
[MM-65701] Document 7zip file blocking in file content search

### DIFF
--- a/source/administration-guide/configure/environment-configuration-settings.rst
+++ b/source/administration-guide/configure/environment-configuration-settings.rst
@@ -2082,6 +2082,7 @@ Enable searching content of documents within ZIP files
 
   - You can search for document content within ZIP files when using Mattermost in a web browser or the desktop app.
   - Searching document contents adds load to your server.
+  - This setting applies only to standard ZIP files. 7zip (``.7z``) files are blocked for security reasons and are not searchable.
   - For large deployments, or teams that share many large, text-heavy documents, we recommend you review our :ref:`hardware requirements <deployment-guide/software-hardware-requirements:hardware requirements>`, and test enabling this feature in a staging environment before enabling it in a production environment.
 
 .. config:setting:: amazon-s3-bucket

--- a/source/end-user-guide/collaborate/search-for-messages.rst
+++ b/source/end-user-guide/collaborate/search-for-messages.rst
@@ -82,7 +82,11 @@ From the **Search** field, select **Files** to search for files attached to mess
 File contents that match on file name, or contain matching text content within supported document types, are returned in the Search Results pane. Each search result includes file name, extension, and size details, as well as details about when and where the file was originally shared. You can adjust search results to show messages from the current team, a specific team, or all teams.
 
 - For Mattermost Cloud :doc:`workspaces </end-user-guide/end-user-guide-index>`, supported document file formats include PDF, PPTX, DOCX, ODT, HTML, and plain text documents. DOC and RTF file formats, as well as the contents of ZIP files, are not supported.
-- For Mattermost self-hosted deployments, supported document file formats include PDF, PPTX, DOCX, ODT, HTML, and plain text documents. 
+- For Mattermost self-hosted deployments, supported document file formats include PDF, PPTX, DOCX, ODT, HTML, and plain text documents.
+
+.. note::
+
+  7zip (``.7z``) files are not supported for file content search and are skipped during search indexing for security reasons. Only standard ZIP files are supported when ZIP file search is enabled.
 
 .. note::
 


### PR DESCRIPTION
## Summary
- Adds a note to end-user search docs (`search-for-messages.rst`) clarifying that 7zip (`.7z`) files are not supported for file content search and are skipped for security reasons
- Adds a note to admin config docs (`environment-configuration-settings.rst`) clarifying that the ZIP file search setting applies only to standard ZIP files, not 7zip
- Ref: https://github.com/mattermost/mattermost/pull/34983

## Test plan
- [ ] Verify the `search-for-messages.rst` page renders correctly with the new note
- [ ] Verify the `environment-configuration-settings.rst` page renders correctly with the new bullet point

🤖 Generated with [Claude Code](https://claude.com/claude-code)