### PR TITLE
docs: update Mattermost Federal, Inc. address

### DIFF
--- a/source/product-overview/faq-federal-procurement.rst
+++ b/source/product-overview/faq-federal-procurement.rst
@@ -79,7 +79,7 @@ What is the entity name, address and CAGE code Mattermost Federal, Inc?
 ------------------------------------------------------------------------
 
 - Entity Name: Mattermost Federal, Inc.
-- Address: 1900 Reston Metro Plaza, Suite #613, Reston, VA, 20190-5952, USA
+- Address: 11921 Freedom Drive, Suite 550, Reston, VA, 20190, USA
 - CAGE Code: 9TG37
 - NAICS Code: 513210
 - SAM.gov Unique Entity ID: RN3UJ3CK94Q3


### PR DESCRIPTION
## Summary
Updates the address for Mattermost Federal, Inc. in the federal procurement FAQ.

- **Old:** 1900 Reston Metro Plaza, Suite #613, Reston, VA, 20190-5952, USA
- **New:** 11921 Freedom Drive, Suite 550, Reston, VA, 20190, USA

Style kept consistent with the existing entries (comma before state, `, USA` suffix). CAGE Code, NAICS Code, and SAM.gov UEI are unchanged.

## File changed
- `source/product-overview/faq-federal-procurement.rst`