### PR TITLE
Warn against enabling cluster sniffing with cloud search providers

### DIFF
--- a/source/administration-guide/configure/environment-configuration-settings.rst
+++ b/source/administration-guide/configure/environment-configuration-settings.rst
@@ -1415,6 +1415,10 @@ Server password
   - **true**: Sniffing finds and connects to all data nodes in your cluster automatically.
   - **false**: **(Default)** Cluster sniffing is disabled.
 
+  .. warning::
+
+    Do not enable cluster sniffing when using cloud-hosted search providers such as Amazon OpenSearch Service. Cloud providers typically hide Elasticsearch behind a proxy, so sniffed node addresses may be unreachable from your network. The provider handles connection pooling for you, making sniffing unnecessary and potentially disruptive.
+
 Enable cluster sniffing
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1425,6 +1429,14 @@ Enable cluster sniffing
 | - **true**: Sniffing finds and connects to all data nodes      |                                                                                 |
 |   in your cluster automatically.                               |                                                                                 |
 | - **false**: **(Default)** Cluster sniffing is disabled.       |                                                                                 |
+|                                                                |                                                                                 |
+| .. warning::                                                   |                                                                                 |
+|                                                                |                                                                                 |
+|   Do not enable cluster sniffing when using cloud-hosted       |                                                                                 |
+|   search providers such as Amazon OpenSearch Service.          |                                                                                 |
+|   Cloud providers hide Elasticsearch behind a proxy, so        |                                                                                 |
+|   sniffed node addresses are unreachable from your network.    |                                                                                 |
+|   The provider handles connection pooling automatically.       |                                                                                 |
 +----------------------------------------------------------------+---------------------------------------------------------------------------------+
 
 Select the **Test Connection** button in the System Console to validate the connection between Mattermost and the Elasticsearch or AWS OpenSearch server.

--- a/source/administration-guide/configure/environment-configuration-settings.rst
+++ b/source/administration-guide/configure/environment-configuration-settings.rst
@@ -1417,7 +1417,7 @@ Server password
 
   .. warning::
 
-    Do not enable cluster sniffing when using cloud-hosted search providers such as Amazon OpenSearch Service. Cloud providers typically hide Elasticsearch behind a proxy, so sniffed node addresses may be unreachable from your network. The provider handles connection pooling for you, making sniffing unnecessary and potentially disruptive.
+    Do not enable cluster sniffing when using cloud-hosted search providers such as Amazon OpenSearch Service. Cloud providers typically hide search cluster nodes behind a proxy, so sniffed node addresses may be unreachable from your network. The provider handles connection pooling for you, making sniffing unnecessary and potentially disruptive.
 
 Enable cluster sniffing
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1430,13 +1430,8 @@ Enable cluster sniffing
 |   in your cluster automatically.                               |                                                                                 |
 | - **false**: **(Default)** Cluster sniffing is disabled.       |                                                                                 |
 |                                                                |                                                                                 |
-| .. warning::                                                   |                                                                                 |
-|                                                                |                                                                                 |
-|   Do not enable cluster sniffing when using cloud-hosted       |                                                                                 |
-|   search providers such as Amazon OpenSearch Service.          |                                                                                 |
-|   Cloud providers hide Elasticsearch behind a proxy, so        |                                                                                 |
-|   sniffed node addresses are unreachable from your network.    |                                                                                 |
-|   The provider handles connection pooling automatically.       |                                                                                 |
+| Do not enable cluster sniffing when using cloud-hosted         |                                                                                 |
+| search providers such as Amazon OpenSearch Service.            |                                                                                 |
 +----------------------------------------------------------------+---------------------------------------------------------------------------------+
 
 Select the **Test Connection** button in the System Console to validate the connection between Mattermost and the Elasticsearch or AWS OpenSearch server.

--- a/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
+++ b/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
@@ -12,7 +12,7 @@ Set server connection details
 
 .. warning::
 
