### PR TITLE
Fix release docs automation

### DIFF
--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -50,7 +50,8 @@ MAX_SEND_CHARS = 50_000
 #   - Patch/Dot: releases page + changelog only
 # ---------------------------------------------------------------------------
  
-SERVER_FILES = [
+# Files updated for every server release type.
+SERVER_BASE_FILES = [
     "source/product-overview/mattermost-server-releases.md",
     "source/deployment-guide/server/linux/deploy-rhel.rst",
     "source/deployment-guide/server/linux/deploy-tar.rst",
@@ -63,6 +64,15 @@ SERVER_FILES = [
     "source/deployment-guide/software-hardware-requirements.rst",
     "source/administration-guide/upgrade/important-upgrade-notes.rst",
     "source/product-overview/ui-ada-changelog.rst",
+]
+ 
+# The v11 changelog is only updated for Patch / Dot releases and Security releases.
+# Feature and ESR releases have a dedicated changelog automation (generate-changelog.yml)
+# that handles this file separately.
+# Note: this file can be very large; MAX_SEND_CHARS already limits what is sent to
+# Claude to the most-recent portion where new dot-release entries are added.
+SERVER_CHANGELOG_FILES = [
+    "source/product-overview/mattermost-v11-changelog.md",
 ]
  
 MOBILE_FILES = [
@@ -83,7 +93,11 @@ DESKTOP_ESR_EXTRA_FILES = [
  
 def get_files() -> list[str]:
     if COMPONENT == "Server":
-        return SERVER_FILES
+        if RELEASE_TYPE in ("Patch / Dot Release", "Security Release"):
+            return SERVER_BASE_FILES + SERVER_CHANGELOG_FILES
+        else:
+            # Feature Release, ESR, Other — changelog handled by generate-changelog.yml
+            return SERVER_BASE_FILES
     elif COMPONENT == "Mobile":
         return MOBILE_FILES
     elif COMPONENT == "Desktop":

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -1,4 +1,3 @@
-
 """
 update_docs.py
  

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -1,3 +1,4 @@
+
 """
 update_docs.py
  
@@ -94,9 +95,14 @@ DESKTOP_ESR_EXTRA_FILES = [
 def get_files() -> list[str]:
     if COMPONENT == "Server":
         if RELEASE_TYPE in ("Patch / Dot Release", "Security Release"):
+            # Changelog included — no dedicated automation for these release types.
             return SERVER_BASE_FILES + SERVER_CHANGELOG_FILES
+        elif RELEASE_TYPE in ("Feature Release", "ESR"):
+            # Changelog excluded — generate-changelog.yml handles it for these types.
+            return SERVER_BASE_FILES
         else:
-            # Feature Release, ESR, Other — changelog handled by generate-changelog.yml
+            # "Other" and any future types — skip the changelog to avoid unintended edits.
+            # Add an explicit branch above if a new release type needs changelog updates.
             return SERVER_BASE_FILES
     elif COMPONENT == "Mobile":
         return MOBILE_FILES

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -65,10 +65,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Use the App token so that subsequent git push calls are authenticated.
+          # Credentials are persisted in the git config (default behaviour) so that
+          # the "Commit and push changes" step can push without extra auth setup.
           token: ${{ steps.app-token.outputs.token }}
-          # Prevent the checkout action from persisting the token in the git config,
-          # since all authenticated operations use the explicit App token above.
-          persist-credentials: false
  
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -45,15 +45,22 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
-    # No GITHUB_TOKEN permissions needed — all git and gh operations use DOCS_PAT,
-    # which authenticates as a user and is not subject to the org-level restriction
-    # that prevents GITHUB_TOKEN from pushing branches or opening PRs.
+    # All git and gh operations authenticate via DOCS_PAT (a fine-grained PAT scoped
+    # to this repo with Contents and Pull requests write access). The org-level policy
+    # prevents GITHUB_TOKEN from pushing branches or opening PRs, so GITHUB_TOKEN is
+    # explicitly locked to read-only below to avoid granting unused token scopes.
+    # If DOCS_PAT is ever rotated or the owning account offboarded, update the secret
+    # under Settings → Secrets and variables → Actions.
+    # Alternative: use a GitHub App installation token (as in generate-changelog.yml)
+    # for finer-grained, expiring credentials that don't depend on a user account.
+    permissions:
+      contents: read
  
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Pass the PAT so that subsequent git push calls are authenticated.
+          # Pass the PAT so that subsequent git push and gh pr create calls are authenticated.
           token: ${{ secrets.DOCS_PAT }}
  
       - name: Set up Python

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.DOCS_APP_ID }}
           private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
@@ -66,6 +66,9 @@ jobs:
         with:
           # Use the App token so that subsequent git push calls are authenticated.
           token: ${{ steps.app-token.outputs.token }}
+          # Prevent the checkout action from persisting the token in the git config,
+          # since all authenticated operations use the explicit App token above.
+          persist-credentials: false
  
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -45,13 +45,16 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    # No GITHUB_TOKEN permissions needed — all git and gh operations use DOCS_PAT,
+    # which authenticates as a user and is not subject to the org-level restriction
+    # that prevents GITHUB_TOKEN from pushing branches or opening PRs.
  
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Pass the PAT so that subsequent git push calls are authenticated.
+          token: ${{ secrets.DOCS_PAT }}
  
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -100,7 +103,7 @@ jobs:
       - name: Create pull request
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DOCS_PAT }}
           COMPONENT: ${{ inputs.component }}
           VERSION: ${{ inputs.version }}
           RELEASE_TYPE: ${{ inputs.release_type }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -54,12 +54,18 @@ jobs:
       contents: read
  
     steps:
-      - name: Generate GitHub App token
+      # Changelog Automation (docs) app -- read/write access to mattermost/docs.
+      # Reuses the same app and credentials as generate-changelog.yml.
+      # Credentials are already present in Settings -> Secrets and variables -> Actions:
+      #   CHANGELOG_WRITE_CLIENT_ID   (variable) -- Client ID from the docs GitHub App
+      #   CHANGELOG_WRITE_PRIVATE_KEY (secret)   -- Private key from the docs GitHub App
+      - name: Get write token (docs repo)
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.DOCS_APP_ID }}
-          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.CHANGELOG_WRITE_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGELOG_WRITE_PRIVATE_KEY }}
+          owner: mattermost
  
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,7 +2,7 @@ name: Update Docs
  
 # Only members with write access to this repo can trigger workflow_dispatch.
 # To further restrict (e.g. require a specific team), protect the branch or
