### PR TITLE
Remove ElasticsearchSettings.ClientKey from sanitized fields list

### DIFF
--- a/source/administration-guide/manage/admin/generating-support-packet.rst
+++ b/source/administration-guide/manage/admin/generating-support-packet.rst
@@ -41,7 +41,7 @@ Santitize confidential data
 
 Please sanitize any confidential data you wish to exclude before sharing the packet with Mattermost. 
 
-When present, the following information is automatically santized during packet generation: ``LdapSettings.BindPassword``, ``FileSettings.PublicLinkSalt``, ``FileSettings.AmazonS3SecretAccessKey``, ``EmailSettings.SMTPPassword``, ``GitLabSettings.Secret``, ``GoogleSettings.Secret``, ``Office365Settings.Secret``, ``OpenIdSettings.Secret``, ``SqlSettings.DataSource``, ``SqlSettings.AtRestEncryptKey``, ``ElasticsearchSettings.Password``, ``All SqlSettings.DataSourceReplicas``, ``All SqlSettings.DataSourceSearchReplicas``, ``MessageExportSettings.GlobalRelaySettings.SmtpPassword``, ``ServiceSettings.SplitKey``, ``FileSettings.ExportAmazonS3SecretAccessKey``, ``ElasticsearchSettings.ClientKey``, ``ServiceSettings.GoogleDeveloperKey``, and ``ServiceSettings.GiphySdkKey`` (from Mattermost v11.6.0).
+When present, the following information is automatically santized during packet generation: ``LdapSettings.BindPassword``, ``FileSettings.PublicLinkSalt``, ``FileSettings.AmazonS3SecretAccessKey``, ``EmailSettings.SMTPPassword``, ``GitLabSettings.Secret``, ``GoogleSettings.Secret``, ``Office365Settings.Secret``, ``OpenIdSettings.Secret``, ``SqlSettings.DataSource``, ``SqlSettings.AtRestEncryptKey``, ``ElasticsearchSettings.Password``, ``All SqlSettings.DataSourceReplicas``, ``All SqlSettings.DataSourceSearchReplicas``, ``MessageExportSettings.GlobalRelaySettings.SmtpPassword``, ``ServiceSettings.SplitKey``, ``FileSettings.ExportAmazonS3SecretAccessKey``, ``ServiceSettings.GoogleDeveloperKey``, and ``ServiceSettings.GiphySdkKey`` (from Mattermost v11.6.0).
 
 .. important::
 

--- a/source/administration-guide/manage/admin/generating-support-packet.rst
+++ b/source/administration-guide/manage/admin/generating-support-packet.rst
@@ -36,12 +36,12 @@ Generate
     Downloading Support Packet
     Downloaded Support Packet to mattermost_support_packet_.zip
 
-Santitize confidential data
+Sanitize confidential data
 ---------------------------
 
 Please sanitize any confidential data you wish to exclude before sharing the packet with Mattermost. 
 
-When present, the following information is automatically santized during packet generation: ``LdapSettings.BindPassword``, ``FileSettings.PublicLinkSalt``, ``FileSettings.AmazonS3SecretAccessKey``, ``EmailSettings.SMTPPassword``, ``GitLabSettings.Secret``, ``GoogleSettings.Secret``, ``Office365Settings.Secret``, ``OpenIdSettings.Secret``, ``SqlSettings.DataSource``, ``SqlSettings.AtRestEncryptKey``, ``ElasticsearchSettings.Password``, ``All SqlSettings.DataSourceReplicas``, ``All SqlSettings.DataSourceSearchReplicas``, ``MessageExportSettings.GlobalRelaySettings.SmtpPassword``, ``ServiceSettings.SplitKey``, ``FileSettings.ExportAmazonS3SecretAccessKey``, ``ServiceSettings.GoogleDeveloperKey``, and ``ServiceSettings.GiphySdkKey`` (from Mattermost v11.6.0).
+When present, the following information is automatically sanitized during packet generation: ``LdapSettings.BindPassword``, ``FileSettings.PublicLinkSalt``, ``FileSettings.AmazonS3SecretAccessKey``, ``EmailSettings.SMTPPassword``, ``GitLabSettings.Secret``, ``GoogleSettings.Secret``, ``Office365Settings.Secret``, ``OpenIdSettings.Secret``, ``SqlSettings.DataSource``, ``SqlSettings.AtRestEncryptKey``, ``ElasticsearchSettings.Password``, ``All SqlSettings.DataSourceReplicas``, ``All SqlSettings.DataSourceSearchReplicas``, ``MessageExportSettings.GlobalRelaySettings.SmtpPassword``, ``ServiceSettings.SplitKey``, ``FileSettings.ExportAmazonS3SecretAccessKey``, ``ServiceSettings.GoogleDeveloperKey``, and ``ServiceSettings.GiphySdkKey`` (from Mattermost v11.6.0).
 
 .. important::
 
@@ -57,7 +57,7 @@ Add the generated Support Packet to a `standard support request <https://support
 
 .. important::
 
-   Disable debug logging once you've generated the Support Packet. Debug logging can cause log files to expand substantially, and may adversely impact server performance. We recommend enabling it temporarily, or in development environments, but not production enviornments.
+   Disable debug logging once you've generated the Support Packet. Debug logging can cause log files to expand substantially, and may adversely impact server performance. We recommend enabling it temporarily, or in development environments, but not production environments.
 
 Contents of a Support Packet
 ----------------------------


### PR DESCRIPTION
#### Summary
This field is no longer sanitized during support packet generation as of mattermost/mattermost#36619.

#### Ticket Link
Relates-to: https://github.com/mattermost/mattermost/pull/36619