-   Do not enable cluster sniffing when using cloud-hosted search providers such as Amazon OpenSearch Service. Cloud providers typically hide search cluster nodes behind a proxy, so sniffed node addresses may be unreachable from your network. The provider handles connection pooling for you, making sniffing unnecessary and potentially disruptive.
+   Do not enable cluster sniffing when using cloud-hosted search providers such as Elastic Cloud or Amazon OpenSearch Service. Cloud providers typically hide search cluster nodes behind a proxy, so sniffed node addresses may be unreachable from your network. The provider handles connection pooling for you, making sniffing unnecessary and potentially disruptive.
 
 4. Optional CA and client certificate configuration settings are available for use with basic authentication credentials or to replace them. See the :ref:`Enterprise search configuration settings <administration-guide/configure/environment-configuration-settings:enterprise search>` documentation for details.
 5. Select **Test Connection** and then select **Save**. If the server connection is unsuccessful you won't be able to save the configuration or enable searching with Elasticsearch or AWS OpenSearch.

--- a/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
+++ b/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
@@ -8,7 +8,12 @@ Set server connection details
 
 1. (Optional) Enter **Server Username** used to access the enterprise search server.
 2. (Optional) Enter **Server Password** associated with the username.
-3. Set **Enable Cluster Sniffing** (Optional). Sniffing finds and connects to all data nodes in your cluster automatically. Do not enable this when using cloud-hosted search providers such as Amazon OpenSearch Service — cloud providers handle connection pooling behind a proxy, and enabling sniffing may cause connectivity issues.
+3. Set **Enable Cluster Sniffing** (Optional). Sniffing finds and connects to all data nodes in your cluster automatically.
+
+.. warning::
+
+   Do not enable cluster sniffing when using cloud-hosted search providers such as Amazon OpenSearch Service. Cloud providers typically hide search cluster nodes behind a proxy, so sniffed node addresses may be unreachable from your network. The provider handles connection pooling for you, making sniffing unnecessary and potentially disruptive.
+
 4. Optional CA and client certificate configuration settings are available for use with basic authentication credentials or to replace them. See the :ref:`Enterprise search configuration settings <administration-guide/configure/environment-configuration-settings:enterprise search>` documentation for details.
 5. Select **Test Connection** and then select **Save**. If the server connection is unsuccessful you won't be able to save the configuration or enable searching with Elasticsearch or AWS OpenSearch.
 

--- a/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
+++ b/source/administration-guide/scale/common-configure-mattermost-for-enterprise-search.rst
@@ -8,7 +8,7 @@ Set server connection details
 
 1. (Optional) Enter **Server Username** used to access the enterprise search server.
 2. (Optional) Enter **Server Password** associated with the username.
-3. Set **Enable Cluster Sniffing** (Optional). Sniffing finds and connects to all data nodes in your cluster automatically.
+3. Set **Enable Cluster Sniffing** (Optional). Sniffing finds and connects to all data nodes in your cluster automatically. Do not enable this when using cloud-hosted search providers such as Amazon OpenSearch Service — cloud providers handle connection pooling behind a proxy, and enabling sniffing may cause connectivity issues.
 4. Optional CA and client certificate configuration settings are available for use with basic authentication credentials or to replace them. See the :ref:`Enterprise search configuration settings <administration-guide/configure/environment-configuration-settings:enterprise search>` documentation for details.
 5. Select **Test Connection** and then select **Save**. If the server connection is unsuccessful you won't be able to save the configuration or enable searching with Elasticsearch or AWS OpenSearch.
 


### PR DESCRIPTION
Cluster sniffing should never be enabled when using cloud-hosted search providers such as Amazon OpenSearch Service, but the documentation didn't make this clear. This PR adds warnings to the relevant settings docs so admins know to leave sniffing disabled in those environments.

Cloud providers hide their search nodes behind a proxy, so sniffed addresses are unreachable from the client network. The provider handles connection pooling automatically, making sniffing both unnecessary and potentially disruptive. See the [Elasticsearch sniffing best practices blog post](https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how) for background.