### PR TITLE
docs: clarify Entra ID SAML attribute namespace matching

### DIFF
--- a/source/administration-guide/onboard/sso-saml-entraid.rst
+++ b/source/administration-guide/onboard/sso-saml-entraid.rst
@@ -40,7 +40,20 @@ Set up an enterprise app for Mattermost SSO in Entra ID
 9. Select **Edit** in the **Attributes & Claims** section then set the below attributes:
 
   a. Set the the **Unique User Identifier (Name ID)** required claim **Name identifier format** and **Source attribute** values as required for your environment. Setting the **Source attribute** to an immutable value such as ``user.objectid`` is recommended.
-  b. Edit claim names and namespaces under **Additional claims** to match SAML attribute settings you wish to set in Mattermost. Configurable settings are Email, Username, Id, Guest, Admin, First Name, Last Name, Nickname, Position, and Preferred Language.
+  b. Edit claim names **and namespaces** under **Additional claims** to match SAML attribute settings you wish to set in Mattermost. Configurable settings are Email, Username, Id, Guest, Admin, First Name, Last Name, Nickname, Position, and Preferred Language.
+
+.. important::
+
+  Mattermost matches each attribute by its **full claim name**, including the namespace, exactly as it appears in the SAML assertion. By default, Entra ID emits its built-in claims under the namespace ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/`` — so the claim that appears in the **Claim name** column as ``emailaddress`` is actually sent in the assertion as ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``.
+
+  This means the value you enter in each Mattermost attribute field (step 15 of **Configure SAML Sign-On for Mattermost**, below) must be the **fully-qualified** claim name. Entering only the short name (for example, ``email`` or ``name``) will **not** match, and login will fail with an error such as ``SAML login was unsuccessful because one of the attributes is incorrect... <attribute> attribute is missing``.
+
+  You have two options:
+
+  - **Clear the namespace** on each claim in Entra ID under **Additional claims** so the claim name becomes the short value (for example, ``email``), then enter that same short value in Mattermost; **or**
+  - **Leave the default namespace** in Entra ID and enter the fully-qualified claim name in Mattermost (for example, ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress``).
+
+  Whichever option you choose, the value in Mattermost must match the assertion **character-for-character**. If a login fails, the safest way to confirm the exact claim names being sent is to capture and decode the SAML response from the browser (for example, with the `SAML-tracer <https://addons.mozilla.org/firefox/addon/saml-tracer/>`__ browser extension) and read the ``Name`` attribute of each ``<Attribute>`` element.
 
 10. Select **Edit** in the **SAML Certificates** section. Select **Sign SAML response and assertion** for **Signing Option** and **SHA-256** for **Signing Algorithm** then select **Save**.
 11. Select the **Certificate (Base64)** Download link in the **SAML Certificates** section. This is the **Identity Provider Public Certificate** to be uploaded to Mattermost.
@@ -71,7 +84,7 @@ Configure SAML Sign-On for Mattermost
 
   The **Test single sign-on with Mattermost SAML** tool in Microsoft Entra ID does not sign the request even if **Sign Request** is set to **True** in Mattermost. Depending on your security settings and key length, the Entra ID testing tool may successfully sign in while an actual sign in request from your Mattermost login page results in the error **AADSTS90015: Requested query string is too long.** since Entra ID handles the initial request with an HTTP GET redirect rather than HTTP POST.
 
-15. Set attribute settings to match attributes configured in step 9 of the **Set up an enterprise app for Mattermost SSO in Entra ID** section.
+15. Set attribute settings to match attributes configured in step 9 of the **Set up an enterprise app for Mattermost SSO in Entra ID** section. Each value must match the **full claim name** sent in the assertion, including the namespace, exactly. See the **important** note under step 9 for details and a common failure mode.
 16. Set the **Login Button Text** to suit your environment.
 17. Select the **Save** button.
 

--- a/source/administration-guide/onboard/sso-saml-faq.rst
+++ b/source/administration-guide/onboard/sso-saml-faq.rst
@@ -30,6 +30,20 @@ This process was designed with backwards compatibility to email binding. Here is
 .. note::
     Existing accounts won't update until they log in to the server. 
  
+Why does login fail with "one of the attributes is incorrect" / "<attribute> attribute is missing"?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A login failure with the error ``SAML login was unsuccessful because one of the attributes is incorrect. Please contact your System Administrator.`` — accompanied in the server logs by a detail such as ``email attribute is missing`` or ``name attribute is missing`` — means the assertion from your Identity Provider (IdP) did not contain an attribute whose name **exactly** matches what you configured in the Mattermost SAML attribute settings.
+
+Mattermost matches each attribute by its full ``Name`` (or ``FriendlyName``) as it appears in the assertion, character-for-character. The named attribute in the error message is the value you entered in Mattermost that could not be found.
+
+This most often happens because the IdP sends attributes under a namespace. For example, Microsoft Entra ID emits its built-in claims under ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/`` by default, so an attribute that looks like ``email`` in the Entra ID admin UI is actually sent in the assertion as ``http://schemas.xmlsoap.org/ws/2005/05/identity/claims/email``. Entering only ``email`` in Mattermost will not match.
+
+To resolve this:
+
+- Capture and decode the SAML response (for example, with the `SAML-tracer <https://addons.mozilla.org/firefox/addon/saml-tracer/>`__ browser extension) and read the ``Name`` attribute of each ``<Attribute>`` element in the ``<AttributeStatement>``.
+- Set each Mattermost attribute field to the **exact** ``Name`` value from the assertion — including any namespace prefix — or reconfigure the IdP to emit the claim under the short name you want to use in Mattermost.
+
 Can SAML via Microsoft ADFS be configured with Integrated Windows Authentication (IWA)?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Mattermost matches SAML assertion attributes by their **full** `Name` (or `FriendlyName`), including any namespace, character-for-character. Microsoft Entra ID emits its built-in claims under the `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/` namespace by default, so an admin who enters the short name shown in the Entra UI (e.g. `email`, `name`) into the Mattermost attribute fields gets a silent mismatch and login fails with:

```
SAML login was unsuccessful because one of the attributes is incorrect. Please contact your System Administrator., <attribute> attribute is missing
```

The current Entra ID guide mentions editing "claim names and namespaces" but doesn't explain that the value entered in Mattermost must be the fully-qualified claim name (or that the namespace must be cleared in Entra). The SAML FAQ has no entry for this error at all. This is a recurring support issue.

## Changes

- **`sso-saml-entraid.rst`**: add an `.. important::` note under the *Attributes & Claims* step explaining exact full-name matching, the two ways to reconcile it (clear the namespace in Entra, or use the fully-qualified name in Mattermost), and how to confirm the real claim names with SAML-tracer. Cross-referenced from the Mattermost-side attribute step.
- **`sso-saml-faq.rst`**: add a provider-agnostic troubleshooting entry for the `"one of the attributes is incorrect" / "<attribute> attribute is missing"` failure. This FAQ is `include`-ed on all SAML provider pages, so it surfaces for Okta/OneLogin/ADFS/Keycloak/Entra alike.

## Source

Derived from a support investigation (ticket 51591) where a captured Entra assertion confirmed the IdP sent `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/{email,name,emailaddress}` while the config used short names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)