### PR TITLE
Fix Bash "safe mode" in upgrade_mattermost.sh

### DIFF
--- a/source/administration-guide/upgrade/upgrade_mattermost.sh
+++ b/source/administration-guide/upgrade/upgrade_mattermost.sh
@@ -2,7 +2,7 @@
 
 # Immediately exit if a command run from a loop, a pipeline or a compound
 # command statement fails or a variable is used unset.
-set -o errexit nounset
+set -o errexit -o nounset -o pipefail
 
 
 ################################################################################


### PR DESCRIPTION
This fixes two aspects of the changed line:
- Raises an error upon using an uninitialized variable. (The already existing `nounset` did not do what was intended.)
- Raises an error if any command in a pipeline fails.

The behavior now conforms to what the comment says it does:

https://github.com/mattermost/docs/blob/3c001a72caaeb0380c1266f2a01cf0c5afa362f3/source/administration-guide/upgrade/upgrade_mattermost.sh#L3-L5