### PR TITLE
Align HA sysctl values with load-test server config

### DIFF
--- a/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
+++ b/source/administration-guide/scale/high-availability-cluster-based-deployment.rst
@@ -136,13 +136,15 @@ Configuration settings
 
     # TCP buffer sizes are tuned for 10Gbit/s bandwidth and 0.5ms RTT (as measured intra EC2 cluster).
     # This gives a BDP (bandwidth-delay-product) of 625000 bytes.
-    net.ipv4.tcp_rmem = 4096 156250 625000
-    net.ipv4.tcp_wmem = 4096 156250 625000
-    net.core.rmem_max = 312500
-    net.core.wmem_max = 312500
-    net.core.rmem_default = 312500
-    net.core.wmem_default = 312500
-    net.ipv4.tcp_mem = 1638400 1638400 1638400
+    # The maximum socket buffer size for kernel autotuning is set to be 4x the BDP (2500000).
+    # The default socket buffer size is set to 1/4 BDP (156250).
+    net.ipv4.tcp_rmem = 4096 156250 2500000
+    net.ipv4.tcp_wmem = 4096 156250 2500000
+
+    # Bumping the theoretical maximum buffer size of receiving/sending sockets,
+    # either UDP, or TCP not using autotuning (i.e. using SO_RCVBUF)
+    net.core.rmem_max = 16777216
+    net.core.wmem_max = 16777216
 
 You can do the same for the proxy server.
 


### PR DESCRIPTION
## Summary

The sysctl block on the High Availability deployment page targets Mattermost server hosts but mirrored the load-test agent (client) values, which are tuned for a different role. Align it with the serverSysctlConfig used by mattermost-load-test-ng to validate large concurrent-user deployments:

- Raise tcp_rmem/tcp_wmem max from 625000 to 2500000 (4x BDP) and expand the comment to describe the autotuning ceiling.
- Raise net.core.{r,w}mem_max from 312500 to 16777216 and dedupe the surrounding comments (mirrors mattermost/mattermost-load-test-ng#987, which removed the redundant double-assignment that set the same keys twice for UDP and TCP).
- Drop rmem_default/wmem_default/tcp_mem, which only belong in the client/agent block and were copied here in error.

## Ticket Link
--