### PR TITLE
[MM-67856] docs: add /mobile-logs slash command

### DIFF
--- a/source/deployment-guide/mobile/mobile-troubleshooting.rst
+++ b/source/deployment-guide/mobile/mobile-troubleshooting.rst
@@ -23,15 +23,15 @@ In line with Microsoft guidance we recommend `configuring intranet forms-based a
 How do I attach mobile app logs to a message?
 ---------------------------------------------
 
-Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile app that lets users attach their mobile app logs as a file to any message they send. This helps administrators and support engineers debug mobile-specific issues by providing device-side context that isn't available from server logs alone. The command updates the ``attach_app_logs`` advanced preference and always responds with an ephemeral message visible only to the invoking user.
+Use ``/mobile-logs`` during mobile troubleshooting to let users attach Mattermost mobile app logs to messages. Running ``/mobile-logs on`` shows the **Attach app logs** option in the attachment menu of the message composer, so users can include device-side logs when messaging an administrator or support engineer. Users can also turn this option on or off from the **Report a problem** screen in the mobile app. The command responds with an ephemeral message visible only to the user who ran it.
 
 .. important::
 
     This command requires Mattermost mobile app v2.38 or later.
 
-- Enable log attachment for yourself using ``/mobile-logs on``.
-- Disable log attachment for yourself using ``/mobile-logs off``.
-- Check your current setting using ``/mobile-logs status``.
+- Enable **Attach app logs** for yourself using ``/mobile-logs on``.
+- Disable **Attach app logs** for yourself using ``/mobile-logs off``.
+- Check whether **Attach app logs** is enabled using ``/mobile-logs status``.
 - System admins can manage the setting for another user by appending a username, such as ``/mobile-logs on @username``, ``/mobile-logs off @username``, or ``/mobile-logs status @username``.
 
 .. important::

--- a/source/deployment-guide/mobile/mobile-troubleshooting.rst
+++ b/source/deployment-guide/mobile/mobile-troubleshooting.rst
@@ -20,6 +20,24 @@ Login with ADFS/Office365 is not working
 
 In line with Microsoft guidance we recommend `configuring intranet forms-based authentication for devices that do not support WIA <https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configure-intranet-forms-based-authentication-for-devices-that-do-not-support-wia>`_. 
 
+How do I attach mobile app logs to a message?
+---------------------------------------------
+
+Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile app that lets users attach their mobile app logs as a file to any message they send. This helps administrators and support engineers debug mobile-specific issues by providing device-side context that isn't available from server logs alone. The command updates the ``attach_app_logs`` advanced preference and always responds with an ephemeral message visible only to the invoking user.
+
+.. note::
+
+    This command requires Mattermost mobile app v2.38 or later.
+
+- Enable log attachment for yourself using ``/mobile-logs on``.
+- Disable log attachment for yourself using ``/mobile-logs off``.
+- Check your current setting using ``/mobile-logs status``.
+- System admins can manage the setting for another user by appending a username, such as ``/mobile-logs on @username``, ``/mobile-logs off @username``, or ``/mobile-logs status @username``.
+
+.. important::
+
+    Non-admin users can only manage their own preference. Attempts to target another account return a neutral **Unable to change mobile log settings for that user** message to avoid username enumeration. Preference changes made through this command are recorded in the audit log.
+
 I see a “Connecting…” bar that does not go away
 -----------------------------------------------
 

--- a/source/deployment-guide/mobile/mobile-troubleshooting.rst
+++ b/source/deployment-guide/mobile/mobile-troubleshooting.rst
@@ -25,7 +25,7 @@ How do I attach mobile app logs to a message?
 
 Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile app that lets users attach their mobile app logs as a file to any message they send. This helps administrators and support engineers debug mobile-specific issues by providing device-side context that isn't available from server logs alone. The command updates the ``attach_app_logs`` advanced preference and always responds with an ephemeral message visible only to the invoking user.
 
-.. note::
+.. important::
 
     This command requires Mattermost mobile app v2.38 or later.
 
@@ -165,4 +165,4 @@ If you did not receive a push notification when testing push notifications, use 
 
   To conserve disk space, once your push notification issue is resolved, go to  **System Console > Environment > Logging > File Log Level**, then select **ERROR** to switch your logging detail level from **DEBUG** to **Errors Only**.
 
-If push notifications are not being delivered on the mobile device, confirm that you're logged in to the **Native** mobile app session through **Profile > Security > View and Log Out of Active Sessions**. Otherwise, the `DeviceId` won't get registered in the `Sessions` table and notifications won't be delivered.
+If push notifications are not being delivered on the mobile device, confirm that you're logged in to the **Native** mobile app session through **Profile > Security > View and Log Out of Active Sessions**. Otherwise, the ``DeviceId`` won't get registered in the ``Sessions`` table and notifications won't be delivered.

--- a/source/integrations-guide/built-in-slash-commands.rst
+++ b/source/integrations-guide/built-in-slash-commands.rst
@@ -56,6 +56,24 @@ Manage channels
 - Edit the channel header using ``/header {text}`` or the channel purpose using ``/purpose {text}``.
 - Rename a channel using ``/rename {text}``.
 
+Manage mobile app log attachments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile client that lets users attach their mobile app logs as a file to the message being sent. This helps administrators and support engineers debug mobile-specific issues by providing device-side context that isn't available from server logs alone. The command updates the ``attach_app_logs`` advanced preference and always responds with an ephemeral message visible only to the invoking user.
+
+.. note::
+
+    This command requires Mattermost mobile app v2.38 or later. On earlier versions the preference can still be set, but the attachment option won't appear in the mobile client.
+
+- Enable log attachment for yourself using ``/mobile-logs on``.
+- Disable log attachment for yourself using ``/mobile-logs off``.
+- Check your current setting using ``/mobile-logs status``.
+- System admins can manage the setting for another user by appending a username, such as ``/mobile-logs on @username``, ``/mobile-logs off @username``, or ``/mobile-logs status @username``.
+
+.. note::
+
+    Non-admin users can only manage their own preference. Attempts to target another account return a neutral *Unable to change mobile log settings for that user* message to avoid username enumeration. Preference changes made through this command are recorded in the audit log.
+
 More useful slash commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/integrations-guide/built-in-slash-commands.rst
+++ b/source/integrations-guide/built-in-slash-commands.rst
@@ -59,7 +59,7 @@ Manage channels
 Manage mobile app log attachments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile client that lets users attach their mobile app logs as a file to the message being sent. This helps administrators and support engineers debug mobile-specific issues by providing device-side context that isn't available from server logs alone. The command updates the ``attach_app_logs`` advanced preference and always responds with an ephemeral message visible only to the invoking user.
+Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile client that lets users attach their mobile app logs as a file to any message they send. This helps administrators and support engineers debug mobile-specific issues by providing device-side context that isn't available from server logs alone. The command updates the ``attach_app_logs`` advanced preference and always responds with an ephemeral message visible only to the invoking user.
 
 .. note::
 
@@ -70,9 +70,9 @@ Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile cli
 - Check your current setting using ``/mobile-logs status``.
 - System admins can manage the setting for another user by appending a username, such as ``/mobile-logs on @username``, ``/mobile-logs off @username``, or ``/mobile-logs status @username``.
 
-.. note::
+.. important::
 
-    Non-admin users can only manage their own preference. Attempts to target another account return a neutral *Unable to change mobile log settings for that user* message to avoid username enumeration. Preference changes made through this command are recorded in the audit log.
+    Non-admin users can only manage their own preference. Attempts to target another account return a neutral **Unable to change mobile log settings for that user** message to avoid username enumeration. Preference changes made through this command are recorded in the audit log.
 
 More useful slash commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/integrations-guide/built-in-slash-commands.rst
+++ b/source/integrations-guide/built-in-slash-commands.rst
@@ -56,24 +56,6 @@ Manage channels
 - Edit the channel header using ``/header {text}`` or the channel purpose using ``/purpose {text}``.
 - Rename a channel using ``/rename {text}``.
 
-Manage mobile app log attachments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use ``/mobile-logs`` to enable an attachment option in the Mattermost mobile client that lets users attach their mobile app logs as a file to any message they send. This helps administrators and support engineers debug mobile-specific issues by providing device-side context that isn't available from server logs alone. The command updates the ``attach_app_logs`` advanced preference and always responds with an ephemeral message visible only to the invoking user.
-
-.. note::
-
-    This command requires Mattermost mobile app v2.38 or later. On earlier versions the preference can still be set, but the attachment option won't appear in the mobile client.
-
-- Enable log attachment for yourself using ``/mobile-logs on``.
-- Disable log attachment for yourself using ``/mobile-logs off``.
-- Check your current setting using ``/mobile-logs status``.
-- System admins can manage the setting for another user by appending a username, such as ``/mobile-logs on @username``, ``/mobile-logs off @username``, or ``/mobile-logs status @username``.
-
-.. important::
-
-    Non-admin users can only manage their own preference. Attempts to target another account return a neutral **Unable to change mobile log settings for that user** message to avoid username enumeration. Preference changes made through this command are recorded in the audit log.
-
 More useful slash commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#### Summary
Document the new /mobile-logs command introduced in mattermost/mattermost#35658, which toggles the attach_app_logs preference to enable attaching mobile app logs as a file in the Mattermost mobile client (v2.38+) for debugging.

#### Ticket Link

[MM-67856]

[MM-67856]: https://mattermost.atlassian.net/browse/MM-67856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