### PR TITLE
Sync agents submodule; exclude internal migration review docs from Sphinx

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -578,6 +578,8 @@ exclude_patterns = [
     "agents/CLAUDE.md",
     "agents/README.md",
     "agents/interpluginclient/README.md",
+    # Plugin-internal schema migration reviews (submodule); not customer-facing docs
+    "agents/store/migrations/reviews/*.md",
     "agents/notice.txt", 
     "agents/license.txt"
 ]


### PR DESCRIPTION
## Summary

- Bump `source/agents` submodule to current `mattermost-plugin-agents` master (includes Agents v2 launch / upgrade documentation from the plugin repo).
- Add `agents/store/migrations/reviews/*.md` to Sphinx `exclude_patterns` so plugin-internal schema migration **review** write-ups are not published to docs.mattermost.com or indexed as customer docs.

## Test Plan

- [ ] CI / docs build passes on this branch.

## Follow-ups

See PR comment from @nickmisasi on **orphaned / dead-link hygiene** for migration-review content vs. upgrade-guide naming.