### PR TITLE
Document experimental video calls in DMs (Calls v1.12.0)

### DIFF
--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -1029,7 +1029,34 @@ Enable AV1 (Experimental)
 
 .. note::
 
-  Avoid enabling both this experimental configuration setting and the `Enable simulcast for screen sharing <#enable-simulcast-for-screen-sharing-experimental>`__ experimental configuration setting at the same time. 
+  Avoid enabling both this experimental configuration setting and the `Enable simulcast for screen sharing <#enable-simulcast-for-screen-sharing-experimental>`__ experimental configuration setting at the same time.
+
+.. config:setting:: enable-pluginsvideo
+  :displayname: Enable video calls in DMs (Experimental) (Plugins - Calls)
+  :systemconsole: Plugins > Calls
+  :configjson: PluginSettings.Plugins.com.mattermost.calls.enablevideo
+  :environment: MM_CALLS_ENABLE_VIDEO
+
+  - **true**: Enables experimental video calls in direct message (DM) channels.
+  - **false**: **(Default)** Video calls are disabled.
+
+Enable video calls in DMs (Experimental)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| - **true**: Enables experimental video calls in direct message (DM)      | - System Config path: **Plugins > Calls**                                                                     |
+|   channels.                                                              | - ``config.json`` setting: ``PluginSettings`` > ``Plugins`` > ``com.mattermost.calls`` > ``enablevideo``      |
+| - **false**: **(Default)** Video calls are disabled.                     | - Environment variable: ``MM_CALLS_ENABLE_VIDEO``                                                             |
+|                                                                          |                                                                                                               |
+| Video is supported in DM calls on the desktop and web apps only. Mobile  |                                                                                                               |
+| users can't start video calls; when joining a DM call that includes      |                                                                                                               |
+| video, they receive voice and screen sharing only. Call recordings       |                                                                                                               |
+| capture voice and screen sharing only — video isn't recorded.            |                                                                                                               |
++--------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+  The ability to enable video calls in DMs is currently :ref:`Experimental <administration-guide/manage/feature-labels:experimental>`.
 
 .. config:setting:: enable-pluginsdcsignaling
   :displayname: Use data channels for signaling media tracks (Plugins - Calls)

--- a/source/administration-guide/configure/plugins-configuration-settings.rst
+++ b/source/administration-guide/configure/plugins-configuration-settings.rst
@@ -1058,6 +1058,10 @@ Enable video calls in DMs (Experimental)
 
   The ability to enable video calls in DMs is currently :ref:`Experimental <administration-guide/manage/feature-labels:experimental>`.
 
+.. note::
+
+  If your deployment offloads calls to the :doc:`RTCD service </administration-guide/configure/calls-rtcd-setup>`, video in DM calls requires **rtcd v1.2.2 or later**. We recommend running the rtcd version that ships with your Calls plugin release (rtcd v1.2.5 for Calls v1.12.0) and keeping rtcd updated alongside the plugin. Deployments that use the plugin's built-in RTC server (no RTCD) support video without additional configuration.
+
 .. config:setting:: enable-pluginsdcsignaling
   :displayname: Use data channels for signaling media tracks (Plugins - Calls)
   :systemconsole: Plugins > Calls

--- a/source/end-user-guide/collaborate/make-calls.rst
+++ b/source/end-user-guide/collaborate/make-calls.rst
@@ -249,7 +249,11 @@ Yes! From Mattermost v8.0 and Calls v0.17.0, desktop app and web users can go to
 Is video supported?
 ~~~~~~~~~~~~~~~~~~~
 
-The integration currently supports only voice calling and screen sharing. We're considering video support in the future.
+From Mattermost Calls plugin v1.12.0, experimental video support is available in direct message (DM) calls on the desktop and web apps. It's disabled by default; a system admin can enable it using the :ref:`Enable video calls in DMs (Experimental) <administration-guide/configure/plugins-configuration-settings:enable video calls in dms (experimental)>` plugin setting in the System Console. The following limitations apply:
+
+- Video is available in DM calls only. All other calls continue to support voice calling and screen sharing only.
+- Video isn't available on the mobile app. Mobile users can't start a video call, and when they join a DM call that includes video, it behaves like an audio call — they hear voice and see shared screens, but don't see video.
+- Call recordings don't capture video. Recordings include voice and screen sharing only.
 
 Can I password-protect a call?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary

Calls plugin v1.12.0 introduces experimental video support, gated behind a new **Enable video calls in DMs (Experimental)** plugin setting (`EnableVideo`, default off). This makes the existing end-user FAQ — which states video is not supported — inaccurate. This PR updates the docs accordingly.

This was flagged by the `docs-impact-review` bot on the server version-bump PR (mattermost/mattermost#37077).

#### Changes

- **End User Guide → Make calls** (`make-calls.rst`): Rewrote the "Is video supported?" FAQ to describe experimental video in DM calls (desktop/web), with limitations:
  - Available in DM calls only
  - Not available on mobile (received video calls behave as audio + screen share; mobile users can't start video calls)
  - Call recordings capture voice and screen sharing only — video isn't recorded
- **System Console settings reference** (`plugins-configuration-settings.rst`): Added an "Enable video calls in DMs (Experimental)" entry (config.json `enablevideo`, env var `MM_CALLS_ENABLE_VIDEO`), cross-linked from the FAQ.

#### Ticket

https://mattermost.atlassian.net/browse/MM-68811

#### Related PRs

- Server prepackaged plugin bump: mattermost/mattermost#37077

#### Checklist

- [x] Built docs locally with Sphinx; build succeeds with no new warnings
- [x] Verified both `:ref:` cross-references resolve in the rendered HTML
