### PR TITLE
Document the Ranked attribute type

### DIFF
--- a/source/administration-guide/configure/site-configuration-settings.rst
+++ b/source/administration-guide/configure/site-configuration-settings.rst
@@ -2620,7 +2620,7 @@ Classification Markings
 
 From Mattermost v11.8, system admins can configure classification markings in the System Console by going to **Site Configuration > Classification Markings**.
 
-Classification markings define reusable classification levels that can be displayed as global or channel-level banners in the web and desktop apps. Each classification level includes a name, color, and rank order. You can select a preset, such as US DoD, NATO, UK GSCP, Canada, or Australia PSPF, or define custom classification levels.
+Classification markings define reusable classification levels that can be displayed as global or channel-level banners in the web and desktop apps. Each classification level includes a name, color, and rank order. You can select a preset, such as US DoD, NATO, UK GSCP, Canada, or Australia PSPF, or define custom classification levels. Levels are ordered using the same **Ranked** attribute type available for :doc:`user attributes </administration-guide/manage/admin/user-attributes>`, so each level sits at a defined position from lowest to highest.
 
 .. note::
 

--- a/source/administration-guide/manage/admin/abac-system-wide-policies.rst
+++ b/source/administration-guide/manage/admin/abac-system-wide-policies.rst
@@ -44,7 +44,15 @@ You can add multiple rules to a single policy, and each rule can include multipl
          - **Ends with**: The attribute value must end with the specified value.
          - **Contains**: The attribute value must exist somewhere with the specified value.
 
-     3. Specify the attribute values that users must have to be granted access to the channel. 
+         When the selected attribute is a **Ranked** attribute (an ordered list of values, such as clearance or classification levels), the match options are ordered comparisons instead. These let you match everyone at or above a threshold rather than only an exact value:
+
+         - **Is exactly** / **Is not**: The value must exactly match, or must not match, the specified value.
+         - **Is at least**: The value must be equal to or higher than the specified value - for example, clearance *is at least* Secret matches Secret and every higher level.
+         - **Is greater than**: The value must be higher than the specified value.
+         - **Is at most**: The value must be equal to or lower than the specified value.
+         - **Is less than**: The value must be lower than the specified value.
+
+     3. Specify the attribute values that users must have to be granted access to the channel.
 
    .. tab:: Advanced Mode
 

--- a/source/administration-guide/manage/admin/user-attributes.rst
+++ b/source/administration-guide/manage/admin/user-attributes.rst
@@ -101,6 +101,7 @@ From Mattermost v11.8, user attributes include both a **Display Name** and a **N
       - **URL** for web site address-based profile attributes.
       - **Select** for a list of profile attribute values users can choose from. Specify each value followed by pressing **TAB** or **ENTER**. Values can be up to 64 characters long, and users can choose a single value.
       - **Multi-select** for a list of profile attribute values users can select from. Specify each value followed by pressing **TAB** or **ENTER**. Values can be up to 64 characters long, and users can choose multiple values.
+      - **Ranked** for an ordered list of values, where each value ranks higher or lower than the others - for example, clearance or classification levels such as *Public*, *Secret*, and *Top Secret*. Specify each value, then order the values from lowest to highest rank. Users can choose a single value. Because the values are ordered, :doc:`access control policies </administration-guide/manage/admin/abac-system-wide-policies>` can compare a ranked attribute against a threshold - for example, clearance *is at least* Secret - rather than only checking for an exact match.
 
 3. Specify the attribute's visibility as one of the following:
 


### PR DESCRIPTION
Add a Ranked entry to the user-attribute type list, document its ordered comparison operators in the system-wide access policy match options, and note that classification markings use the same Ranked attribute type.