### PR TITLE
Add support for preferred_username claims

### DIFF
--- a/source/administration-guide/configure/authentication-configuration-settings.rst
+++ b/source/administration-guide/configure/authentication-configuration-settings.rst
@@ -2246,6 +2246,24 @@ GitLab OpenID Client secret
 .. note::
   See **Step 2** of the :doc:`GitLab Single Sign-On </administration-guide/onboard/sso-gitlab>` documentation for details.
 
+.. config:setting:: oidc-gitlabusepreferredusername
+  :displayname: Use preferred username (OpenID Connect - GitLab)
+  :systemconsole: Authentication > OpenID Connect
+  :configjson: .GitLabSettings.UsePreferredUsername
+  :environment: MM_GITLABSETTINGS_USEPREFERREDUSERNAME
+
+  - **true**: Mattermost uses the ``preferred_username`` claim from the GitLab OpenID token as the Mattermost username.
+  - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.
+
+GitLab OpenID use preferred username
+'''''''''''''''''''''''''''''''''''''
+
++-------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
+| - **true**: Mattermost uses the ``preferred_username`` claim from the GitLab OpenID token as the Mattermost      | - System Config path: **Authentication > OpenID Connect**                              |
+|   username.                                                                                                       | - ``config.json`` setting: ``GitLabSettings`` > ``UsePreferredUsername`` > ``false``   |
+| - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.      | - Environment variable: ``MM_GITLABSETTINGS_USEPREFERREDUSERNAME``                     |
++-------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
+
 Google OpenID settings
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2322,6 +2340,24 @@ Google OpenID Client secret
 |                                                                                                                   |                                                           |
 | String input.                                                                                                     |                                                           |
 +-------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+
+
+.. config:setting:: oidc-googleusepreferredusername
+  :displayname: Use preferred username (OpenID Connect - Google)
+  :systemconsole: Authentication > OpenID Connect
+  :configjson: .GoogleSettings.UsePreferredUsername
+  :environment: MM_GOOGLESETTINGS_USEPREFERREDUSERNAME
+
+  - **true**: Mattermost uses the ``preferred_username`` claim from the Google OpenID token as the Mattermost username.
+  - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.
+
+Google OpenID use preferred username
+'''''''''''''''''''''''''''''''''''''
+
++-------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
+| - **true**: Mattermost uses the ``preferred_username`` claim from the Google OpenID token as the Mattermost      | - System Config path: **Authentication > OpenID Connect**                              |
+|   username.                                                                                                       | - ``config.json`` setting: ``GoogleSettings`` > ``UsePreferredUsername`` > ``false``   |
+| - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.      | - Environment variable: ``MM_GOOGLESETTINGS_USEPREFERREDUSERNAME``                     |
++-------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
 
 Entra ID OpenID settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2419,6 +2455,27 @@ Entra ID Client secret
 |                                                                                                                      |                                                                |
 | String input.                                                                                                        |                                                                |
 +----------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------+
+
+.. config:setting:: oidc-entraidusepreferredusername
+  :displayname: Use preferred username (OpenID Connect - Entra ID)
+  :systemconsole: Authentication > OpenID Connect
+  :configjson: .Office365Settings.UsePreferredUsername
+  :environment: MM_OFFICE365SETTINGS_USEPREFERREDUSERNAME
+
+  - **true**: Mattermost uses the ``preferred_username`` claim from the Entra ID OpenID token as the Mattermost username.
+  - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.
+
+Entra ID use preferred username
+''''''''''''''''''''''''''''''''
+
++----------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------+
+| - **true**: Mattermost uses the ``preferred_username`` claim from the Entra ID OpenID token as the Mattermost username.   | - System Config path: **Authentication > OpenID Connect**                                  |
+| - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.               | - ``config.json`` setting: ``Office365Settings`` > ``UsePreferredUsername`` > ``false``    |
+|                                                                                                                            | - Environment variable: ``MM_OFFICE365SETTINGS_USEPREFERREDUSERNAME``                      |
++----------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------+
+
+.. note::
+  To make the ``preferred_username`` claim available, add it as an optional claim in the Azure Portal under **App registrations > Token configuration**. See :doc:`Entra ID Single Sign-On </administration-guide/onboard/sso-entraid>` for setup details.
 
 OpenID Connect (other) settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2534,6 +2591,26 @@ OpenID Connect (other) Client secret
 | See :doc:`OpenID Connect Single Sign-On </administration-guide/onboard/sso-openidconnect>` implementation instructions.         | - Environment variable: ``MM_OPENIDSETTINGS_SECRET``      |
 |                                                                                                                                 |                                                           |
 | String input.                                                                                                                   |                                                           |
++---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+
+
+.. config:setting:: oidc-usepreferredusername
+  :displayname: Use preferred username (OpenID Connect)
+  :systemconsole: Authentication > OpenID Connect
+  :configjson: .OpenIdSettings.UsePreferredUsername
+  :environment: MM_OPENIDSETTINGS_USEPREFERREDUSERNAME
+
+  - **true**: Mattermost uses the ``preferred_username`` claim from the OpenID token as the Mattermost username.
+  - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.
+
+OpenID Connect (other) use preferred username
+''''''''''''''''''''''''''''''''''''''''''''''
+
++---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+
+| - **true**: Mattermost uses the ``preferred_username`` claim from the provider's OpenID token as the Mattermost username.       | - System Config path: **Authentication > OpenID Connect** |
+| - **false**: **(Default)** Mattermost does not use the ``preferred_username`` claim for username assignment.                    | - ``config.json`` setting: ``OpenIdSettings`` >           |
+|                                                                                                                                 |   ``UsePreferredUsername`` > ``false``                    |
+|                                                                                                                                 | - Environment variable:                                   |
+|                                                                                                                                 |   ``MM_OPENIDSETTINGS_USEPREFERREDUSERNAME``               |
 +---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------+
 
 ----

--- a/source/administration-guide/onboard/sso-openidconnect.rst
+++ b/source/administration-guide/onboard/sso-openidconnect.rst
@@ -29,7 +29,8 @@ Step 2: Configure Mattermost for an OpenID Connect SSO
 
 .. note::
   - When Mattermost is configured to use OpenID Connect for user authentication, the following user attribute changes can't be made through the Mattermost API: first name, last name, or username. OpenID Connect must be the authoritative source for these user attributes.
-  - The **Discovery Endpoint** setting can be used to determine the connectivity and availability of arbitrary hosts. System admins concerned about this can use custom admin roles to limit access to modifying these settings. See the :ref:`delegated granular administration <administration-guide/onboard/delegated-granular-administration:edit privileges of admin roles (advanced)>` documentation for details. 
+  - Admins can configure Mattermost to use the ``preferred_username`` claim from the OpenID token as the Mattermost username. Enable the **Use preferred username** option in the provider's settings under **System Console > Authentication > OpenID Connect**. See the :ref:`authentication configuration settings <administration-guide/configure/authentication-configuration-settings:openid connect>` for details.
+  - The **Discovery Endpoint** setting can be used to determine the connectivity and availability of arbitrary hosts. System admins concerned about this can use custom admin roles to limit access to modifying these settings. See the :ref:`delegated granular administration <administration-guide/onboard/delegated-granular-administration:edit privileges of admin roles (advanced)>` documentation for details.
   
 Frequently Asked Questions
 --------------------------


### PR DESCRIPTION
Adds `Use preferred username` setting documentation to each OpenID Connect provider section in the authentication configuration settings reference, and a note in the OpenID Connect SSO setup guide.

Closes #8835

Generated with [Claude Code](https://claude.ai/code)