### PR TITLE
Fix non-working migration instructions

### DIFF
--- a/source/administration-guide/onboard/migrate-gitlab-omnibus.rst
+++ b/source/administration-guide/onboard/migrate-gitlab-omnibus.rst
@@ -37,7 +37,7 @@ Run this command on the GitLab server:
 
 .. code-block:: bash
 
-   sudo gitlab-psql -- /opt/gitlab/embedded/bin/pg_dump -h /var/opt/gitlab/postgresql --no-owner mattermost_production | gzip > mattermost_dbdump_$(date --rfc-3339=date).sql.gz
+   sudo -u gitlab-psql -- /opt/gitlab/embedded/bin/pg_dump -h /var/opt/gitlab/postgresql --no-owner mattermost_production | gzip > mattermost_dbdump_$(date --rfc-3339=date).sql.gz
 
 This will create a compressed SQL dump file of your Mattermost database.
 


### PR DESCRIPTION
#### Summary

Fix not working instructions: `sudo user -- command` doesn't do what the author thought it does.

```
root@gitlab ~ # sudo gitlab-psql -- id
psql: error: connection to server on socket "/var/opt/gitlab/postgresql/.s.PGSQL.5432" failed: FATAL:  Peer authentication failed for user "id"

root@gitlab ~ # sudo -u gitlab-psql -- id
uid=998(gitlab-psql) gid=1003(gitlab-psql) groups=1003(gitlab-psql)
```

