### PR TITLE
Document v11.8 classification markings and banners

### DIFF
--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,8 +9,7 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting in Mattermost v11.9, CJK post search is enabled by default on PostgreSQL.
-   In Mattermost v11.5 through v11.8, enable the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,7 +9,8 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting in Mattermost v11.9, CJK post search is enabled by default on PostgreSQL.
+   In Mattermost v11.5 through v11.8, enable the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -18,6 +18,7 @@ Review and manage the following site configuration options in the System Console
 - `Public Links <#public-links>`__
 - `Notices <#notices>`__
 - `Connected Workspaces <#connected-workspaces>`__
+- `Classification Markings <#classification-markings>`__
 
 .. tip::
 
@@ -2586,6 +2587,34 @@ Member sync batch size
 .. note::
 
   Enabling these features can increase the load on your Mattermost server’s CPU, memory, and database due to frequent updates, database queries, and API communication. Excessive sync frequency and retries can overwhelm system resources, potentially causing performance degradation or instability. Monitor your system carefully when enabling these features.
+
+----
+
+Classification Markings
+-----------------------
+
+From Mattermost v11.8, system admins can configure classification markings in the System Console by going to **Site Configuration > Classification Markings**.
+
+Classification markings define reusable classification levels that can be displayed as global or channel-level banners in the web and desktop apps. Each classification level includes a name, color, and rank order. You can select a preset, such as US DoD, NATO, UK GSCP, Canada, or Australia PSPF, or define custom classification levels.
+
+.. note::
+
+  Classification markings are informational only and aren't tied to access control decisions at this time.
+
+Configure classification markings:
+
+1. Go to **System Console > Site Configuration > Classification Markings**.
+2. Enable **Enable classification markings**.
+3. Select a **Classification preset**, or create custom classification levels.
+4. Configure classification level names, colors, and rank order.
+5. Optionally enable the **Global Classification Banner** under **Global Classification Indicators**.
+6. Select the **Banner visibility**:
+
+   - **Top only**
+   - **Top and bottom**
+
+7. Select the **Global classification level** to display.
+8. Select **Save**.
 
 ----
 

--- a/source/end-user-guide/collaborate/display-channel-banners.rst
+++ b/source/end-user-guide/collaborate/display-channel-banners.rst
@@ -36,3 +36,12 @@ Disable the **Channel Banner** option in the channel settings to remove the bann
 .. tip::
 
   System admins can grant any user the ability to create and manage channel banners by assigning the **Manage Channel Banners** permission in the System Console. See the :doc:`advanced permissions </administration-guide/onboard/advanced-permissions>` documentation for details.
+
+Classification markings
+-----------------------
+
+From Mattermost v11.8, system admins can configure classification markings that display as global or channel-level banners in the web and desktop apps. See the :ref:`Classification Markings <administration-guide/configure/site-configuration-settings:classification markings>` configuration documentation for setup details.
+
+Classification markings use predefined or custom classification levels, including the classification name and banner color. These markings are informational only and don't control access to channels, messages, files, or other Mattermost resources.
+
+When a channel classification is applied, Mattermost displays the selected classification as the channel banner. Classification markings take priority over a custom channel banner when both are configured for the same channel.


### PR DESCRIPTION
Documents Mattermost v11.8 classification markings and banners (engineering PRs mattermost/mattermost#36231 MM-68196 and #36490 MM-68197, milestone v11.8.0).

- Adds a Classification markings section to the end-user display-channel-banners page.
- Adds a Classification Markings section and Site Configuration list entry to site-configuration-settings.

Classification markings are informational only and don't control access. Scoped to web and desktop apps.

Resolves #9031

Generated with [Claude Code](https://claude.ai/code)