### PR TITLE
Add popout window documentation for search results

### DIFF
--- a/source/end-user-guide/collaborate/search-for-messages.rst
+++ b/source/end-user-guide/collaborate/search-for-messages.rst
@@ -71,15 +71,7 @@ Search for message
 
     You can adjust search results to show messages from the current team, a specific team, or all teams.
 
-Open search results in a popout window
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-From Mattermost v11.6, when using Mattermost in a web browser or the desktop app, you can open your current search results in a separate popout window. Select the **Open in new window** |new-window-icon| icon in the search results header to open the search view in a popout window that preserves your query and search parameters.
-
-Within the popout window, you can:
-
-- Navigate thread replies, then select **Back** to return to your search results.
-- Select **Jump** next to any result to open the message in its source channel in the main Mattermost window.
+    From Mattermost v11.6, when using Mattermost in a web browser or the desktop app, you can open your current search results in a separate popout window by selecting the **Open in new window** |new-window-icon| icon in the search results header.
 
 Search for files
 ----------------

--- a/source/end-user-guide/collaborate/search-for-messages.rst
+++ b/source/end-user-guide/collaborate/search-for-messages.rst
@@ -4,7 +4,7 @@ Search for messages
 .. include:: ../../_static/badges/all-commercial.rst
   :start-after: :nosearch:
 
-Use Mattermost search to find messages, replies, and the contents of files. You can also search by `hashtags <#hashtags>`__ and perform more advanced searches using `search modifiers <#search-modifiers>`__.
+Use Mattermost search to find messages, replies, and the contents of files. You can also search by `hashtags <#hashtags>`__, perform more advanced searches using `search modifiers <#search-modifiers>`__, or adjust search results to show messages from the current team, a specific team, or all teams.
 
 Search for message
 -------------------
@@ -69,9 +69,7 @@ Search for message
 
   .. tip::
 
-    You can adjust search results to show messages from the current team, a specific team, or all teams.
-
-    From Mattermost v11.6, when using Mattermost in a web browser or the desktop app, you can open your current search results in a separate popout window by selecting the **Open in new window** |new-window-icon| icon in the search results header.
+    When using Mattermost in a web browser or the desktop app, you can open your current search results in a separate popout window by selecting the **Open in new window** |new-window-icon| icon in the search results header.
 
 Search for files
 ----------------

--- a/source/end-user-guide/collaborate/search-for-messages.rst
+++ b/source/end-user-guide/collaborate/search-for-messages.rst
@@ -71,6 +71,16 @@ Search for message
 
     You can adjust search results to show messages from the current team, a specific team, or all teams.
 
+Open search results in a popout window
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+From Mattermost v11.6, when using Mattermost in a web browser or the desktop app, you can open your current search results in a separate popout window. Select the **Open in new window** |new-window-icon| icon in the search results header to open the search view in a popout window that preserves your query and search parameters.
+
+Within the popout window, you can:
+
+- Navigate thread replies, then select **Back** to return to your search results.
+- Select **Jump** next to any result to open the message in its source channel in the main Mattermost window.
+
 Search for files
 ----------------
 


### PR DESCRIPTION
Documents the new Search RHS popout feature introduced in Mattermost v11.6, covering: opening search results in a popout window, query preservation, thread navigation within the popout, back button behavior, and Jump opening the source channel in the main window.

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

