### PR TITLE
Document plugin-provided metrics at the standard /metrics endpoint

### DIFF
--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,8 +9,7 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting in Mattermost v11.9, CJK post search is enabled by default on PostgreSQL.
-   In Mattermost v11.5 through v11.8, enable the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
+++ b/source/administration-guide/configure/enabling-chinese-japanese-korean-search.rst
@@ -9,7 +9,8 @@ Chinese, Japanese and Korean search
 
 .. attention::
 
-   Starting on Mattermost v11.5, searching for Chinese, Japanese or Korean (CJK) characters can be enabled with the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
+   Starting in Mattermost v11.9, CJK post search is enabled by default on PostgreSQL.
+   In Mattermost v11.5 through v11.8, enable the `feature flag <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values>`_ ``MM_FEATUREFLAGS_CJKSEARCH``.
 
    The general recommendation of `using either Elasticsearch or Opensearch once the server reaches 2.5 million posts <https://docs.mattermost.com/administration-guide/scale/enterprise-search.html#do-i-need-to-use-elasticsearch-or-aws-opensearch>`_ still applies.
 

--- a/source/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring.rst
+++ b/source/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring.rst
@@ -122,6 +122,8 @@ What's collected?
 
 Mattermost provides :ref:`custom metrics <administration-guide/scale/performance-monitoring-metrics:custom Mattermost metrics>` and :ref:`standard Go metrics <administration-guide/scale/performance-monitoring-metrics:standard go metrics>` that can be used to monitor your system's performance.
 
+When the ``AggregatePluginMetrics`` feature flag is enabled, plugin-provided metrics are included in the same ``/metrics`` scrape target and can be filtered by the ``plugin_id`` label.
+
 Next steps
 ----------
 

--- a/source/administration-guide/scale/performance-monitoring-metrics.rst
+++ b/source/administration-guide/scale/performance-monitoring-metrics.rst
@@ -176,6 +176,11 @@ Plugin metrics
 - ``mattermost_plugin_multi_hook_server_time``: Time for the server to execute multiple plugin hook handlers in seconds.
 - ``mattermost_plugin_multi_hook_time``: Time to execute multiple plugin hook handler in seconds.
 
+The metrics above are measured by the Mattermost server as it executes plugin code. From Mattermost v11.8.0, plugin-provided Prometheus metrics can also be exposed through the standard Mattermost ``/metrics`` endpoint when the ``AggregatePluginMetrics`` feature flag is enabled. Aggregated plugin metrics include a ``plugin_id`` label, based on the plugin's manifest ID, so admins can identify which plugin produced each metric.
+
+.. note::
+  ``AggregatePluginMetrics`` is disabled by default and must be enabled before plugin-provided metrics are included in the ``/metrics`` response.
+
 Shared metrics
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Documents that, from Mattermost v11.8.0, plugin-provided Prometheus metrics can be exposed through the standard `/metrics` endpoint when the `AggregatePluginMetrics` feature flag is enabled. Aggregated metrics carry a `plugin_id` label.

Resolves #9034

Generated with [Claude Code](https://claude.ai/code)