### PR TITLE
Correct badge in Intune MAM configuration guide

### DIFF
--- a/source/deployment-guide/mobile/configure-microsoft-intune-mam.rst
+++ b/source/deployment-guide/mobile/configure-microsoft-intune-mam.rst
@@ -1,7 +1,7 @@
 Configure Microsoft Intune Mobile Application Management (MAM)
 ==============================================================
 
-.. include:: ../../_static/badges/entry-ent.rst
+.. include:: ../../_static/badges/entry-adv.rst
   :start-after: :nosearch:
 
 You can configure the Mattermost Mobile App on iOS to enforce Microsoft Intune App Protection Policies (MAM) so organizational data remains protected on Bring Your Own Device (BYOD) and mixed-use devices without requiring device enrollment (MDM).


### PR DESCRIPTION
#### Summary
Intune for MDM was incorrectly listed as available in Enterprise and Enterprise Advanced. It is only available in Enterprise Advanced.

This updates the doc to reflect that.

#### Ticket Link

n/a