### PR TITLE
Remove CJK search feature flag mention now that it defaults to true

### DIFF
--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,7 +9,7 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters is supported on PostgreSQL.
+   Starting on Mattermost v11.9, searching for Chinese, Japanese or Korean (CJK) characters is enabled by default on PostgreSQL. On Mattermost v11.5 through v11.8, this can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,7 +9,7 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters is supported on PostgreSQL.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,7 +9,8 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting on Mattermost v11.9, searching for Chinese, Japanese or Korean (CJK) characters is enabled by default on PostgreSQL. On Mattermost v11.5 through v11.8, this can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting in Mattermost v11.9, CJK post search is enabled by default on PostgreSQL.
+   In Mattermost v11.5 through v11.8, enable the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 


### PR DESCRIPTION
## Summary

CJK (Chinese, Japanese, Korean) post search on PostgreSQL is now enabled by default, so the `MM_FEATUREFLAGS_CJKSEARCH` feature flag no longer needs to be set by administrators.

This updates the admin documentation to drop the feature-flag framing and state that CJK search is supported on PostgreSQL starting in Mattermost v11.5.

## Changes

- `source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst`: removed the `MM_FEATUREFLAGS_CJKSEARCH` feature flag reference.

## Notes

- The v11 changelog entry (`source/product-overview/mattermost-v11-changelog.md`) still references the flag. It's been left intact as a historical record of what shipped in v11.5.