### PR TITLE
Fix release docs automation

### DIFF
--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -1,3 +1,4 @@
+
 """
 update_docs.py
  
@@ -141,7 +142,7 @@ Rules:
 - Never remove or alter existing content unless it is explicitly outdated by this release.
 - Do not add placeholder text, commentary, or notes -- only real documentation content.
 - If a file does not need changes for this release type, return it exactly as-is.
-- Return ONLY the complete file content. No explanations, no markdown code fences, no preamble.
+- Return ONLY the content you were given (the full file, or the provided portion if the user prompt says the file is truncated). No explanations, no markdown code fences, no preamble.
 """
  
  
@@ -186,7 +187,9 @@ def update_file(client: anthropic.Anthropic, filepath: str) -> str:
     This keeps each Claude call small and well-defined, and ensures changelog
     entries accumulate correctly across versions.
  
-    Returns one of: "updated", "unchanged", "skipped", "not_found".
+    Returns one of: "updated", "unchanged", "not_found".
+    Version-level quality failures (empty response, too-short response) are logged
+    and skipped via continue -- they do not surface as a file-level "skipped" status.
     Raises on hard failures (I/O errors, API errors) so the caller can track them.
     """
     print(f"  Reading {filepath}...")
@@ -236,6 +239,16 @@ def update_file(client: anthropic.Anthropic, filepath: str) -> str:
             )
  
         updated = response.content[0].text
+ 
+        # For truncated files, Claude should return only the head portion, but it may
+        # occasionally return slightly more. Cap the result at MAX_SEND_CHARS so that
+        # subsequent version passes don't receive an ever-growing prompt.
+        if truncated and len(updated) > MAX_SEND_CHARS:
+            print(
+                f"  WARNING: Claude returned {len(updated):,} chars for {filepath} "
+                f"(version {version}); truncating to first {MAX_SEND_CHARS:,} chars."
+            )
+            updated = updated[:MAX_SEND_CHARS]
  
         # --- Content quality guards (warn and skip this version, not the whole file) ---
         if not updated.strip():

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -10,7 +10,11 @@ Required environment variables:
   ANTHROPIC_API_KEY  -- Anthropic API key (stored as a GitHub secret)
   COMPONENT          -- "Server", "Mobile", or "Desktop"
   RELEASE_TYPE       -- e.g. "ESR", "Feature Release", "Patch / Dot Release"
-  VERSION            -- Version number, e.g. "11.7", "2.40", "6.2", "5.13.6"
+  VERSION            -- One or more version numbers, comma-separated.
+                        e.g. "11.7" or "10.11.20, 11.6.5, 11.7.3"
+                        When multiple versions are given, each file is updated
+                        once per version in sequence. Enter oldest-to-newest so
+                        the newest entry ends up at the top of changelogs.
   RELEASE_DATE       -- Human-readable release date, e.g. "May 15, 2026"
  
 Optional:
@@ -27,9 +31,17 @@ import anthropic
  
 COMPONENT = os.environ["COMPONENT"]          # Server | Mobile | Desktop
 RELEASE_TYPE = os.environ["RELEASE_TYPE"]    # ESR | Feature Release | etc.
-VERSION = os.environ["VERSION"]
 RELEASE_DATE = os.environ["RELEASE_DATE"]
 ESR_END_DATE = os.environ.get("ESR_END_DATE", "").strip()
+ 
+# Parse VERSION as a comma-separated list so the workflow can be triggered once
+# for multi-version releases (e.g. security patches across several branches).
+# Each version is applied to every file in sequence; the output of one version
+# becomes the input for the next, so entries accumulate correctly in changelogs.
+VERSIONS: list[str] = [v.strip() for v in os.environ["VERSION"].split(",") if v.strip()]
+if not VERSIONS:
+    print("ERROR: VERSION environment variable is empty.")
+    sys.exit(1)
  
 # Upper bound on Claude's output per file. Most docs files are a few thousand
 # tokens; 32 000 provides ample headroom without approaching the model's 64 k
@@ -133,7 +145,7 @@ Rules:
 """
  
  
