### PR TITLE
Document mobile team menu join and leave in v2.40.0

### DIFF
--- a/source/end-user-guide/access/client-availability.rst
+++ b/source/end-user-guide/access/client-availability.rst
@@ -94,7 +94,7 @@ Teams
 +----------------------------------------------------------------------------------------------+-------------+-------------+-------------+
 | :ref:`Manage team members <administration-guide/manage/team-channel-members:teams>`          | |checkmark| | |checkmark| |             |
 +----------------------------------------------------------------------------------------------+-------------+-------------+-------------+
-| :ref:`Leave team <end-user-guide/collaborate/organize-using-teams:leave a team>`             | |checkmark| | |checkmark| |             |
+| :ref:`Leave team <end-user-guide/collaborate/organize-using-teams:leave a team>`             | |checkmark| | |checkmark| | |checkmark| |
 +----------------------------------------------------------------------------------------------+-------------+-------------+-------------+
 
 Collaborative playbooks

--- a/source/end-user-guide/collaborate/organize-using-teams.rst
+++ b/source/end-user-guide/collaborate/organize-using-teams.rst
@@ -87,10 +87,14 @@ You can be a member of multiple teams at the same time. To join additional teams
 .. image:: ../../images/join-team.png
   :alt: Select a team name to join another team.
 
+From Mattermost Mobile v2.40.0, you can join another team from the mobile app by tapping the team name in the channel list header, then tapping **Join Another Team**.
+
 Leave a team
 ------------
 
 Users can also choose to remove themselves from a team, from **Team menu > Leave Team**. This will remove the user from the team, and from all public channels and private channels on the team.
+
+From Mattermost Mobile v2.40.0, you can leave a team from the mobile app when you belong to more than one team. In the channel list, tap the team name, tap **Leave team**, then confirm.
 
 They will only be able to rejoin the team if it's open, or if they receive a new invitation. If they do rejoin, they will no longer be a part of their old channels.
 


### PR DESCRIPTION
## Summary

Adds mobile-app instructions for joining and leaving a team via the new bottom-sheet team menu introduced in Mattermost Mobile v2.40.0 (mattermost/mattermost-mobile#9721).

- `source/end-user-guide/collaborate/organize-using-teams.rst` — adds mobile join/leave paragraphs under the existing Join a team and Leave a team sections; existing warning about channel removal preserved.
- `source/end-user-guide/access/client-availability.rst` — marks Leave team as supported on Mobile.

Closes #8968

## Test plan
- [ ] Verify RST renders correctly in preview
- [ ] Verify cross-reference to `leave a team` anchor still resolves

Generated with [Claude Code](https://claude.ai/code)