### PR TITLE
docs: add Enterprise Advanced to subscription grace period downgrade

### DIFF
--- a/source/product-overview/self-hosted-subscriptions.rst
+++ b/source/product-overview/self-hosted-subscriptions.rst
@@ -118,7 +118,7 @@ What happens to my subscription if I don't renew in time?
 
 If you don't renew within the 60-day renewal period, a 10-day grace period is provided. During this period your Mattermost installation runs as normal, with full access to commercial features. During the grace period, the notification banner is not dismissable.
 
-When the grace period expires, your Mattermost Enterprise or Professional plan is downgraded to the Free plan and other plan features are disabled.
+When the grace period expires, your Mattermost Professional, Enterprise, or Enterprise Advanced plan is downgraded to the Free plan and other plan features are disabled.
  
 What happens when my subscription expires?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Updates the [self-hosted subscriptions FAQ](https://docs.mattermost.com/product-overview/self-hosted-subscriptions.html#what-happens-to-my-subscription-if-i-don-t-renew-in-time) so the **"What happens to my subscription if I don't renew in time?"** section covers all paid self-hosted plans.

Previously, the grace-period downgrade note only mentioned **Enterprise** and **Professional**. It now also includes **Enterprise Advanced**, using the repo's standard plan ordering ("Professional, Enterprise, and Enterprise Advanced").

## Change

> When the grace period expires, your Mattermost ~~Enterprise or Professional~~ **Professional, Enterprise, or Enterprise Advanced** plan is downgraded to the Free plan and other plan features are disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)