### PR TITLE
Changelog automation fixes

### DIFF
--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -86,9 +86,10 @@ def get_milestone_number(repo: str, title: str) -> int | None:
             "state": "all",
             "per_page": 100,
             "page": page,
-            "direction": "desc",  # most recent first so we find it quickly
+            "sort": "due_on",       # sort by due date
+            "direction": "desc",    # most recently due first, so active milestones are found quickly
         }
-        resp = requests.get(url, headers=HEADERS, params=params)
+        resp = requests.get(url, headers=HEADERS, params=params, timeout=30)
         resp.raise_for_status()
         milestones = resp.json()
         if not milestones:
@@ -101,7 +102,7 @@ def get_milestone_number(repo: str, title: str) -> int | None:
         page += 1
     print(f"  ⚠️  Milestone '{title}' not found in {repo} — skipping")
     if recent_titles:
-        print(f"     Most recent milestones: {', '.join(recent_titles)}")
+        print(f"     Most recently due milestones: {', '.join(recent_titles)}")
     return None
  
  

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -79,17 +79,29 @@ Here are your instructions:
 def get_milestone_number(repo: str, title: str) -> int | None:
     """Look up the numeric ID for a milestone by its title in the given repo."""
     url = f"https://api.github.com/repos/{repo}/milestones"
-    params = {"state": "all", "per_page": 100}
-    resp = requests.get(url, headers=HEADERS, params=params)
-    resp.raise_for_status()
-    milestones = resp.json()
-    for m in milestones:
-        if m["title"] == title:
-            return m["number"]
+    page = 1
+    recent_titles = []
+    while True:
+        params = {
+            "state": "all",
+            "per_page": 100,
+            "page": page,
+            "direction": "desc",  # most recent first so we find it quickly
+        }
+        resp = requests.get(url, headers=HEADERS, params=params)
+        resp.raise_for_status()
+        milestones = resp.json()
+        if not milestones:
+            break
+        for m in milestones:
+            if m["title"] == title:
+                return m["number"]
+        if page == 1:
+            recent_titles = [m["title"] for m in milestones[:10]]
+        page += 1
     print(f"  ⚠️  Milestone '{title}' not found in {repo} — skipping")
-    available = [m["title"] for m in milestones]
-    if available:
-        print(f"     Available milestones: {', '.join(available[:10])}")
+    if recent_titles:
+        print(f"     Most recent milestones: {', '.join(recent_titles)}")
     return None
  
  


### PR DESCRIPTION
Fix an issue where the changelog automation didn't work properly. The milestones API only returns 100 results per page, and mattermost/mattermost has been active since 2015 — it has hundreds of milestones. The script is only fetching the first page (the oldest ones), so v11.7.0 is never seen. The fix is to paginate through all milestone pages, and sort descending so recent milestones come first.

The fix:
 - Paginates through all milestone pages until it finds a match.
 - Sorts descending so the most recent milestones come first — for a repo like this, v11.7.0 will almost certainly be found on page 1 now, making it fast.
 - The "available milestones" debug line now shows the most recent ones instead of the oldest, which is much more useful if there's ever a name mismatch.

