### PR TITLE
Add minimum Desktop App version enforcement

### DIFF
--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -407,7 +407,7 @@ Enable desktop app landing page
   :systemconsole: Site Configuration > Customization
   :configjson: .ServiceSettings.MinimumDesktopAppVersion
   :environment: MM_SERVICESETTINGS_MINIMUMDESKTOPAPPVERSION
-  :description: Enforce a minimum Mattermost Desktop App version required to connect to the server.
+  :description: Available from Mattermost server v11.6.0. Enforce a minimum Mattermost Desktop App version required to connect to the server.
 
 Minimum desktop app version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/deployment-guide/desktop/desktop-troubleshooting.rst
+++ b/source/deployment-guide/desktop/desktop-troubleshooting.rst
@@ -52,6 +52,15 @@ If you're not seeing in-app update notifications when new versions are available
 
 5. **Version previously skipped**: If you selected **Skip This Version** for the current release, manually check for updates to see it again.
 
+Update required screen
+~~~~~~~~~~~~~~~~~~~~~~~
+
+From Mattermost server v11.6.0, system admins can set a minimum Desktop App version in **System Console > Site Configuration > Customization > Minimum desktop app version**. If your Desktop App version is below the configured minimum, you will see an update required screen and cannot access Mattermost until you update.
+
+The screen includes a **Download** button that links to the apps download page configured by your admin. Select **Download** to go to that page, then follow the :ref:`manual update steps <deployment-guide/desktop/desktop-troubleshooting:how to manually update mattermost desktop>` for your platform.
+
+If you believe your app is already up to date, contact your system admin to confirm the configured minimum version.
+
 How to manually update Mattermost Desktop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Document the server-enforced minimum Desktop App version feature introduced in Mattermost server v11.6.0.

## Changes

- Added v11.6.0 version note to the `:description:` attribute of the `Minimum desktop app version` setting in `site-configuration-settings.rst`
- Added "Update required screen" troubleshooting section to `desktop-troubleshooting.rst` explaining the blocked-access experience and resolution steps for end users

Closes #8888

Generated with [Claude Code](https://claude.ai/code)