-# add an environment with required reviewers in repo Settings → Environments.
+# add an environment with required reviewers in repo Settings -> Environments.
 on:
   workflow_dispatch:
     inputs:
@@ -45,23 +45,27 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
-    # All git and gh operations authenticate via DOCS_PAT (a fine-grained PAT scoped
-    # to this repo with Contents and Pull requests write access). The org-level policy
-    # prevents GITHUB_TOKEN from pushing branches or opening PRs, so GITHUB_TOKEN is
-    # explicitly locked to read-only below to avoid granting unused token scopes.
-    # If DOCS_PAT is ever rotated or the owning account offboarded, update the secret
-    # under Settings → Secrets and variables → Actions.
-    # Alternative: use a GitHub App installation token (as in generate-changelog.yml)
-    # for finer-grained, expiring credentials that don't depend on a user account.
+    # GITHUB_TOKEN is locked to read-only; all git and gh operations authenticate
+    # via a short-lived GitHub App installation token (generated in the first step).
+    # This matches the pattern used in generate-changelog.yml and avoids the
+    # org-level restriction that prevents GITHUB_TOKEN from pushing branches or
+    # opening PRs.
     permissions:
       contents: read
  
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+ 
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Pass the PAT so that subsequent git push and gh pr create calls are authenticated.
-          token: ${{ secrets.DOCS_PAT }}
+          # Use the App token so that subsequent git push calls are authenticated.
+          token: ${{ steps.app-token.outputs.token }}
  
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -98,7 +102,7 @@ jobs:
           git add source/
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No files were modified — skipping PR creation."
+            echo "No files were modified -- skipping PR creation."
           else
             git commit -m "docs: update ${{ inputs.component }} files for v${{ inputs.version }} ${{ inputs.release_type }}"
             # --force-with-lease safely overwrites the remote branch on re-runs
@@ -110,7 +114,7 @@ jobs:
       - name: Create pull request
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.DOCS_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           COMPONENT: ${{ inputs.component }}
           VERSION: ${{ inputs.version }}
           RELEASE_TYPE: ${{ inputs.release_type }}
@@ -127,7 +131,7 @@ jobs:
           # Check before creating to avoid a duplicate-PR error.
           existing_pr="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')"
           if [ -n "$existing_pr" ]; then
-            echo "PR #${existing_pr} already exists for ${BRANCH} — skipping creation."
+            echo "PR #${existing_pr} already exists for ${BRANCH} -- skipping creation."
           else
             {
               echo "## ${COMPONENT} v${VERSION} ${RELEASE_TYPE} Documentation Update"

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -66,6 +66,7 @@ jobs:
           client-id: ${{ vars.CHANGELOG_WRITE_CLIENT_ID }}
           private-key: ${{ secrets.CHANGELOG_WRITE_PRIVATE_KEY }}
           owner: mattermost
+          repositories: docs
  
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Fixes based on a request from IT:

 - Added ``actions/create-github-app-token@v1``, which generates a short-lived installation token from ``DOCS_APP_ID and DOCS_APP_PRIVATE_KEY``. That token is then passed to both the checkout step and ``GH_TOKEN`` in the PR step. The note on the permissions block updated to reflect this.
 - Also added a minor fix for "source/product-overview/mattermost-v11-changelog.md" file.
