### PR TITLE
Fix RequirePluginSignature default value in plugin docs

### DIFF
--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -72,17 +72,17 @@ Enable plugins
   :configjson: .PluginSettings.RequirePluginSignature
   :environment: MM_PLUGINSETTINGS_REQUIREPLUGINSIGNATURE
 
-  - **true**: **(Default)** Enables plugin signature validation for managed and unmanaged plugins.
-  - **false**: Disables plugin signature validation for managed and unmanaged plugins.
+  - **true**: Enables plugin signature validation for managed and unmanaged plugins.
+  - **false**: **(Default)** Disables plugin signature validation for managed and unmanaged plugins.
 
 Require plugin signature
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
-| - **true**: **(Default)** Enables plugin signature validation for managed and unmanaged plugins.                                                                                      | - System Config path: **Plugins > Plugin Management**                                  |
-| - **false**: Disables plugin signature validation for managed and unmanaged plugins.                                                                                                  | -  ``config.json`` setting: ``PluginSettings`` > ``RequirePluginSignature`` > ``true`` |
-|                                                                                                                                                                                       | - Environment variable: ``MM_PLUGINSETTINGS_REQUIREPLUGINSIGNATURE``                   |
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
+| - **true**: Enables plugin signature validation for managed and unmanaged plugins.                                                                                                    | - System Config path: **Plugins > Plugin Management**                                   |
+| - **false**: **(Default)** Disables plugin signature validation for managed and unmanaged plugins.                                                                                    | -  ``config.json`` setting: ``PluginSettings`` > ``RequirePluginSignature`` > ``false`` |
+|                                                                                                                                                                                       | - Environment variable: ``MM_PLUGINSETTINGS_REQUIREPLUGINSIGNATURE``                    |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
 
 .. note::
   - This setting is applicable to self-hosted deployments only.


### PR DESCRIPTION
## Summary

Updates the documented default for `PluginSettings.RequirePluginSignature` from `true` to `false` to match the [server code](https://github.com/mattermost/mattermost/blob/master/server/public/model/config.go#L3658).

Affects the `config:setting` directive block and the rendered summary table for the "Require plugin signature" setting, including the `config.json` example value.

Fixes #8993