### PR TITLE
Add production warning to EnableTesting docs

### DIFF
--- a/source/administration-guide/configure/environment-configuration-settings.rst
+++ b/source/administration-guide/configure/environment-configuration-settings.rst
@@ -4167,7 +4167,7 @@ With self-hosted deployments, you can configure developer mode by going to **Sys
   :environment: MM_SERVICESETTINGS_ENABLETESTING
   :description: Enable or disable the ``/test`` slash command.
 
-  - **true**: **(Default)** The ``/test`` slash command is enabled to load test accounts and test data.
+  - **true**: **(Default)** The ``/test`` slash command is enabled to load test accounts and test data. Use this setting only in isolated non-production environments and never in production.
   - **false**:  The ``/test`` slash command is disabled.
 
 Enable testing commands
@@ -4178,7 +4178,9 @@ Enable testing commands
 |                                                   | - ``config.json`` setting: ``ServiceSettings`` > ``EnableTesting`` > ``true``  |
 | - **true**: **(Default)** The ``/test`` slash     | - Environment variable: ``MM_SERVICESETTINGS_ENABLETESTING``                   |
 |   command is enabled to load test accounts        |                                                                                |
-|   and test data.                                  |                                                                                |
+|   and test data. Use this setting only in         |                                                                                |
+|   isolated non-production environments and        |                                                                                |
+|   never in production.                            |                                                                                |
 | - **false**:  The ``/test`` slash command is      |                                                                                |
 |   disabled.                                       |                                                                                |
 +---------------------------------------------------+--------------------------------------------------------------------------------+


### PR DESCRIPTION
Add a note that EnableTesting should only be used in isolated non-production environments and never in production.

Closes #8926

Jira ticket: https://mattermost.atlassian.net/browse/MM-67460

Generated with [Claude Code](https://claude.ai/code)