### PR TITLE
Add \c mattermost step to PostgreSQL preparation grants

### DIFF
--- a/source/deployment-guide/server/preparations.rst
+++ b/source/deployment-guide/server/preparations.rst
@@ -59,7 +59,7 @@ PostgreSQL v14+ is required for Mattermost server installations. :doc:`MySQL dat
 
    e. If using PostgreSQL v15.x or later, additional grants are required:
 
-      .. code-block:: sql
+      .. code-block:: postgresql
 
          ALTER DATABASE mattermost OWNER TO mmuser;
          -- Connect to the mattermost database so the schema grants below apply to the right schema

--- a/source/deployment-guide/server/preparations.rst
+++ b/source/deployment-guide/server/preparations.rst
@@ -62,6 +62,7 @@ PostgreSQL v14+ is required for Mattermost server installations. :doc:`MySQL dat
       .. code-block:: sql
 
          ALTER DATABASE mattermost OWNER TO mmuser;
+         -- Connect to the mattermost database so the schema grants below apply to the right schema
          \c mattermost
          ALTER SCHEMA public OWNER TO mmuser;
          GRANT USAGE, CREATE ON SCHEMA public TO mmuser;

--- a/source/deployment-guide/server/preparations.rst
+++ b/source/deployment-guide/server/preparations.rst
@@ -62,6 +62,7 @@ PostgreSQL v14+ is required for Mattermost server installations. :doc:`MySQL dat
       .. code-block:: sql
 
          ALTER DATABASE mattermost OWNER TO mmuser;
+         \c mattermost
          ALTER SCHEMA public OWNER TO mmuser;
          GRANT USAGE, CREATE ON SCHEMA public TO mmuser;
 

--- a/source/deployment-guide/server/preparations.rst
+++ b/source/deployment-guide/server/preparations.rst
@@ -59,7 +59,7 @@ PostgreSQL v14+ is required for Mattermost server installations. :doc:`MySQL dat
 
    e. If using PostgreSQL v15.x or later, additional grants are required:
 
-      .. code-block:: postgresql
+      .. code-block:: text
 
          ALTER DATABASE mattermost OWNER TO mmuser;
          -- Connect to the mattermost database so the schema grants below apply to the right schema


### PR DESCRIPTION
## Summary

In the PostgreSQL preparation steps for v15.x or later (database-preparation step 5e), the `ALTER SCHEMA public` and `GRANT USAGE, CREATE ON SCHEMA public` commands operate on the **current database's** `public` schema. Without first connecting to the `mattermost` database, those grants are applied to whatever database the admin happens to be connected to (typically `postgres`), leaving the actual `mattermost` database without the required schema permissions.

This PR adds a `\c mattermost` step between `ALTER DATABASE` and the schema-level commands so the grants land on the right schema.

Before:
```sql
ALTER DATABASE mattermost OWNER TO mmuser;
ALTER SCHEMA public OWNER TO mmuser;
GRANT USAGE, CREATE ON SCHEMA public TO mmuser;
```

After:
```sql
ALTER DATABASE mattermost OWNER TO mmuser;
\c mattermost
ALTER SCHEMA public OWNER TO mmuser;
GRANT USAGE, CREATE ON SCHEMA public TO mmuser;
```

## Test plan

- [ ] Verify the rendered page at `deployment-guide/server/preparations.html#database-preparation` shows the new `\c mattermost` line in the step 5e code block.
- [ ] Confirm running the updated sequence in `psql` against a fresh PostgreSQL 15+ instance results in `mmuser` owning the `public` schema **of the `mattermost` database**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)