### PR TITLE
Document channel category sorting GA and default category behavior (v11.8)

### DIFF
--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,8 +9,7 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting in Mattermost v11.9, CJK post search is enabled by default on PostgreSQL.
-   In Mattermost v11.5 through v11.8, enable the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,7 +9,8 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting in Mattermost v11.9, CJK post search is enabled by default on PostgreSQL.
+   In Mattermost v11.5 through v11.8, enable the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/configure/experimental-configuration-settings.rst
+++ b/source/administration-guide/configure/experimental-configuration-settings.rst
@@ -1520,6 +1520,9 @@ From Mattermost v10.10, when this :ref:`experimental <administration-guide/manag
 | This feature's ``config.json`` setting is ``"ExperimentalEnableChannelCategorySorting": false`` with options ``true`` and ``false``.     |
 +------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. note::
+  From Mattermost v11.8, channel category sorting is generally available and enabled by default. Configure it from **System Console > Site Configuration > Users and Teams** using the :ref:`Channel category sorting <administration-guide/configure/site-configuration-settings:channel category sorting>` setting (``TeamSettings.EnableChannelCategorySorting``).
+
 .. config:setting:: strict-csrf-token-enforcement
   :displayname: Strict CSRF token enforcement (Experimental)
   :systemconsole: N/A

--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -1098,6 +1098,31 @@ User statistics update time
 | Default is **00:00**.                                                                      |                                                                                          |
 +--------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+
 
+.. config:setting:: channel-category-sorting
+  :displayname: Channel category sorting (Users and Teams)
+  :systemconsole: Site Configuration > Users and Teams
+  :configjson: .TeamSettings.EnableChannelCategorySorting
+  :environment: MM_TEAMSETTINGS_ENABLECHANNELCATEGORYSORTING
+  :description: This setting controls whether channel admins can choose a default sidebar category when creating or editing a channel. Default is **true**.
+
+  - **true**: **(Default)** When creating or editing supported channels, channel admins see a **Default category (optional)** field. Members who join the channel see it under that category in their sidebar.
+  - **false**: The default category selector is hidden.
+
+Channel category sorting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+From Mattermost v11.8, channel category sorting is enabled by default. When enabled, channel admins can choose a default sidebar category when creating or editing a channel. Channel admins can select an existing category, type a new category name, or clear the default category from channel settings. Members who join the channel see it under that category in their sidebar. When disabled, the default category selector is hidden.
+
+.. list-table::
+  :widths: 55 45
+  :header-rows: 0
+
+  * - - **true**: **(Default)** When creating or editing supported channels, channel admins see a **Default category (optional)** field. They can select an existing category, enter a new category name, or clear the default category from channel settings. Members who join the channel see it under that category in their sidebar.
+      - **false**: The default category selector is hidden when creating or editing channels.
+    - - System Config path: **Site Configuration > Users and Teams**
+      - ``config.json`` setting: ``TeamSettings`` > ``EnableChannelCategorySorting`` > ``true``
+      - Environment variable: ``MM_TEAMSETTINGS_ENABLECHANNELCATEGORYSORTING``
+
 ----
 
 Notifications

--- a/source/end-user-guide/collaborate/create-channels.rst
+++ b/source/end-user-guide/collaborate/create-channels.rst
@@ -21,7 +21,7 @@ Anyone can create public channels, private channels, direct messages, and group 
   2. Enter a channel name.
   3. Choose whether this is a public or private channel. See the :doc:`channel types </end-user-guide/collaborate/channel-types>` documentation to learn more about public and private channels.
   4. (Optional) Describe the channel's focus or purpose. This text is visible to all channel members in the channel header.
-  5. (Optional) Assign the channel to a category. If your system admin has enabled :ref:`channel category sorting <administration-guide/configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the new channel to a new or existing channel category. If this option isn't available, you can `customize your channel sidebar </end-user-guide/preferences/customize-your-channel-sidebar>`.
+  5. (Optional) Assign the channel to a category. When :ref:`channel category sorting <administration-guide/configure/site-configuration-settings:channel category sorting>` is enabled (the default from Mattermost v11.8), channel admins see a **Default category (optional)** field when creating or editing a channel. You can select an existing category, type a new category name, or clear the default category from channel settings. Members who join the channel see it under that category in their sidebar. If this option isn't available, you can `customize your channel sidebar </end-user-guide/preferences/customize-your-channel-sidebar>`.
 
   Start a direct or group message
   --------------------------------

