### PR TITLE
Docs: Update AI Rewrite to use AI Actions menu (v11.7)

### DIFF
--- a/source/end-user-guide/collaborate/send-messages.rst
+++ b/source/end-user-guide/collaborate/send-messages.rst
@@ -44,10 +44,12 @@ You can use AI to enhance your messages before sending them. This feature helps 
 
 From Mattermost v11.5, when you use AI Rewrite while composing a reply in a thread, the AI incorporates context from the thread to generate suggestions that better fit the ongoing conversation.
 
+From Mattermost v11.7, Rewrite is accessed through the **AI Actions** |ai-actions-icon| menu, alongside any custom prompts your system admin has made available.
+
 On Web/Desktop or Mobile:
 
   1. Type your message in the message compose field.
-  2. Select the **Rewrite** |ai-rewrite| option from the message actions.
+  2. Open the **AI Actions** |ai-actions-icon| menu from the message actions, then select **Rewrite**.
   3. Select a bot from the list of available AI agents.
   4. Choose from available rewrite options:
 
@@ -61,6 +63,10 @@ On Web/Desktop or Mobile:
 
   5. Review the AI-generated suggestion. Select **Regenerate** to try again or **Discard** to return to your original message.
   6. Select **Send** |send-icon|
+
+.. tip::
+
+  From Mattermost v11.7, system admins can publish custom prompts that appear alongside Rewrite in the **AI Actions** |ai-actions-icon| menu. If you don't see a custom prompt you expect, check with your system admin.
 
 .. note::
 


### PR DESCRIPTION
Updates the *Rewrite messages with AI* workflow to reflect Agents v2.0 / Mattermost v11.7, where Rewrite is accessed through the new **AI Actions** menu instead of as a top-level message action.

## Summary

- `source/end-user-guide/collaborate/send-messages.rst` — re-path Rewrite through the **AI Actions** menu (v11.7) and add a tip about custom prompts appearing in the same menu.

## What's intentionally not in this PR

Agents v2.0 end-user and admin guide content (mobile entry point, agent threads list, chat screen, bot/agent selector, auto-navigation, `manage_own_agent`, `manage_others_agent`) lives upstream in `source/agents/docs/*.md` (the `mattermost-plugin-agents` submodule). Sphinx regenerates `source/_generated/agents/docs/*.md` from that submodule on every build (`source/conf.py:126-205`), so those edits must land in [mattermost/mattermost-plugin-agents#709](https://github.com/mattermost/mattermost-plugin-agents/pull/709) (or a follow-up plugin docs PR), not here.

Refs: ##8952. See the issue thread for the trimmed reviewer checklist.

Generated with [Claude Code](https://claude.ai/code)