### PR TITLE
MM-69311: Document new metric: mattermost_cluster_reliable_fallback_tcp

### DIFF
--- a/source/administration-guide/scale/performance-monitoring-metrics.rst
+++ b/source/administration-guide/scale/performance-monitoring-metrics.rst
@@ -37,7 +37,7 @@ Cluster metrics
 - ``mattermost_cluster_cluster_health_score``: A score that gives an idea of how well it is meeting the soft-real time requirements of the gossip protocol.
 - ``mattermost_cluster_cluster_requests_total``: The total number of inter-node requests.
 - ``mattermost_cluster_cluster_event_type_totals``: The total number of cluster requests sent for any type.
-- ``mattermost_cluster_reliable_fallback_tcp``: The total length in bytes of the SendBestEffort calls (UDP) that had to fallback to SendReliable (TCP) because of the message length. This is a histogram with 8 buckets, from 32KiB to 4MiB. Ideally, the count of this metric should be always 0, but plugins may be misusing the websocket API and attempting to send large messages via UDP; in that case, plugins should be fixed to set `ReliableClusterSend <https://github.com/mattermost/mattermost/blob/4fe11a7d5d14616f3c31363762617ddfd99895df/server/public/model/websocket_message.go#L155-L157>`__ to true.
+- ``mattermost_cluster_reliable_fallback_tcp``: The total length in bytes of the ``SendBestEffort`` calls (UDP) that had to fallback to ``SendReliable`` (TCP) because of the message length. This is a histogram with 8 buckets, from 32KiB to 4MiB. Ideally, the count of this metric should be always 0, but plugins may be misusing the websocket API and attempting to send large messages via UDP; in that case, plugins should be fixed to set `ReliableClusterSend <https://github.com/mattermost/mattermost/blob/4fe11a7d5d14616f3c31363762617ddfd99895df/server/public/model/websocket_message.go#L155-L157>`__ to true.
 
 Database metrics
 ~~~~~~~~~~~~~~~~

--- a/source/administration-guide/scale/performance-monitoring-metrics.rst
+++ b/source/administration-guide/scale/performance-monitoring-metrics.rst
@@ -37,6 +37,7 @@ Cluster metrics
 - ``mattermost_cluster_cluster_health_score``: A score that gives an idea of how well it is meeting the soft-real time requirements of the gossip protocol.
 - ``mattermost_cluster_cluster_requests_total``: The total number of inter-node requests.
 - ``mattermost_cluster_cluster_event_type_totals``: The total number of cluster requests sent for any type.
+- ``mattermost_cluster_reliable_fallback_tcp``: The total length in bytes of the SendBestEffort calls (UDP) that had to fallback to SendReliable (TCP) because of the message length. This is a histogram with 8 buckets, from 32KiB to 4MiB. Ideally, the count of this metric should be always 0, but plugins may be misusing the websocket API and attempting to send large messages via UDP; in that case, plugins should be fixed to set `ReliableClusterSend <https://github.com/mattermost/mattermost/blob/4fe11a7d5d14616f3c31363762617ddfd99895df/server/public/model/websocket_message.go#L155-L157>`__ to true.
 
 Database metrics
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
Document new metric: `mattermost_cluster_reliable_fallback_tcp`

The new metric will land on v11.9, and was cherry-picked to v11.7 and v11.8 as well. I still don't know what the docs policy is with regards to the releases. Should I change the target branch to be `v11.9-documentation`?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69311