-def build_user_prompt(filepath: str, content: str, truncated: bool = False) -> str:
+def build_user_prompt(filepath: str, content: str, version: str, truncated: bool = False) -> str:
     esr_note = f"\n- ESR end-of-support date: {ESR_END_DATE}" if ESR_END_DATE else ""
     truncation_note = (
         "\nNOTE: This file was too large to send in full. You are seeing only the first "
@@ -145,7 +157,7 @@ def build_user_prompt(filepath: str, content: str, truncated: bool = False) -> s
  
 Release details:
 - Component: {COMPONENT}
-- Version: {VERSION}
+- Version: {version}
 - Release type: {RELEASE_TYPE}
 - Release date: {RELEASE_DATE}{esr_note}
  
@@ -169,7 +181,14 @@ Return the complete file content only."""
 def update_file(client: anthropic.Anthropic, filepath: str) -> str:
     """Update a single documentation file via the Claude API.
  
-    Returns one of: "updated", "unchanged", "skipped", "not_found".
+    When VERSIONS contains multiple entries, the file is updated once per version
+    in sequence: the output of version N becomes the input for version N+1.
+    This keeps each Claude call small and well-defined, and ensures changelog
+    entries accumulate correctly across versions.
+ 
+    Returns one of: "updated", "unchanged", "not_found".
+    Version-level quality failures (empty response, too-short response) are logged
+    and skipped via continue -- they do not surface as a file-level status.
     Raises on hard failures (I/O errors, API errors) so the caller can track them.
     """
     print(f"  Reading {filepath}...")
@@ -181,63 +200,82 @@ def update_file(client: anthropic.Anthropic, filepath: str) -> str:
         return "not_found"
  
     # Large changelogs only need recent context; new entries go near the top.
-    # Send only the head and reconstruct the full file afterward.
+    # Capture the tail once from the original; it stays untouched across all versions.
     truncated = len(original) > MAX_SEND_CHARS
-    send_content = original[:MAX_SEND_CHARS] if truncated else original
     tail = original[MAX_SEND_CHARS:] if truncated else ""
- 
     if truncated:
         print(
             f"  NOTE: File is {len(original):,} chars; "
             f"sending first {MAX_SEND_CHARS:,} chars to Claude."
         )
  
-    print(f"  Sending to Claude...")
-    response = client.messages.create(
-        model="claude-sonnet-4-6",
-        max_tokens=MAX_TOKENS,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": build_user_prompt(filepath, send_content, truncated)}],
-    )
+    # current holds the working head (without tail) updated after each version pass.
+    current = original[:MAX_SEND_CHARS] if truncated else original
+    any_changed = False
  
-    # --- API response integrity checks (raise -> file marked as failed) ---
-    # These guard against malformed or truncated API responses before we touch
-    # the file. They are distinct from the content-quality guards below, which
-    # are softer checks that skip a file with a warning rather than failing it.
-    if not response.content or response.content[0].type != "text":
-        raise RuntimeError(
-            f"Unexpected API response structure for {filepath}: "
-            f"content={response.content!r}"
-        )
-    if response.stop_reason == "max_tokens":
-        raise RuntimeError(
-            f"Claude hit max_tokens ({MAX_TOKENS}) for {filepath}; output is truncated. "
-            "Increase MAX_TOKENS or split the file."
+    for version in VERSIONS:
+        print(f"  Sending to Claude (version {version})...")
+        response = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": build_user_prompt(filepath, current, version, truncated)}],
         )
  
-    updated = response.content[0].text
+        # --- API response integrity checks (raise -> file marked as failed) ---
+        # These guard against malformed or truncated API responses before we touch
+        # the file. They are distinct from the content-quality guards below, which
+        # are softer checks that skip a version with a warning rather than failing it.
+        if not response.content or response.content[0].type != "text":
+            raise RuntimeError(
+                f"Unexpected API response structure for {filepath} (version {version}): "
+                f"content={response.content!r}"
+            )
+        if response.stop_reason == "max_tokens":
+            raise RuntimeError(
+                f"Claude hit max_tokens ({MAX_TOKENS}) for {filepath} (version {version}); "
+                "output is truncated. Increase MAX_TOKENS or split the file."
+            )
  
-    # --- Content quality guards (return "skipped", file not marked failed) ---
-    # Safety: don't write empty content
-    if not updated.strip():
-        print(f"  WARNING: Claude returned empty content for {filepath} -- skipping.")
-        return "skipped"
+        updated = response.content[0].text
  
-    # Safety: skip if response is dramatically shorter than what was sent
-    if len(updated) < len(send_content) * 0.5:
-        print(
-            f"  WARNING: Updated content for {filepath} is less than 50% of sent "
-            "content length. Skipping to avoid data loss."
-        )
-        return "skipped"
+        # For truncated files, Claude should return only the head portion, but it may
+        # occasionally return slightly more. Cap the result at MAX_SEND_CHARS so that
+        # subsequent version passes don't receive an ever-growing prompt.
+        if truncated and len(updated) > MAX_SEND_CHARS:
+            print(
+                f"  WARNING: Claude returned {len(updated):,} chars for {filepath} "
+                f"(version {version}); truncating to first {MAX_SEND_CHARS:,} chars."
+            )
+            updated = updated[:MAX_SEND_CHARS]
  
-    # No-op: the sent portion is unchanged (compare against what was sent, not full file)
-    if updated.strip() == send_content.strip():
+        # --- Content quality guards (warn and skip this version, not the whole file) ---
+        if not updated.strip():
+            print(f"  WARNING: Claude returned empty content for {filepath} (version {version}) -- skipping this version.")
+            continue
+ 
+        if len(updated) < len(current) * 0.5:
+            print(
+                f"  WARNING: Updated content for {filepath} (version {version}) is less than "
+                "50% of sent content length -- skipping this version to avoid data loss."
+            )
+            continue
+ 
+        if updated.strip() == current.strip():
+            print(f"  No changes needed for version {version}.")
+            continue
+ 
+        # This version changed the file -- chain its output as input to the next version.
+        current = updated
+        any_changed = True
+        print(f"  Version {version} applied.")
+ 
+    if not any_changed:
         print(f"  No changes needed -- {filepath} left as-is.")
         return "unchanged"
  
-    # Reconstruct: Claude's updated head + the untouched tail (if file was truncated)
-    final_content = updated + tail if truncated else updated
+    # Reconstruct: updated head + the untouched tail (if file was truncated)
+    final_content = current + tail if truncated else current
  
     with open(filepath, "w", encoding="utf-8") as f:
         f.write(final_content)
@@ -256,7 +294,7 @@ def main():
     print(f"\nMattermost Docs Update")
     print(f"  Component:    {COMPONENT}")
     print(f"  Release type: {RELEASE_TYPE}")
-    print(f"  Version:      {VERSION}")
+    print(f"  Version(s):   {', '.join(VERSIONS)}")
     print(f"  Release date: {RELEASE_DATE}")
     if ESR_END_DATE:
         print(f"  ESR end date: {ESR_END_DATE}")

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -86,13 +86,10 @@ SERVER_BASE_FILES = [
     "source/product-overview/ui-ada-changelog.rst",
 ]
  
-# The v11 changelog is only updated for Patch / Dot releases and Security releases.
+# These changelog files are only updated for Patch / Dot releases and Security releases.
 # Feature and ESR releases have a dedicated changelog automation (generate-changelog.yml)
-# that handles this file separately.
-# Note: this list only covers v11. If a security release patches an older major version
-# (e.g. v10), the corresponding changelog file (e.g. mattermost-v10-changelog.md) would
-# need to be added here. Update this list when the active major version changes.
-# The file can be very large; MAX_SEND_CHARS limits what is sent to Claude per version
+# that handles them separately.
+# The files can be very large; MAX_SEND_CHARS limits what is sent to Claude per version
 # pass to the most-recent portion where new entries are added.
 SERVER_CHANGELOG_FILES = [
     "source/product-overview/mattermost-v10-changelog.md",

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -7,14 +7,18 @@ sends each file to the Anthropic API with release context, and writes
 the updated content back to disk.
  
 Required environment variables:
-  ANTHROPIC_API_KEY  — Anthropic API key (stored as a GitHub secret)
-  COMPONENT          — "Server", "Mobile", or "Desktop"
-  RELEASE_TYPE       — e.g. "ESR", "Feature Release", "Patch / Dot Release"
-  VERSION            — Version number, e.g. "11.7", "2.40", "6.2", "5.13.6"
-  RELEASE_DATE       — Human-readable release date, e.g. "May 15, 2026"
+  ANTHROPIC_API_KEY  -- Anthropic API key (stored as a GitHub secret)
+  COMPONENT          -- "Server", "Mobile", or "Desktop"
+  RELEASE_TYPE       -- e.g. "ESR", "Feature Release", "Patch / Dot Release"
+  VERSION            -- One or more version numbers, comma-separated.
+                        e.g. "11.7" or "11.7.3, 11.6.5, 10.11.20"
+                        When multiple versions are given, each file is updated
+                        once per version in sequence (oldest-first is recommended
+                        so entries appear newest-first in changelogs).
+  RELEASE_DATE       -- Human-readable release date, e.g. "May 15, 2026"
  
 Optional:
-  ESR_END_DATE       — ESR end-of-support date, e.g. "November 15, 2026"
+  ESR_END_DATE       -- ESR end-of-support date, e.g. "November 15, 2026"
 """
  
 import os
@@ -27,9 +31,17 @@ import anthropic
  
 COMPONENT = os.environ["COMPONENT"]          # Server | Mobile | Desktop
 RELEASE_TYPE = os.environ["RELEASE_TYPE"]    # ESR | Feature Release | etc.
-VERSION = os.environ["VERSION"]
 RELEASE_DATE = os.environ["RELEASE_DATE"]
 ESR_END_DATE = os.environ.get("ESR_END_DATE", "").strip()
+ 
+# Parse VERSION as a comma-separated list so the workflow can be triggered once
+# for multi-version releases (e.g. security patches across several branches).
+# Each version is applied to every file in sequence; the output of one version
+# becomes the input for the next, so entries accumulate correctly in changelogs.
+VERSIONS: list[str] = [v.strip() for v in os.environ["VERSION"].split(",") if v.strip()]
+if not VERSIONS:
+    print("ERROR: VERSION environment variable is empty.")
+    sys.exit(1)
  
 # Upper bound on Claude's output per file. Most docs files are a few thousand
 # tokens; 32 000 provides ample headroom without approaching the model's 64 k
@@ -94,13 +106,13 @@ DESKTOP_ESR_EXTRA_FILES = [
 def get_files() -> list[str]:
     if COMPONENT == "Server":
         if RELEASE_TYPE in ("Patch / Dot Release", "Security Release"):
-            # Changelog included — no dedicated automation for these release types.
+            # Changelog included -- no dedicated automation for these release types.
             return SERVER_BASE_FILES + SERVER_CHANGELOG_FILES
         elif RELEASE_TYPE in ("Feature Release", "ESR"):
-            # Changelog excluded — generate-changelog.yml handles it for these types.
+            # Changelog excluded -- generate-changelog.yml handles it for these types.
             return SERVER_BASE_FILES
         else:
-            # "Other" and any future types — skip the changelog to avoid unintended edits.
+            # "Other" and any future types -- skip the changelog to avoid unintended edits.
             # Add an explicit branch above if a new release type needs changelog updates.
             return SERVER_BASE_FILES
     elif COMPONENT == "Mobile":
@@ -109,7 +121,7 @@ def get_files() -> list[str]:
         if RELEASE_TYPE == "ESR":
             return DESKTOP_BASE_FILES + DESKTOP_ESR_EXTRA_FILES
         else:
-            # Patch / Dot Release, Feature Release, etc. — base files only
+            # Patch / Dot Release, Feature Release, etc. -- base files only
             return DESKTOP_BASE_FILES
     else:
         print(f"ERROR: Unknown component '{COMPONENT}'. Expected Server, Mobile, or Desktop.")
@@ -127,17 +139,17 @@ Rules:
 - Follow the exact same formatting, style, and conventions already present in the file.
 - Add new entries in the correct location (usually at the top of a table or list, or after the most recent entry).
 - Never remove or alter existing content unless it is explicitly outdated by this release.
-- Do not add placeholder text, commentary, or notes — only real documentation content.
+- Do not add placeholder text, commentary, or notes -- only real documentation content.
 - If a file does not need changes for this release type, return it exactly as-is.
 - Return ONLY the complete file content. No explanations, no markdown code fences, no preamble.
 """
  
  
-def build_user_prompt(filepath: str, content: str, truncated: bool = False) -> str:
+def build_user_prompt(filepath: str, content: str, version: str, truncated: bool = False) -> str:
     esr_note = f"\n- ESR end-of-support date: {ESR_END_DATE}" if ESR_END_DATE else ""
     truncation_note = (
         "\nNOTE: This file was too large to send in full. You are seeing only the first "
-        f"{MAX_SEND_CHARS:,} characters. Return only this portion (updated as needed) — "
+        f"{MAX_SEND_CHARS:,} characters. Return only this portion (updated as needed) -- "
         "do NOT attempt to reconstruct or append the rest of the file."
     ) if truncated else ""
  
@@ -145,7 +157,7 @@ def build_user_prompt(filepath: str, content: str, truncated: bool = False) -> s
  
 Release details:
 - Component: {COMPONENT}
-- Version: {VERSION}
+- Version: {version}
 - Release type: {RELEASE_TYPE}
 - Release date: {RELEASE_DATE}{esr_note}
  
@@ -169,6 +181,11 @@ Return the complete file content only."""
 def update_file(client: anthropic.Anthropic, filepath: str) -> str:
     """Update a single documentation file via the Claude API.
  
+    When VERSIONS contains multiple entries, the file is updated once per version
+    in sequence: the output of version N becomes the input for version N+1.
+    This keeps each Claude call small and well-defined, and ensures changelog
+    entries accumulate correctly across versions.
+ 
     Returns one of: "updated", "unchanged", "skipped", "not_found".
     Raises on hard failures (I/O errors, API errors) so the caller can track them.
     """
@@ -177,72 +194,81 @@ def update_file(client: anthropic.Anthropic, filepath: str) -> str:
         with open(filepath, "r", encoding="utf-8") as f:
             original = f.read()
     except FileNotFoundError:
-        print(f"  WARNING: {filepath} not found — skipping.")
+        print(f"  WARNING: {filepath} not found -- skipping.")
         return "not_found"
  
     # Large changelogs only need recent context; new entries go near the top.
-    # Send only the head and reconstruct the full file afterward.
+    # Capture the tail once from the original; it stays untouched across all versions.
     truncated = len(original) > MAX_SEND_CHARS
-    send_content = original[:MAX_SEND_CHARS] if truncated else original
     tail = original[MAX_SEND_CHARS:] if truncated else ""
- 
     if truncated:
         print(
             f"  NOTE: File is {len(original):,} chars; "
             f"sending first {MAX_SEND_CHARS:,} chars to Claude."
         )
  
-    print(f"  Sending to Claude...")
-    response = client.messages.create(
-        model="claude-sonnet-4-6",
-        max_tokens=MAX_TOKENS,
-        system=SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": build_user_prompt(filepath, send_content, truncated)}],
-    )
+    # current holds the working head (without tail) updated after each version pass.
+    current = original[:MAX_SEND_CHARS] if truncated else original
+    any_changed = False
  
-    # --- API response integrity checks (raise → file marked as failed) ---
-    # These guard against malformed or truncated API responses before we touch
-    # the file. They are distinct from the content-quality guards below, which
-    # are softer checks that skip a file with a warning rather than failing it.
-    if not response.content or response.content[0].type != "text":
-        raise RuntimeError(
-            f"Unexpected API response structure for {filepath}: "
-            f"content={response.content!r}"
-        )
-    if response.stop_reason == "max_tokens":
-        raise RuntimeError(
-            f"Claude hit max_tokens ({MAX_TOKENS}) for {filepath}; output is truncated. "
-            "Increase MAX_TOKENS or split the file."
+    for version in VERSIONS:
+        print(f"  Sending to Claude (version {version})...")
+        response = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": build_user_prompt(filepath, current, version, truncated)}],
         )
  
-    updated = response.content[0].text
+        # --- API response integrity checks (raise -> file marked as failed) ---
+        # These guard against malformed or truncated API responses before we touch
+        # the file. They are distinct from the content-quality guards below, which
+        # are softer checks that skip a version with a warning rather than failing it.
+        if not response.content or response.content[0].type != "text":
+            raise RuntimeError(
+                f"Unexpected API response structure for {filepath} (version {version}): "
+                f"content={response.content!r}"
+            )
+        if response.stop_reason == "max_tokens":
+            raise RuntimeError(
+                f"Claude hit max_tokens ({MAX_TOKENS}) for {filepath} (version {version}); "
+                "output is truncated. Increase MAX_TOKENS or split the file."
+            )
  
-    # --- Content quality guards (return "skipped", file not marked failed) ---
-    # Safety: don't write empty content
-    if not updated.strip():
-        print(f"  WARNING: Claude returned empty content for {filepath} — skipping.")
-        return "skipped"
+        updated = response.content[0].text
  
-    # Safety: skip if response is dramatically shorter than what was sent
-    if len(updated) < len(send_content) * 0.5:
-        print(
-            f"  WARNING: Updated content for {filepath} is less than 50% of sent "
-            "content length. Skipping to avoid data loss."
-        )
-        return "skipped"
+        # --- Content quality guards (warn and skip this version, not the whole file) ---
+        if not updated.strip():
+            print(f"  WARNING: Claude returned empty content for {filepath} (version {version}) -- skipping this version.")
+            continue
  
-    # No-op: the sent portion is unchanged (compare against what was sent, not full file)
-    if updated.strip() == send_content.strip():
-        print(f"  No changes needed — {filepath} left as-is.")
+        if len(updated) < len(current) * 0.5:
+            print(
+                f"  WARNING: Updated content for {filepath} (version {version}) is less than "
+                "50% of sent content length -- skipping this version to avoid data loss."
+            )
+            continue
+ 
+        if updated.strip() == current.strip():
+            print(f"  No changes needed for version {version}.")
+            continue
+ 
+        # This version changed the file -- chain its output as input to the next version.
+        current = updated
+        any_changed = True
+        print(f"  Version {version} applied.")
+ 
+    if not any_changed:
+        print(f"  No changes needed -- {filepath} left as-is.")
         return "unchanged"
  
-    # Reconstruct: Claude's updated head + the untouched tail (if file was truncated)
-    final_content = updated + tail if truncated else updated
+    # Reconstruct: updated head + the untouched tail (if file was truncated)
+    final_content = current + tail if truncated else current
  
     with open(filepath, "w", encoding="utf-8") as f:
         f.write(final_content)
  
-    print(f"  Done — {filepath} updated.")
+    print(f"  Done -- {filepath} updated.")
     return "updated"
  
  
@@ -256,7 +282,7 @@ def main():
     print(f"\nMattermost Docs Update")
     print(f"  Component:    {COMPONENT}")
     print(f"  Release type: {RELEASE_TYPE}")
-    print(f"  Version:      {VERSION}")
+    print(f"  Version(s):   {', '.join(VERSIONS)}")
     print(f"  Release date: {RELEASE_DATE}")
     if ESR_END_DATE:
         print(f"  ESR end date: {ESR_END_DATE}")
@@ -267,7 +293,10 @@ def main():
  
     client = anthropic.Anthropic(
         api_key=os.environ["ANTHROPIC_API_KEY"],
-        timeout=120.0,   # seconds per request; prevents hung runs on slow responses
+        # Large files (e.g. the v11 changelog at 50 k chars input + up to 32 k output
+        # tokens) can take several minutes. 300 s gives ample headroom without
+        # letting a truly hung request block the workflow indefinitely.
+        timeout=300.0,
         max_retries=2,   # default is 2; made explicit for clarity
     )
  
@@ -289,7 +318,7 @@ def main():
             errors.append((filepath, f"{type(e).__name__}: {e}"))
         print()
  
-    # Summary — always printed so operators can see what actually happened
+    # Summary -- always printed so operators can see what actually happened
     print("--- Summary ---")
     print(f"  Updated:   {len(results['updated'])}")
     print(f"  Unchanged: {len(results['unchanged'])}")
@@ -303,7 +332,7 @@ def main():
             print(f"  {fp}: {err}")
         sys.exit(1)
     elif results["skipped"] or results["not_found"]:
-        print("\nCompleted with warnings — review skipped/not-found files above.")
+        print("\nCompleted with warnings -- review skipped/not-found files above.")
     else:
         print("\nAll files processed successfully.")
  

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -1,4 +1,3 @@
-
 """
 update_docs.py
  

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -95,6 +95,7 @@ SERVER_BASE_FILES = [
 # The file can be very large; MAX_SEND_CHARS limits what is sent to Claude per version
 # pass to the most-recent portion where new entries are added.
 SERVER_CHANGELOG_FILES = [
+    "source/product-overview/mattermost-v10-changelog.md",
     "source/product-overview/mattermost-v11-changelog.md",
 ]
  

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -10,11 +10,7 @@ Required environment variables:
   ANTHROPIC_API_KEY  -- Anthropic API key (stored as a GitHub secret)
   COMPONENT          -- "Server", "Mobile", or "Desktop"
   RELEASE_TYPE       -- e.g. "ESR", "Feature Release", "Patch / Dot Release"
-  VERSION            -- One or more version numbers, comma-separated.
-                        e.g. "11.7" or "11.7.3, 11.6.5, 10.11.20"
-                        When multiple versions are given, each file is updated
-                        once per version in sequence (oldest-first is recommended
-                        so entries appear newest-first in changelogs).
+  VERSION            -- Version number, e.g. "11.7", "2.40", "6.2", "5.13.6"
   RELEASE_DATE       -- Human-readable release date, e.g. "May 15, 2026"
  
 Optional:
@@ -31,17 +27,9 @@ import anthropic
  
 COMPONENT = os.environ["COMPONENT"]          # Server | Mobile | Desktop
 RELEASE_TYPE = os.environ["RELEASE_TYPE"]    # ESR | Feature Release | etc.
+VERSION = os.environ["VERSION"]
 RELEASE_DATE = os.environ["RELEASE_DATE"]
 ESR_END_DATE = os.environ.get("ESR_END_DATE", "").strip()
- 
-# Parse VERSION as a comma-separated list so the workflow can be triggered once
-# for multi-version releases (e.g. security patches across several branches).
-# Each version is applied to every file in sequence; the output of one version
-# becomes the input for the next, so entries accumulate correctly in changelogs.
-VERSIONS: list[str] = [v.strip() for v in os.environ["VERSION"].split(",") if v.strip()]
-if not VERSIONS:
-    print("ERROR: VERSION environment variable is empty.")
-    sys.exit(1)
  
 # Upper bound on Claude's output per file. Most docs files are a few thousand
 # tokens; 32 000 provides ample headroom without approaching the model's 64 k
@@ -145,7 +133,7 @@ Rules:
 """
  
  
-def build_user_prompt(filepath: str, content: str, version: str, truncated: bool = False) -> str:
+def build_user_prompt(filepath: str, content: str, truncated: bool = False) -> str:
     esr_note = f"\n- ESR end-of-support date: {ESR_END_DATE}" if ESR_END_DATE else ""
     truncation_note = (
         "\nNOTE: This file was too large to send in full. You are seeing only the first "
@@ -157,7 +145,7 @@ def build_user_prompt(filepath: str, content: str, version: str, truncated: bool
  
 Release details:
 - Component: {COMPONENT}
-- Version: {version}
+- Version: {VERSION}
 - Release type: {RELEASE_TYPE}
 - Release date: {RELEASE_DATE}{esr_note}
  
@@ -181,14 +169,7 @@ Return the complete file content only."""
 def update_file(client: anthropic.Anthropic, filepath: str) -> str:
     """Update a single documentation file via the Claude API.
  
-    When VERSIONS contains multiple entries, the file is updated once per version
-    in sequence: the output of version N becomes the input for version N+1.
-    This keeps each Claude call small and well-defined, and ensures changelog
-    entries accumulate correctly across versions.
- 
-    Returns one of: "updated", "unchanged", "not_found".
-    Version-level quality failures (empty response, too-short response) are logged
-    and skipped via continue -- they do not surface as a file-level "skipped" status.
+    Returns one of: "updated", "unchanged", "skipped", "not_found".
     Raises on hard failures (I/O errors, API errors) so the caller can track them.
     """
     print(f"  Reading {filepath}...")
@@ -200,82 +181,63 @@ def update_file(client: anthropic.Anthropic, filepath: str) -> str:
         return "not_found"
  
     # Large changelogs only need recent context; new entries go near the top.
-    # Capture the tail once from the original; it stays untouched across all versions.
+    # Send only the head and reconstruct the full file afterward.
     truncated = len(original) > MAX_SEND_CHARS
+    send_content = original[:MAX_SEND_CHARS] if truncated else original
     tail = original[MAX_SEND_CHARS:] if truncated else ""
+ 
     if truncated:
         print(
             f"  NOTE: File is {len(original):,} chars; "
             f"sending first {MAX_SEND_CHARS:,} chars to Claude."
         )
  
-    # current holds the working head (without tail) updated after each version pass.
-    current = original[:MAX_SEND_CHARS] if truncated else original
-    any_changed = False
+    print(f"  Sending to Claude...")
+    response = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=MAX_TOKENS,
+        system=SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": build_user_prompt(filepath, send_content, truncated)}],
+    )
  
-    for version in VERSIONS:
-        print(f"  Sending to Claude (version {version})...")
-        response = client.messages.create(
-            model="claude-sonnet-4-6",
-            max_tokens=MAX_TOKENS,
-            system=SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": build_user_prompt(filepath, current, version, truncated)}],
+    # --- API response integrity checks (raise -> file marked as failed) ---
+    # These guard against malformed or truncated API responses before we touch
+    # the file. They are distinct from the content-quality guards below, which
+    # are softer checks that skip a file with a warning rather than failing it.
+    if not response.content or response.content[0].type != "text":
+        raise RuntimeError(
+            f"Unexpected API response structure for {filepath}: "
+            f"content={response.content!r}"
+        )
+    if response.stop_reason == "max_tokens":
+        raise RuntimeError(
+            f"Claude hit max_tokens ({MAX_TOKENS}) for {filepath}; output is truncated. "
+            "Increase MAX_TOKENS or split the file."
         )
  
-        # --- API response integrity checks (raise -> file marked as failed) ---
-        # These guard against malformed or truncated API responses before we touch
-        # the file. They are distinct from the content-quality guards below, which
-        # are softer checks that skip a version with a warning rather than failing it.
-        if not response.content or response.content[0].type != "text":
-            raise RuntimeError(
-                f"Unexpected API response structure for {filepath} (version {version}): "
-                f"content={response.content!r}"
-            )
-        if response.stop_reason == "max_tokens":
-            raise RuntimeError(
-                f"Claude hit max_tokens ({MAX_TOKENS}) for {filepath} (version {version}); "
-                "output is truncated. Increase MAX_TOKENS or split the file."
-            )
+    updated = response.content[0].text
  
-        updated = response.content[0].text
+    # --- Content quality guards (return "skipped", file not marked failed) ---
+    # Safety: don't write empty content
+    if not updated.strip():
+        print(f"  WARNING: Claude returned empty content for {filepath} -- skipping.")
+        return "skipped"
  
-        # For truncated files, Claude should return only the head portion, but it may
-        # occasionally return slightly more. Cap the result at MAX_SEND_CHARS so that
-        # subsequent version passes don't receive an ever-growing prompt.
-        if truncated and len(updated) > MAX_SEND_CHARS:
-            print(
-                f"  WARNING: Claude returned {len(updated):,} chars for {filepath} "
-                f"(version {version}); truncating to first {MAX_SEND_CHARS:,} chars."
-            )
-            updated = updated[:MAX_SEND_CHARS]
+    # Safety: skip if response is dramatically shorter than what was sent
+    if len(updated) < len(send_content) * 0.5:
+        print(
+            f"  WARNING: Updated content for {filepath} is less than 50% of sent "
+            "content length. Skipping to avoid data loss."
+        )
+        return "skipped"
  
-        # --- Content quality guards (warn and skip this version, not the whole file) ---
-        if not updated.strip():
-            print(f"  WARNING: Claude returned empty content for {filepath} (version {version}) -- skipping this version.")
-            continue
- 
-        if len(updated) < len(current) * 0.5:
-            print(
-                f"  WARNING: Updated content for {filepath} (version {version}) is less than "
-                "50% of sent content length -- skipping this version to avoid data loss."
-            )
-            continue
- 
-        if updated.strip() == current.strip():
-            print(f"  No changes needed for version {version}.")
-            continue
- 
-        # This version changed the file -- chain its output as input to the next version.
-        current = updated
-        any_changed = True
-        print(f"  Version {version} applied.")
- 
-    if not any_changed:
+    # No-op: the sent portion is unchanged (compare against what was sent, not full file)
+    if updated.strip() == send_content.strip():
         print(f"  No changes needed -- {filepath} left as-is.")
         return "unchanged"
  
-    # Reconstruct: updated head + the untouched tail (if file was truncated)
-    final_content = current + tail if truncated else current
+    # Reconstruct: Claude's updated head + the untouched tail (if file was truncated)
+    final_content = updated + tail if truncated else updated
  
     with open(filepath, "w", encoding="utf-8") as f:
         f.write(final_content)
@@ -294,7 +256,7 @@ def main():
     print(f"\nMattermost Docs Update")
     print(f"  Component:    {COMPONENT}")
     print(f"  Release type: {RELEASE_TYPE}")
-    print(f"  Version(s):   {', '.join(VERSIONS)}")
+    print(f"  Version:      {VERSION}")
     print(f"  Release date: {RELEASE_DATE}")
     if ESR_END_DATE:
         print(f"  ESR end date: {ESR_END_DATE}")

--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -43,6 +43,14 @@ if not VERSIONS:
     print("ERROR: VERSION environment variable is empty.")
     sys.exit(1)
  
+# Guard against accidental long lists (e.g. a typo that produces many tokens).
+# Each version multiplies API calls (one per file per version), so cap this early.
+MAX_VERSIONS = 5
+if len(VERSIONS) > MAX_VERSIONS:
+    print(f"ERROR: {len(VERSIONS)} versions given; maximum is {MAX_VERSIONS}.")
+    print("Split into multiple workflow runs or fix the version list.")
+    sys.exit(1)
+ 
 # Upper bound on Claude's output per file. Most docs files are a few thousand
 # tokens; 32 000 provides ample headroom without approaching the model's 64 k
 # output limit. Raise this if a truncation error is ever hit.
@@ -81,8 +89,11 @@ SERVER_BASE_FILES = [
 # The v11 changelog is only updated for Patch / Dot releases and Security releases.
 # Feature and ESR releases have a dedicated changelog automation (generate-changelog.yml)
 # that handles this file separately.
-# Note: this file can be very large; MAX_SEND_CHARS already limits what is sent to
-# Claude to the most-recent portion where new dot-release entries are added.
+# Note: this list only covers v11. If a security release patches an older major version
+# (e.g. v10), the corresponding changelog file (e.g. mattermost-v10-changelog.md) would
+# need to be added here. Update this list when the active major version changes.
+# The file can be very large; MAX_SEND_CHARS limits what is sent to Claude per version
+# pass to the most-recent portion where new entries are added.
 SERVER_CHANGELOG_FILES = [
     "source/product-overview/mattermost-v11-changelog.md",
 ]
@@ -249,17 +260,21 @@ def update_file(client: anthropic.Anthropic, filepath: str) -> str:
             )
             updated = updated[:MAX_SEND_CHARS]
  
-        # --- Content quality guards (warn and skip this version, not the whole file) ---
+        # --- Content quality guards ---
+        # These raise rather than continue so that a partial application (some versions
+        # applied, some not) is surfaced as a hard failure. A PR opened with only some
+        # versions applied is harder to detect than a failed run.
         if not updated.strip():
-            print(f"  WARNING: Claude returned empty content for {filepath} (version {version}) -- skipping this version.")
-            continue
+            raise RuntimeError(
+                f"Claude returned empty content for {filepath} (version {version}). "
+                "Aborting to prevent partial version application."
+            )
  
         if len(updated) < len(current) * 0.5:
-            print(
-                f"  WARNING: Updated content for {filepath} (version {version}) is less than "
-                "50% of sent content length -- skipping this version to avoid data loss."
+            raise RuntimeError(
+                f"Updated content for {filepath} (version {version}) is less than 50% of "
+                "sent content length. Aborting to prevent partial version application or data loss."
             )
-            continue
  
         if updated.strip() == current.strip():
             print(f"  No changes needed for version {version}.")

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -25,7 +25,7 @@ on:
           - Patch / Dot Release
           - Other
       version:
-        description: 'Version number (e.g., 11.7, 2.40, 6.2, 5.13.6)'
+        description: 'Version number(s), comma-separated (e.g., 11.7 or 10.11.20, 11.6.5, 11.7.3). For multi-version security releases enter oldest-to-newest.'
         required: true
         type: string
       release_date:
@@ -98,7 +98,10 @@ jobs:
         id: vars
         shell: bash
         run: |
-          safe_version="$(printf '%s' "${{ inputs.version }}" | tr ' /' '--' | tr -cd '[:alnum:]._-')"
+          # Replace commas and spaces with hyphens, strip remaining special chars,
+          # then squeeze any consecutive hyphens to one.
+          # e.g. "10.11.20, 11.6.5, 11.7.3" -> "10.11.20-11.6.5-11.7.3"
+          safe_version="$(printf '%s' "${{ inputs.version }}" | tr ', ' '-' | tr -cd '[:alnum:]._-' | tr -s '-')"
           test -n "$safe_version"
           echo "safe_version=$safe_version" >> "$GITHUB_OUTPUT"
  

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -97,11 +97,15 @@ jobs:
       - name: Normalize version for branch naming
         id: vars
         shell: bash
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
+          # Pass the version via an environment variable rather than direct template
+          # interpolation to prevent shell injection from crafted input values.
           # Replace commas and spaces with hyphens, strip remaining special chars,
           # then squeeze any consecutive hyphens to one.
           # e.g. "10.11.20, 11.6.5, 11.7.3" -> "10.11.20-11.6.5-11.7.3"
-          safe_version="$(printf '%s' "${{ inputs.version }}" | tr ', ' '-' | tr -cd '[:alnum:]._-' | tr -s '-')"
+          safe_version="$(printf '%s' "$VERSION_INPUT" | tr ', ' '-' | tr -cd '[:alnum:]._-' | tr -s '-')"
           test -n "$safe_version"
           echo "safe_version=$safe_version" >> "$GITHUB_OUTPUT"
  


### PR DESCRIPTION
Two fixes:

1. Updated the script to support a comma-separated version list.
2. Fixed timeout issue at https://github.com/mattermost/docs/actions/runs/26812807336/job/79046907907.


Updated spec doc: https://mattermost.atlassian.net/wiki/spaces/Security/pages/4518772760/Automation+-+Release+Docs+Update+GitHub+Actions+Workflow.
