### PR TITLE
Improve PostgreSQL database setup discoverability in search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BUILDDIR        = build
 SPHINXOPTS      ?= -j auto
 SPHINXBUILD     ?= pipenv run sphinx-build
 SPHINXAUTOBUILD ?= pipenv run sphinx-autobuild
-AUTOBUILDOPTS   ?= -D=html_baseurl=http://127.0.0.1:8000
+AUTOBUILDOPTS   ?= -D=html_baseurl=http://127.0.0.1:8000 --ignore '*/_generated/*'
 
 # If we're using Windows, use CMD to run commands in the Makefile.
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BUILDDIR        = build
 SPHINXOPTS      ?= -j auto
 SPHINXBUILD     ?= pipenv run sphinx-build
 SPHINXAUTOBUILD ?= pipenv run sphinx-autobuild
-AUTOBUILDOPTS   ?= -D=html_baseurl=http://127.0.0.1:8000 --ignore '*/_generated/*'
+AUTOBUILDOPTS   ?= -D=html_baseurl=http://127.0.0.1:8000 --ignore "*/_generated/*"
 
 # If we're using Windows, use CMD to run commands in the Makefile.
 ifeq ($(OS),Windows_NT)

--- a/source/deployment-guide/server/preparations.rst
+++ b/source/deployment-guide/server/preparations.rst
@@ -32,6 +32,8 @@ Before installing Mattermost Server, review the following preparation requiremen
    single: database; PostgreSQL setup
    single: create database; PostgreSQL
 
+.. _database-preparation:
+
 PostgreSQL database setup
 --------------------------
 

--- a/source/deployment-guide/server/preparations.rst
+++ b/source/deployment-guide/server/preparations.rst
@@ -1,7 +1,10 @@
+.. meta::
+   :keywords: PostgreSQL, postgres, database setup, database preparation, create database, database configuration
+
 Prepare your Mattermost Server environment
 ===========================================
 
-This guide outlines the key preparation steps required before installing the Mattermost Server, focusing on setting up the database and file storage systems.
+This guide outlines the key preparation steps required before installing the Mattermost Server, focusing on setting up the PostgreSQL database and file storage systems.
 
 .. toctree::
     :maxdepth: 1
@@ -22,8 +25,15 @@ Before installing Mattermost Server, review the following preparation requiremen
 * :doc:`Set up TLS </deployment-guide/server/setup-tls>` - Enable secure communication with SSL/TLS encryption.
 * :doc:`Use an image proxy </deployment-guide/server/image-proxy>` - Configure image proxy for enhanced privacy and security.
 
-Database preparation
---------------------
+.. index::
+   ! PostgreSQL setup
+   single: PostgreSQL; database preparation
+   single: postgres setup
+   single: database; PostgreSQL setup
+   single: create database; PostgreSQL
+
+PostgreSQL database setup
+--------------------------
 
 PostgreSQL v14+ is required for Mattermost server installations. :doc:`MySQL database support </deployment-guide/server/prepare-mattermost-mysql-database>` is being deprecated starting with Mattermost v11. See the :doc:`PostgreSQL migration </deployment-guide/postgres-migration>` documentation for guidance on migrating from MySQL to PostgreSQL.
 


### PR DESCRIPTION
## Summary

- Renamed "Database preparation" section heading to "PostgreSQL database setup" so Sphinx search indexes "PostgreSQL" and "setup" as title terms (3x weight vs body text)
- Added `.. meta:: :keywords:` for external search engine discoverability
- Added `.. index::` directives for future Sphinx index support (currently disabled via `html_use_index = False`)
- Added "PostgreSQL" to the intro paragraph so it appears in search result snippets

## Makefile: Fix sphinx-autobuild rebuild loop

**Note for Agents team reviewers:** The `conf.py` agents-link-fix extension rewrites files into `source/_generated/` during each build. `sphinx-autobuild` watches the entire `source/` directory, detects these writes as changes, and triggers another build — creating an infinite loop. This PR adds `--ignore '*/_generated/*'` to the autobuild options to break the cycle. The ignore is safe because `_generated/` files are derived from the `agents` submodule during builds, not hand-edited.

## Test plan

- [ ] Run `make livehtml` and confirm no rebuild loop
- [ ] Search for "postgres", "postgres setup", "postgresql" at `/search.html` and verify the preparations page appears in the top results
- [ ] Verify the preparations page renders correctly with the renamed heading

Closes https://github.com/mattermost/docs/issues/8864

🤖 Generated with [Claude Code](https://claude.com/claude-code)