--- a/source/end-user-guide/collaborate/rename-channels.rst
+++ b/source/end-user-guide/collaborate/rename-channels.rst
@@ -13,7 +13,7 @@ Anyone can rename the channels they belong to, unless the system admin has :doc:
   - **Channel name:** The channel name that displays in the Mattermost user interface for all users. Enter a different channel name if needed or preferred.
   - **Channel URL:** The web URL used to access the channel in a web browser. Select **Edit** to change the URL, and select **Done** to save your changes. If your system admin has enabled anonymous team and channel URLs (available in Mattermost Enterprise Advanced from v11.6.0), channel URLs are assigned automatically and do not reflect the channel name.
 
-  If your system admin has enabled :ref:`channel category sorting <administration-guide/configure/experimental-configuration-settings:enable channel category sorting>`, you can assign the renamed channel to a new or existing channel category.
+  When :ref:`channel category sorting <administration-guide/configure/site-configuration-settings:channel category sorting>` is enabled (the default from Mattermost v11.8), channel admins can set a **Default category (optional)** for the channel. You can select an existing category, type a new category name, or clear the default category. Members who join the channel see it under that category in their sidebar.
 
   For example, a channel could be named ``UX Design`` and have a URL of ``https://community.mattermost.com/core/channels/ux-design`` (or an anonymous URL if enabled by your system admin).
 

--- a/source/end-user-guide/preferences/customize-your-channel-sidebar.rst
+++ b/source/end-user-guide/preferences/customize-your-channel-sidebar.rst
@@ -36,7 +36,7 @@ Create custom categories to group channels together for quicker and easier navig
 To create categories, select the **+** symbol at the top of the sidebar. Or, select the **More options** |more-icon| icon in the sidebar on any category header, then select **Create New Category**.
 
 .. note::
-  If your system admin has enabled :ref:`channel category sorting <administration-guide/configure/experimental-configuration-settings:enable channel category sorting>`, you can assign channels to new or existing channel categories when :doc:`creating channels </end-user-guide/collaborate/create-channels>` and :doc:`renaming channels </end-user-guide/collaborate/rename-channels>`.
+  When :ref:`channel category sorting <administration-guide/configure/site-configuration-settings:channel category sorting>` is enabled (the default from Mattermost v11.8), you can assign channels to new or existing channel categories when :doc:`creating channels </end-user-guide/collaborate/create-channels>` and :doc:`renaming channels </end-user-guide/collaborate/rename-channels>`.
 
 Next, type a category name, select **Create**, then drag any channels or direct messages into this new category. You can also multi-select channels and direct messages to drag them together as a group by pressing :kbd:`Ctrl` or :kbd:`Shift` and selecting on Windows or Linux, or :kbd:`⌘` or :kbd:`⇧` and selecting on Mac. See the section `drag and drop selections <#drag-and-drop-selections>`__ below for details.
 


### PR DESCRIPTION
Documents that, from Mattermost v11.8.0, channel category sorting is enabled by default (`TeamSettings.EnableChannelCategorySorting`). Channel admins can set or clear a **Default category (optional)** when creating or editing a channel, and members who join see it under that sidebar category.

- Adds the **Channel category sorting** setting under Site Configuration > Users and Teams.
- Notes GA graduation on the legacy experimental settings entry.
- Updates the end-user create-channels and rename-channels guides.

Per mattermost/mattermost#36289. Closes #9033

Generated with [Claude Code](https://claude.ai/code)