### PR TITLE
MM-69100 - Add team membership ABAC documentation and update channel ABAC pages for team support

### DIFF
--- a/source/administration-guide/manage/admin/abac-channel-access-rules.rst
+++ b/source/administration-guide/manage/admin/abac-channel-access-rules.rst
@@ -330,7 +330,7 @@ Synchronization and membership
 How quickly are membership changes applied?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When you save access rules, membership sync job is created and changes are applied as soon as the job is completed. Additionally, Mattermost runs synchronization jobs every 30 minutes to handle attribute changes from external systems (LDAP, SAML).
+When you save access rules, membership sync job is created and changes are applied as soon as the job is completed. Additionally, Mattermost runs synchronization jobs on a schedule to handle attribute changes from external systems (LDAP, SAML). The interval is set by ``AccessControlSettings.SyncJobIntervalSeconds`` and defaults to 3600 seconds (60 minutes).
 
 Will users be notified when they're removed from a channel?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -353,7 +353,7 @@ You can use any user attributes either synchronized via LDAP/SAML or manually co
 What happens if a user attribute changes?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-During the next synchronization (every 30 minutes), users who no longer match the access rules will be removed from the channel, and new users who now match will be added (if auto-sync is enabled).
+During the next scheduled synchronization (every 60 minutes by default), users who no longer match the access rules will be removed from the channel, and new users who now match will be added (if auto-sync is enabled).
 
 Do guest users work with ABAC channels?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/administration-guide/manage/admin/abac-system-wide-policies.rst
+++ b/source/administration-guide/manage/admin/abac-system-wide-policies.rst
@@ -4,7 +4,7 @@ System-wide attribute-based access policies
 .. include:: ../../../_static/badges/entry-adv.rst
   :start-after: :nosearch:
 
-Use this guide to create and manage organization-wide attribute-based access policies in the System Console. For channel-level rules managed by Channel Admins, see :doc:`Channel-specific access rules </administration-guide/manage/admin/abac-channel-access-rules>`.
+Use this guide to create and manage organization-wide attribute-based access policies in the System Console. Policies can be assigned to both channels and teams. For channel-level rules managed by Channel Admins, see :doc:`Channel-specific access rules </administration-guide/manage/admin/abac-channel-access-rules>`. For team membership policies, see :doc:`Team membership access policies </administration-guide/manage/admin/abac-team-membership>`.
 
 Prerequisites
 -------------
@@ -112,10 +112,22 @@ Default channels (such as Town Square and Off-Topic), shared channels, and group
 
   Private channels with attribute-based access control policies can't have guest users invited to them. Only users who match the defined attribute criteria can be added to ABAC-controlled private channels, ensuring strict adherence to access control policies. Public channels remain joinable by anyone regardless of the policy.
 
+Assign policies to teams
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+From Mattermost v11.10, system-wide policies can also be assigned to teams. Go to **System Console > User Management > Teams**, open the team you want to configure, and use the **Membership Policy** section to link an existing policy.
+
+The policy behaves differently depending on the team's privacy mode:
+
+- **Private teams** — strict enforcement: join is gated, non-qualifying members are removed at sync, and the team is hidden from non-qualifying non-members in Browse Teams.
+- **Public teams** — advisory: the policy is never a gate. Qualifying non-members see a **Recommended** chip in Browse Teams; anyone can still join freely.
+
+For a full description of team assignment, custom rules, sync configuration, and end-user surfaces, see :doc:`Team membership access policies </administration-guide/manage/admin/abac-team-membership>`.
+
 Delete policies
 ~~~~~~~~~~~~~~~
 
-To delete a policy, select the **Delete** button next to the policy you want to remove. You can only delete policies that are not currently assigned to any channels. If a policy is assigned to channels, you must first remove it from those channels before you can delete it.
+To delete a policy, select the **Delete** button next to the policy you want to remove. You can only delete policies that are not currently assigned to any channels or teams. If a policy is assigned to channels or teams, you must first remove it from all assigned resources before you can delete it.
 
 Define access controls per channel
 ----------------------------------

--- a/source/administration-guide/manage/admin/abac-system-wide-policies.rst
+++ b/source/administration-guide/manage/admin/abac-system-wide-policies.rst
@@ -115,7 +115,9 @@ Default channels (such as Town Square and Off-Topic), shared channels, and group
 Assign policies to teams
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-From Mattermost v11.10, system-wide policies can also be assigned to teams. Go to **System Console > User Management > Teams**, open the team you want to configure, and use the **Membership Policy** section to link an existing policy.
+From Mattermost v11.10, system-wide policies can also be assigned to teams. Go to **System Console > User Management > Teams** and open the team you want to configure. In the **Team Management** section, enable **Manage membership with attribute based membership policies** — the **Membership policies** section only appears once this toggle is on. Then link an existing policy and select **Save**.
+
+Group-synced teams cannot use membership policies, so the toggle is unavailable on them.
 
 The policy behaves differently depending on the team's privacy mode:
 

--- a/source/administration-guide/manage/admin/abac-system-wide-policies.rst
+++ b/source/administration-guide/manage/admin/abac-system-wide-policies.rst
@@ -127,7 +127,9 @@ For a full description of team assignment, custom rules, sync configuration, and
 Delete policies
 ~~~~~~~~~~~~~~~
 
-To delete a policy, select the **Delete** button next to the policy you want to remove. You can only delete policies that are not currently assigned to any channels or teams. If a policy is assigned to channels or teams, you must first remove it from all assigned resources before you can delete it.
+To delete a policy, select the **Delete** button next to the policy you want to remove. Policies that are still assigned to channels cannot be deleted — remove the policy from those channels first.
+
+Team assignments are not checked before deletion, so unlink the policy from every team that uses it before deleting it. Otherwise those teams keep a reference to a policy that no longer exists.
 
 Define access controls per channel
 ----------------------------------

--- a/source/administration-guide/manage/admin/abac-team-channel-policies.rst
+++ b/source/administration-guide/manage/admin/abac-team-channel-policies.rst
@@ -6,6 +6,10 @@ Team-level channel membership policies
 
 Team Admins can create and manage attribute-based membership policies for private channels within their team, directly from Team Settings, without requiring System Admin involvement. For organization-wide policies managed by System Admins, see :doc:`System-wide attribute-based access policies </administration-guide/manage/admin/abac-system-wide-policies>`.
 
+.. note::
+
+   From Mattermost v11.10, Team Settings has four tabs: **Info**, **Access**, **Team Membership**, and **Channel Membership**. This page covers the **Channel Membership** tab — policies that Team Admins configure for *channels* within their team. For team-level membership policies (controlling who can join the team itself), see :doc:`Team membership access policies </administration-guide/manage/admin/abac-team-membership>`.
+
 With team-level channel membership policies, Team Admins can:
 
 - Create policies that apply attribute-based access rules to one or more private channels within their team.
@@ -31,23 +35,23 @@ Access Team Settings
 
 1. Select the team name in the sidebar to open the team menu.
 2. Select **Team Settings**.
-3. Navigate to the **Membership Policies** tab. This tab is only visible when ABAC is enabled system-wide and you have Team Admin permissions.
+3. Navigate to the **Channel Membership** tab (the fourth tab in Team Settings). This tab is only visible when ABAC is enabled system-wide and you have Team Admin permissions.
 
 .. note::
 
-  System Admins also have access to the **Membership Policies** tab in Team Settings and see the same policies as Team Admins.
+  System Admins also have access to the **Channel Membership** tab in Team Settings and see the same policies as Team Admins.
 
 Manage membership policies
 --------------------------
 
-The **Membership Policies** tab shows policies scoped to the team. Each policy displays its name and the number of private channels it applies to.
+The **Channel Membership** tab shows policies scoped to the team. Each policy displays its name and the number of private channels it applies to.
 
 Team Admins only see policies whose access rules their own user attributes satisfy. If a policy has rules that exclude the Team Admin's attributes (for example, a policy requiring ``Department=Engineering`` and the Team Admin has ``Department=Finance``), that policy will not appear in their list. This is a self-inclusion safety mechanism to prevent admins from being locked out of policies they manage.
 
 Create a policy
 ~~~~~~~~~~~~~~~
 
-1. In the **Membership Policies** tab, select **Add policy**.
+1. In the **Channel Membership** tab, select **Add policy**.
 2. Enter a unique policy name.
 3. Define access rules under **Access rules**:
 
@@ -111,9 +115,9 @@ When both a system-wide policy and a team-level policy apply to the same channel
 Cross-team policies
 ~~~~~~~~~~~~~~~~~~~
 
-A policy that has private channels from more than one team is considered a cross-team policy. Cross-team policies are not visible in any team's **Membership Policies** tab — they are managed exclusively through the System Console.
+A policy that has private channels from more than one team is considered a cross-team policy. Cross-team policies are not visible in any team's **Channel Membership** tab — they are managed exclusively through the System Console.
 
-If a System Admin adds a channel from another team to a policy that was previously scoped to one team, that policy will no longer appear in any team's **Membership Policies** tab.
+If a System Admin adds a channel from another team to a policy that was previously scoped to one team, that policy will no longer appear in any team's **Channel Membership** tab.
 
 Synchronization
 ---------------
@@ -123,10 +127,10 @@ When you save a policy or modify channel assignments, Mattermost creates a membe
 Troubleshooting and FAQs
 --------------------------
 
-Why can't I see the Membership Policies tab in Team Settings?
+Why can't I see the Channel Membership tab in Team Settings?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The **Membership Policies** tab is only visible when:
+The **Channel Membership** tab is only visible when:
 
 - You have Team Admin permissions.
 - ABAC is enabled system-wide by a System Admin in **System Console > System Attributes > Attribute-Based Access**.
@@ -134,7 +138,7 @@ The **Membership Policies** tab is only visible when:
 Why can't I see a policy that I know exists?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are two reasons a policy may not appear in your **Membership Policies** tab:
+There are two reasons a policy may not appear in your **Channel Membership** tab:
 
 - **Cross-team policy**: The policy includes private channels from more than one team. Cross-team policies are not visible in Team Settings for anyone and must be managed through the System Console.
 - **Self-inclusion filter**: Your own user attributes do not satisfy the policy's access rules. For example, if a policy requires ``Department=Engineering`` and your profile has ``Department=Finance``, you will not see that policy. A System Admin or another Team Admin whose attributes do satisfy the rules would need to manage it instead.

--- a/source/administration-guide/manage/admin/abac-team-channel-policies.rst
+++ b/source/administration-guide/manage/admin/abac-team-channel-policies.rst
@@ -122,7 +122,7 @@ If a System Admin adds a channel from another team to a policy that was previous
 Synchronization
 ---------------
 
-When you save a policy or modify channel assignments, Mattermost creates a membership synchronization job. Changes are applied as soon as the job completes. Synchronization also runs automatically every 30 minutes to handle attribute changes from external systems such as LDAP or SAML.
+When you save a policy or modify channel assignments, Mattermost creates a membership synchronization job. Changes are applied as soon as the job completes. Synchronization also runs automatically on a schedule to handle attribute changes from external systems such as LDAP or SAML. The interval is set by ``AccessControlSettings.SyncJobIntervalSeconds`` and defaults to 3600 seconds (60 minutes).
 
 Troubleshooting and FAQs
 --------------------------

--- a/source/administration-guide/manage/admin/abac-team-membership.rst
+++ b/source/administration-guide/manage/admin/abac-team-membership.rst
@@ -1,0 +1,506 @@
+Team membership access policies
+================================
+
+.. include:: ../../../_static/badges/entry-adv.rst
+  :start-after: :nosearch:
+
+From Mattermost v11.10, system admins and team admins can apply attribute-based access control (ABAC) directly to teams — controlling who can join a team based on user profile attributes. This extends the existing ABAC channel membership system to the team boundary, closing the "hallway access" gap where users who fail channel policies could still see the team, its member list, and its channel structure.
+
+Team membership ABAC uses the same policies and attribute rules as channel ABAC, but behaves differently depending on whether the team is public or private:
+
+- **Public teams (advisory mode)**: The policy never blocks access. Anyone can still join freely. Qualifying users who are not yet members see a **Recommended** chip in Browse Teams. Sync can auto-add qualifying users when enabled but never removes anyone.
+- **Private teams (strict mode)**: The policy gates directory visibility, join evaluation, and membership at sync. Non-qualifying users cannot find or join the team. Non-qualifying members are removed at the next sync.
+
+.. note::
+
+   **Upgrade notice:** The Access tab in Team Settings has a new UI from Mattermost v11.10 that affects **every team on every deployment** — whether or not ABAC is licensed or enabled. The old "Allow any user to join" checkbox has been replaced by **Public Team / Private Team** selection cards. See `Access tab: Public/Private team cards`_ for details.
+
+.. contents::
+   :local:
+   :depth: 2
+
+Access tab: Public/Private team cards
+---------------------------------------
+
+.. important::
+
+   This change affects **all Mattermost teams on all deployments**, regardless of whether ABAC is enabled or whether your organization has an Enterprise Advanced license. Any team admin who opens **Team Settings > Access** after upgrading will see the new UI.
+
+**What changed:** The "Allow any user to join" checkbox has been permanently replaced by two selection cards:
+
+- **Public Team** — anyone on the server can find and join.
+- **Private Team** — only invited members can join.
+
+**Why the change was made:** The cards make a team's public-vs-private state explicit and unambiguous, which is what team ABAC enforcement depends on to decide between advisory and strict mode.
+
+**Behavior without ABAC:** Functionally identical to the old checkbox. Public Team = "Allow any user to join" was ON. Private Team = it was OFF. No other behavior changes for teams that have no membership policy.
+
+**Behavior with ABAC:** The cards drive the enforcement mode — public teams get advisory ABAC, private teams get strict ABAC. Mode changes on policy-governed teams may trigger a confirmation modal (see below).
+
+**Default on new teams:** New teams are Private by default, so any policy assigned before explicitly choosing a mode activates strict enforcement. Teams are always protected by default; advisory mode requires explicitly selecting **Public Team**.
+
+Switching modes
+~~~~~~~~~~~~~~~~
+
+**Private → Public:** Always safe — relaxes enforcement. Saves directly with no confirmation modal. If a policy is applied, the team immediately transitions to advisory mode: no existing members are removed.
+
+**Public → Private:** If team ABAC is enabled (both flags on) and the team has a membership policy assigned, clicking **Private Team** opens a confirmation modal before saving:
+
+- Title: **"Switch to Private Team?"**
+- Body shows how many current members do not meet the policy criteria and will be removed at the next sync. (If no count is available, a generic warning is shown instead.)
+- **Cancel** — closes the modal, no changes made.
+- **Switch to Private** — saves the change and immediately creates a team sync job to enforce strict mode.
+
+If no policy is assigned, switching Public → Private saves directly with no modal.
+
+**The cards stay interactive on ABAC-governed teams.** ABAC never disables the Public/Private cards. A public-to-private switch on a governed team is guarded by the mode-flip confirmation modal described above, not by locking the cards.
+
+Other Access tab fields (Invite Code and Allowed Email Domain) are unaffected by this change. On teams managed by LDAP/AD group sync, the Access tab shows a static "Members of this team are added and removed by linked groups" message instead of the cards.
+
+Advisory and strict enforcement
+---------------------------------
+
+Whether a policy is enforced strictly or treated as advisory depends only on whether the team is public or private. The table below summarizes how each combination behaves.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 20 15 15
+
+   * - Team
+     - ABAC policy?
+     - Join gate
+     - Browse Teams
+     - Sync removal
+     - Recommended tag
+   * - Public
+     - No
+     - Open
+     - Visible to all
+     - N/A
+     - No
+   * - Public
+     - Yes — **Advisory**
+     - Open (no gate)
+     - Visible to all
+     - Skipped
+     - Yes (qualifying non-members)
+   * - Private
+     - No
+     - Invite-only
+     - Members only
+     - N/A
+     - No
+   * - Private
+     - Yes — **Strict**
+     - Denied for non-qualifying users
+     - Hidden from non-qualifying non-members
+     - Non-qualifiers removed
+     - No
+
+.. note::
+
+   Auto-add is the only behavior that applies to **both** advisory and strict mode. When enabled, sync adds qualifying non-members regardless of whether the team is public or private.
+
+Prerequisites
+-------------
+
+Before configuring team membership policies:
+
+1. :doc:`Configure user attributes </administration-guide/manage/admin/user-attributes>` in the System Console.
+2. Go to **System Console > System Attributes > Attribute-Based Access** and enable **Enable Attribute-Based Access Control**.
+3. Enable the ``TeamMembershipAccessControl`` feature flag. See the Mattermost developer documentation for details on `enabling feature flags in a self-hosted deployment <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#self-hosted-and-local-development>`_. Mattermost Cloud customers can request this feature flag be enabled by contacting their Mattermost Account Manager or by `creating a support ticket <https://support.mattermost.com/hc/en-us/requests/new?ticket_form_id=11184911962004>`_.
+4. For Team Admins configuring rules: the ``manage_team_access_rules`` permission is required. This permission is included in the Team Admin role by default.
+
+**What changes when the flags are off:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 42 29 29
+
+   * - Surface
+     - Both flags ON
+     - Either flag OFF
+   * - Join gate (private teams)
+     - Enforced — non-qualifying users denied
+     - Off — anyone can join as before
+   * - Browse Teams filter
+     - Private+ABAC teams hidden from non-qualifying users
+     - All teams visible
+   * - Team Membership tab (Team Settings)
+     - Visible to Team Admins and System Admins
+     - Hidden — tab does not appear
+   * - System Console per-team ABAC controls
+     - Policy assignment + custom rules panel visible
+     - Hidden
+   * - Recommended tag
+     - Shown to qualifying users on public+ABAC teams
+     - Not shown
+   * - Sync job — removal pass
+     - Removes non-qualifiers from private+ABAC teams
+     - No team sync jobs run
+   * - Invite modal filtering
+     - Filters on private+ABAC teams
+     - All users shown, as before
+   * - Public/Private cards (Access tab)
+     - **Always visible** — not gated by these flags
+     - **Still visible** — always rendered (see note above)
+   * - Channel ABAC
+     - Unaffected by team flag
+     - Unaffected by team flag
+
+System Admin configuration
+---------------------------
+
+Assign a membership policy to a team
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+System Admins assign existing system-wide membership policies to teams via the per-team System Console page.
+
+1. Go to **System Console > User Management > Teams** and open the team you want to configure.
+2. Locate the **Membership Policy** section.
+3. Select **Link to a policy** and choose an existing policy from the picker.
+4. Select **Save**.
+
+Before saving, a confirmation modal shows:
+
+- The number of workspace users who currently qualify for the policy.
+- The number of current team members who do not qualify (and will be affected at the next sync on private teams).
+- An **empty-team warning** if the team is private and no current member qualifies.
+
+**To remove a policy:** Select the trash icon next to the policy row, then **Save**. The team's enforcement flag is cleared and the team reverts to standard access behavior.
+
+**Policy list team counts:** The **Membership Policies** list page shows the count of channels and teams each policy is applied to — for example, ``2 channels, 1 team``. A zero side is omitted (so ``1 team`` not ``0 channels, 1 team``).
+
+Enable auto-add from the Membership Policy section
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a parent policy is linked, the **Membership Policy** section shows an **Auto-add** checkbox per linked policy row. This checkbox is always enabled for any linked policy — it does not require custom rules to exist. Checking it and saving starts the backfill scan immediately.
+
+This is separate from the **Auto-add members based on access rules** checkbox in the Custom access rules panel (see below), which requires at least one custom rule before it can be checked.
+
+Configure custom access rules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to a system-wide parent policy, System Admins can define team-specific custom rules directly on the per-team System Console page.
+
+1. Go to **System Console > User Management > Teams** and open the team.
+2. Enable the **Manage membership with attribute based membership policies** switch.
+3. Scroll to the **Custom access rules** panel.
+4. Select **Add attribute** to add a condition. For each condition, choose:
+
+   - **Attribute**: The user profile attribute to evaluate.
+   - **Operator**: How the attribute must match. Options: **Is**, **Is not**, **In**, **Starts with**, **Ends with**, **Contains**. For ranked attributes: **Is exactly**, **Is at least**, **Is greater than**, **Is at most**, **Is less than**.
+   - **Value**: The required attribute value.
+
+   All conditions are combined with a logical AND — users must satisfy all of them.
+
+5. Optionally, check **Auto-add members based on access rules**. This checkbox requires at least one rule to be defined before it can be enabled.
+6. Select **Save**. A confirmation modal shows qualifying and non-qualifying counts before changes are applied.
+
+.. important::
+
+   Saving rules always triggers an immediate team sync — **even when auto-add is off**. On private teams, this immediately enforces the rules by removing members who no longer qualify. Confirm the impact in the save modal before proceeding.
+
+.. note::
+
+   Custom rules compose additively with any parent policy assigned to the team. A user must satisfy **both** the parent policy and the custom rules. Custom rules cannot weaken or bypass the parent.
+
+Sync status footer (System Console)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below the Custom access rules panel, a sync status footer appears when membership policy enforcement is enabled. It is rendered inside the white-box Custom access rules panel — scroll down within the panel to find it.
+
+- **"Never synced."** with a **Sync now** link — no sync has run for this team yet.
+- **"Last synced N minutes ago."** with a **Sync now** link — after a prior sync.
+- Clicking **Sync now** changes the link to **"Syncing…"** with a spinner while the job is in-flight, then updates to **"Last synced just now."** on completion.
+
+Monitor membership sync
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+System Admins can review the results of team sync jobs from the System Console.
+
+1. Go to **System Console > Access Control > Membership sync jobs**.
+2. Select a job row to open the **Sync Job Details** modal.
+3. Select the **Teams** tab.
+
+The Teams tab shows per-team rows with:
+
+- A ``+N added / −N removed`` summary for each governed team.
+- A **mass-removal warning indicator** on any team row where more than 50% of members would be removed. This is a warning only — the job is not blocked.
+- An expandable per-team user drill-down showing which users were added and removed.
+
+.. note::
+
+   The Teams tab appears only when viewing a team sync job directly, or a channel sync job that was chained from a team sync. The system console section heading was renamed from "Channel access control sync jobs" to **"Membership sync jobs"** to reflect both job types.
+
+.. tip::
+
+   The **Run sync job** button on the Membership Policies list page runs a channel sync only, not a team sync. To trigger a team sync, use the **Sync now** link on the per-team System Console page or in Team Settings > Team Membership tab.
+
+Team Admin configuration
+-------------------------
+
+Team Membership tab
+~~~~~~~~~~~~~~~~~~~~
+
+From Mattermost v11.10, Team Settings has four tabs: **Info**, **Access**, **Team Membership**, and **Channel Membership**.
+
+.. note::
+
+   The fourth tab was previously labeled **Membership Policies**. It is now labeled **Channel Membership** and covers channel-scope policies only. The new **Team Membership** tab (the third tab) is for policies that control who can join the team itself.
+
+The **Team Membership** tab lets Team Admins view the system policy applied to their team and configure team-specific custom rules — without requiring System Admin involvement for every change.
+
+The tab is visible only when:
+
+- **Enable Attribute-Based Access Control** is on.
+- The ``TeamMembershipAccessControl`` feature flag is on.
+- The user has the ``manage_team_access_rules`` permission (Team Admin or System Admin).
+
+To open Team Settings: select the team name in the sidebar → **Team Settings** → **Team Membership** tab.
+
+System policy indicator
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a system-level policy is applied to the team by a System Admin, a non-dismissible information banner appears at the top of the Team Membership tab, showing the name of the applied policy. The banner is absent when no parent policy exists.
+
+Configure custom rules
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Team Admins can add attribute rules that apply on top of any system policy. These rules use the same Basic Mode editor as channel rules.
+
+1. Select **Add attribute rule**.
+2. Choose the attribute, operator, and value for each condition.
+3. Add additional rules as needed. All rules are AND-combined.
+4. Select **Save** to open the save confirmation modal.
+
+Available operators: **Is**, **Is not**, **In**, **Starts with**, **Ends with**, **Contains**. For ranked attributes: **Is exactly**, **Is at least**, **Is greater than**, **Is at most**, **Is less than**.
+
+.. important::
+
+   Saving rules always triggers an immediate team sync — **even when auto-add is off**. On private teams, this removes members who no longer satisfy the rules. Review the impact counts in the confirmation modal before saving.
+
+.. note::
+
+   Team Settings rules are Basic Mode only. Advanced CEL expressions are not available here. For complex rules with nested logic or mixed operators, a System Admin must create a system-wide parent policy in the System Console.
+
+Auto-add members
+~~~~~~~~~~~~~~~~~
+
+The **Auto-add members based on access rules** checkbox controls whether the sync job automatically adds qualifying non-members to the team.
+
+- This checkbox is enabled only when at least one rule exists, **or** when a system-level policy is applied.
+- Checking it and saving triggers an immediate backfill scan — qualifying non-members are added right away.
+- Subsequent syncs continue to add newly qualifying users.
+- Turning auto-add **off** does not remove any members — it is additive only. Toggling auto-add off also does **not** trigger a sync job.
+
+Test matching users
+~~~~~~~~~~~~~~~~~~~~
+
+Select **Test matching users** to open a preview modal listing users who would match the current rules, before saving. This lets you verify your intended scope without applying the rules.
+
+.. note::
+
+   If the current rules would exclude the editing Team Admin, the result set is empty. This is intentional — the preview is fail-secure and does not leak information about restricted users.
+
+Save confirmation and safety
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Selecting **Save** opens a confirmation modal before changes are applied. The modal shows:
+
+- The number of workspace users who match the current rules.
+- The number of current team members who do not qualify (and will be removed at the next sync on private teams).
+
+**Empty-team warning**: For private teams, if no current member qualifies under the rules, the modal displays a highlighted warning. Save is not blocked, but the team will be empty until sync runs.
+
+**Self-exclusion hard block**: If the rules would exclude the editing Team Admin, a separate error modal appears *before* the confirmation modal and prevents saving. Select **Back to editing** to adjust the rules.
+
+.. note::
+
+   The self-exclusion block only applies to the editing admin's own custom rules. A system-level parent policy that happens to exclude all Team Admins is not blocked here — this is a known limitation.
+
+Sync status footer (Team Settings)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below the auto-add section, a sync status footer appears whenever the team has at least one rule or a parent policy applied:
+
+- **"Never synced."** + **Sync now** link.
+- **"Last synced N minutes ago."** + **Sync now** link.
+- After clicking **Sync now**: **"Syncing…"** with spinner → **"Last synced just now."** on completion.
+
+The footer is not shown in the empty state (no rules and no parent policy).
+
+Clicking **Sync now** creates a team sync job scoped to this team only.
+
+End-user experience
+--------------------
+
+Browse Teams
+~~~~~~~~~~~~~
+
+The Browse Teams directory respects team ABAC enforcement:
+
+**Private + ABAC teams (strict mode):**
+
+- Non-qualifying users who are not already members do not see the team in Browse Teams at all. The team is simply absent — not greyed out or locked.
+- Qualifying users and existing members see the team normally.
+
+**Public + ABAC teams (advisory mode):**
+
+- All users see the team.
+- Qualifying users who are not yet members see a **Recommended** chip (lightbulb outline icon) next to the team name.
+- Users who are already members, or who do not qualify for the policy, do not see the chip.
+
+**Teams without a policy:**
+
+- Behave exactly as before — no filtering, no chip.
+
+Invite People modal
+~~~~~~~~~~~~~~~~~~~~
+
+The Invite People modal adapts to the team's enforcement mode:
+
+**Private + ABAC team (strict mode):**
+
+- Only users who qualify for the team's membership policy appear in search results. Non-qualifying users are filtered out before any results are shown.
+- A section notice informs admins: *"Only users who meet the membership requirements can be added to this team."*
+- Qualifying users in the results show attribute value tags (for example, "Department: Engineering").
+
+**Public + ABAC team (advisory mode):**
+
+- All users appear in search results — there is no filtering because advisory mode never blocks access.
+- A section notice is still shown informing admins that the team has membership requirements.
+- A warning is shown when generating an invite link, noting that the link recipients will be subject to membership requirements.
+
+**Team without a policy:**
+
+- No change from previous behavior — all users appear, no notice shown.
+
+Add Members flow (admin)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a System Admin or Team Admin uses the **Add Members** admin flow on a private + ABAC team and selects multiple users, ABAC denials are reported per user without aborting the batch:
+
+- Qualifying users in the selection are added successfully.
+- Non-qualifying users show an inline **"Does not meet membership requirements"** indicator on their row.
+- The batch continues — qualifying users are not affected by a co-selected user's denial.
+
+On a public + ABAC team (advisory mode), all users can be added without restriction.
+
+Team Members modal
+~~~~~~~~~~~~~~~~~~~
+
+When a team has an active membership policy:
+
+- A requirements notice banner appears at the top of the Team Members modal explaining that membership is controlled by access rules.
+- Qualifying members see attribute value tags on their own user entry (for example, "Department: Engineering").
+- Members without the matching attributes see only the generic notice — attribute values are never shown to non-holders.
+
+Membership notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Removal notification:** When the sync job removes a non-qualifying member from a private team, that user receives a direct message from the System Bot identifying the team they were removed from. The message does not include policy names, attribute values, or CEL expressions.
+
+**Auto-add notification:** When the sync job auto-adds a qualifying user to a team, that user receives a direct message from the System Bot identifying the team they were added to. Removal and auto-add notifications use different icons so users can distinguish them at a glance.
+
+Policy inheritance and composition
+------------------------------------
+
+When a parent (system-level) policy and custom team rules both apply:
+
+- The parent policy is shown in a non-dismissible info banner at the top of the Team Membership tab (read-only).
+- The user must satisfy **both** the parent policy and the custom team rules to be admitted.
+- Custom rules can only add restrictions — they cannot weaken or bypass the parent policy.
+- If a parent policy is deleted, the deletion cascades to unlink it from the team. Child (team-scoped) policies are not cascade-deleted.
+
+Sync behavior
+--------------
+
+A team sync batch runs in the following order:
+
+1. **Evaluate team membership rules** for all teams that have a policy assigned.
+2. **Removal pass** (private + ABAC teams only): remove members who no longer qualify. Each removal triggers a channel cascade — the user is removed from all channels within the team. Each removal notifies the user by system-bot DM and is recorded in the audit log. Ordinary, non-ABAC team leaves are not recorded as policy-driven cascades.
+3. **Auto-add pass** (any mode, when auto-add is enabled): add qualifying non-members to the team. Each addition emits a system-bot DM.
+4. **Channel membership sync** (chained): evaluate and apply channel policy changes. Deduped against any already-pending or in-progress channel sync job.
+
+**Mass-removal guardrail**: If a sync pass would remove more than 50% of a team's current members, the job sets a warning flag visible in the Sync Job Details > Teams tab. The job is not blocked — all removals proceed — but the warning is surfaced for admin review.
+
+Team sync also runs automatically every 30 minutes to handle attribute changes propagated from LDAP or SAML.
+
+Mutual exclusivity with group sync
+------------------------------------
+
+A team managed by LDAP/AD group synchronization cannot have an ABAC membership policy assigned. Attempting to assign a policy to a group-synced team returns an error.
+
+You must choose one membership control mechanism per team: group sync or ABAC.
+
+Troubleshooting and FAQs
+--------------------------
+
+Why did the Access tab change and where did the "Allow any user to join" checkbox go?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+From Mattermost v11.10, the "Allow any user to join" checkbox has been permanently replaced by **Public Team** and **Private Team** selection cards on the Access tab. This change applies to all teams on all deployments regardless of ABAC. The cards are functionally equivalent to the old checkbox — Public Team is the same as having the checkbox enabled, Private Team is the same as having it disabled.
+
+Why is the Team Membership tab not visible in Team Settings?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The tab requires all of the following:
+
+- **Enable Attribute-Based Access Control** is ON in System Console > System Attributes > Attribute-Based Access.
+- The ``TeamMembershipAccessControl`` feature flag is ON.
+- The user has the ``manage_team_access_rules`` permission (Team Admin or System Admin).
+
+If all three conditions are met but the tab is still missing, confirm the feature flag is actually enabled by checking **System Console > Environment > Feature Flags** or the server configuration.
+
+Why are private ABAC teams not appearing in Browse Teams for some users?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is intended behavior. When a private team has an ABAC policy and a user does not satisfy that policy, the team is completely hidden from them in Browse Teams and search results. They will not see an error or a locked entry — the team simply does not appear. Qualifying users see the team normally.
+
+Can I use advanced CEL expressions in Team Settings?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No. The Team Membership tab uses Basic Mode only — the same simple attribute editor available in Channel Settings. For rules that require nested logic, mixed ``&&`` / ``||`` operators, or grouping, a System Admin must create a system-wide parent policy using the CEL editor in the System Console.
+
+Can a group-synced team use ABAC?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No. Group sync and ABAC are mutually exclusive on a per-team basis. If a team is group-constrained, assigning an ABAC policy returns an error. You must remove the group sync configuration before applying an ABAC policy, or vice versa.
+
+How quickly are membership changes applied?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Saving rules in Team Settings or the System Console triggers an immediate team sync — **including when auto-add is off**, because enforcement (removal on private teams) runs regardless of the auto-add setting. Changes are applied as soon as the sync completes. An automatic sync also runs every 30 minutes to process attribute changes from LDAP or SAML.
+
+Does System Admin role bypass team ABAC enforcement?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No. All roles — including System Admin — are subject to team ABAC policy evaluation. A System Admin who does not satisfy a private team's policy cannot join that team as a member through the standard UI, though they can still access the team's configuration in the System Console and make changes.
+
+What happens when I switch a team from public to private while a policy is assigned?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If team ABAC is enabled (both flags on) and a policy is assigned to the team, clicking **Private Team** opens a confirmation modal — **"Switch to Private Team?"** — showing how many current members do not meet the policy criteria. Confirming the switch saves the change and triggers an immediate sync to enforce strict mode. Members who don't qualify are removed at that sync.
+
+If no policy is assigned, the switch saves directly with no confirmation.
+
+What happens when I switch a team from private to public while a policy is assigned?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Switching from Private to Public always saves directly with no confirmation modal. The team immediately transitions to advisory mode: existing members (including non-qualifying ones) are retained, and no removals occur. The policy continues to drive the Recommended tag and optional auto-add for qualifying users.
+
+Can I add a non-qualifying user to a private ABAC team?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No. The enforcement gate applies to all add paths: the Invite People modal (non-qualifying users are filtered from search results entirely), the Add Members admin flow (inline denial per user), and direct API calls. The error message is generic and does not expose policy names or attribute details. Qualifying users in the same batch request are still added — a denial for one user does not abort the rest.
+
+How does ABAC interact with email-domain restrictions?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Email-domain restrictions (configured on the Access tab) and ABAC rules (Team Membership tab) apply independently. A user must satisfy both to join the team. If both are configured and they conflict — for example, an email-domain rule and an attribute rule that together make the team unreachable — no warning is shown at configuration time. Review both settings together when debugging unexpected access denials.
+
+Why does saving rules trigger a sync even when auto-add is off?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Auto-add controls only the **add pass** (whether sync adds qualifying non-members). The **enforcement pass** (removing non-qualifying members from private teams) runs whenever rules exist, regardless of auto-add. This ensures that newly saved or changed rules take effect immediately rather than waiting up to 30 minutes for the next scheduled sync.

--- a/source/administration-guide/manage/admin/abac-team-membership.rst
+++ b/source/administration-guide/manage/admin/abac-team-membership.rst
@@ -42,18 +42,18 @@ Access tab: Public/Private team cards
 Switching modes
 ~~~~~~~~~~~~~~~~
 
-**Private → Public:** Always safe — relaxes enforcement. Saves directly with no confirmation modal. If a policy is applied, the team immediately transitions to advisory mode: no existing members are removed.
+**Private → Public:** Relaxes enforcement. Saves directly with no confirmation modal. If a policy is applied, the team immediately transitions to advisory mode: no existing members are removed.
 
-**Public → Private:** If team ABAC is enabled (both flags on) and the team has a membership policy assigned, clicking **Private Team** opens a confirmation modal before saving:
+**Public → Private:** If team ABAC is enabled (Enterprise Advanced license and **Enable Attribute-Based Access Control**) and the team has a membership policy assigned, clicking **Private Team** opens a confirmation modal before saving:
 
 - Title: **"Switch to Private Team?"**
-- Body shows how many current members do not meet the policy criteria and will be removed at the next sync. (If no count is available, a generic warning is shown instead.)
+- Body shows how many current members do not meet the policy criteria and will be removed at the next sync. If all current members meet the criteria, the modal says no one will be removed. If no count is available, a generic warning is shown instead.
 - **Cancel** — closes the modal, no changes made.
 - **Switch to Private** — saves the change and immediately creates a team sync job to enforce strict mode.
 
-If no policy is assigned, switching Public → Private saves directly with no modal.
+If the admin making the switch does not meet the policy criteria, a **"Cannot switch to Private Team"** error modal appears instead and the switch is blocked, since strict mode would remove them from the team. Update the rules to include yourself, or ask another admin to make the switch.
 
-**The cards stay interactive on ABAC-governed teams.** ABAC never disables the Public/Private cards. A public-to-private switch on a governed team is guarded by the mode-flip confirmation modal described above, not by locking the cards.
+If no policy is assigned, switching Public → Private saves directly with no modal.
 
 Other Access tab fields (Invite Code and Allowed Email Domain) are unaffected by this change. On teams managed by LDAP/AD group sync, the Access tab shows a static "Members of this team are added and removed by linked groups" message instead of the cards.
 
@@ -108,18 +108,19 @@ Before configuring team membership policies:
 
 1. :doc:`Configure user attributes </administration-guide/manage/admin/user-attributes>` in the System Console.
 2. Go to **System Console > System Attributes > Attribute-Based Access** and enable **Enable Attribute-Based Access Control**.
-3. Enable the ``TeamMembershipAccessControl`` feature flag. See the Mattermost developer documentation for details on `enabling feature flags in a self-hosted deployment <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#self-hosted-and-local-development>`_. Mattermost Cloud customers can request this feature flag be enabled by contacting their Mattermost Account Manager or by `creating a support ticket <https://support.mattermost.com/hc/en-us/requests/new?ticket_form_id=11184911962004>`_.
-4. For Team Admins configuring rules: the ``manage_team_access_rules`` permission is required. This permission is included in the Team Admin role by default.
+3. For Team Admins configuring rules: the ``manage_team_access_rules`` permission is required. This permission is included in the Team Admin role by default.
 
-**What changes when the flags are off:**
+Team membership ABAC is also gated by the ``TeamMembershipAccessControl`` feature flag, which is **enabled by default** from Mattermost v11.10. Disabling it turns off team enforcement without affecting channel ABAC. See the Mattermost developer documentation for details on `feature flags in a self-hosted deployment <https://developers.mattermost.com/contribute/more-info/server/feature-flags/#self-hosted-and-local-development>`_.
+
+**What changes when team membership ABAC is off:**
 
 .. list-table::
    :header-rows: 1
    :widths: 42 29 29
 
    * - Surface
-     - Both flags ON
-     - Either flag OFF
+     - Team membership ABAC ON
+     - Team membership ABAC OFF
    * - Join gate (private teams)
      - Enforced — non-qualifying users denied
      - Off — anyone can join as before
@@ -142,11 +143,11 @@ Before configuring team membership policies:
      - Filters on private+ABAC teams
      - All users shown, as before
    * - Public/Private cards (Access tab)
-     - **Always visible** — not gated by these flags
+     - **Always visible** — not gated
      - **Still visible** — always rendered (see note above)
    * - Channel ABAC
-     - Unaffected by team flag
-     - Unaffected by team flag
+     - Unaffected
+     - Unaffected
 
 System Admin configuration
 ---------------------------
@@ -157,35 +158,29 @@ Assign a membership policy to a team
 System Admins assign existing system-wide membership policies to teams via the per-team System Console page.
 
 1. Go to **System Console > User Management > Teams** and open the team you want to configure.
-2. Locate the **Membership Policy** section.
-3. Select **Link to a policy** and choose an existing policy from the picker.
+2. In the **Team Management** section, enable **Manage membership with attribute based membership policies**. The **Membership policies** and **Team-specific membership rules** sections appear only once this toggle is on. The toggle is unavailable on group-synced teams, and becomes read-only once a policy is linked.
+3. In the **Membership policies** section, select **Link to a policy** and choose an existing policy from the picker.
 4. Select **Save**.
 
-Before saving, a confirmation modal shows:
+Before saving, an **Apply membership policy** confirmation modal appears. It shows only the outcomes that apply to this team:
 
-- The number of workspace users who currently qualify for the policy.
-- The number of current team members who do not qualify (and will be affected at the next sync on private teams).
-- An **empty-team warning** if the team is private and no current member qualifies.
+- The number of current members who do not meet the policy criteria and will be removed at the next sync — private teams only, and only when that number is above zero.
+- The number of qualifying users who will be added at the next sync — only when auto-add is enabled and that number is above zero.
+- An **empty-team warning** if the team is private and no user matches the policy ("Saving may result in an empty private team").
+- A confirmation prompt: "Are you sure you want to apply the membership policy?"
 
-**To remove a policy:** Select the trash icon next to the policy row, then **Save**. The team's enforcement flag is cleared and the team reverts to standard access behavior.
+**To remove a policy:** Select the trash icon next to the policy row and confirm in the **"Remove this team from policy"** modal, then **Save**. Existing members are retained and the team returns to its standard access mode at the next sync.
 
 **Policy list team counts:** The **Membership Policies** list page shows the count of channels and teams each policy is applied to — for example, ``2 channels, 1 team``. A zero side is omitted (so ``1 team`` not ``0 channels, 1 team``).
 
-Enable auto-add from the Membership Policy section
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Configure team-specific membership rules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a parent policy is linked, the **Membership Policy** section shows an **Auto-add** checkbox per linked policy row. This checkbox is always enabled for any linked policy — it does not require custom rules to exist. Checking it and saving starts the backfill scan immediately.
-
-This is separate from the **Auto-add members based on access rules** checkbox in the Custom access rules panel (see below), which requires at least one custom rule before it can be checked.
-
-Configure custom access rules
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In addition to a system-wide parent policy, System Admins can define team-specific custom rules directly on the per-team System Console page.
+In addition to a system-wide parent policy, System Admins can define team-specific rules directly on the per-team System Console page.
 
 1. Go to **System Console > User Management > Teams** and open the team.
 2. Enable the **Manage membership with attribute based membership policies** switch.
-3. Scroll to the **Custom access rules** panel.
+3. Scroll to the **Team-specific membership rules** panel.
 4. Select **Add attribute** to add a condition. For each condition, choose:
 
    - **Attribute**: The user profile attribute to evaluate.
@@ -194,8 +189,8 @@ In addition to a system-wide parent policy, System Admins can define team-specif
 
    All conditions are combined with a logical AND — users must satisfy all of them.
 
-5. Optionally, check **Auto-add members based on access rules**. This checkbox requires at least one rule to be defined before it can be enabled.
-6. Select **Save**. A confirmation modal shows qualifying and non-qualifying counts before changes are applied.
+5. Optionally, check **Auto-add members based on access rules**. This checkbox is enabled once the team has at least one rule **or** a linked parent policy. There is only one auto-add setting per team — it is not configured per linked policy.
+6. Select **Save**. The **Apply membership policy** modal shows the impact counts before changes are applied.
 
 .. important::
 
@@ -203,15 +198,15 @@ In addition to a system-wide parent policy, System Admins can define team-specif
 
 .. note::
 
-   Custom rules compose additively with any parent policy assigned to the team. A user must satisfy **both** the parent policy and the custom rules. Custom rules cannot weaken or bypass the parent.
+   Team-specific rules compose additively with any parent policy assigned to the team. A user must satisfy **both** the parent policy and the team-specific rules. Team-specific rules cannot weaken or bypass the parent.
 
 Sync status footer (System Console)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Below the Custom access rules panel, a sync status footer appears when membership policy enforcement is enabled. It is rendered inside the white-box Custom access rules panel — scroll down within the panel to find it.
+A sync status footer is rendered at the bottom of the **Team-specific membership rules** panel — scroll down within the panel to find it.
 
 - **"Never synced."** with a **Sync now** link — no sync has run for this team yet.
-- **"Last synced N minutes ago."** with a **Sync now** link — after a prior sync.
+- **"Last synced N minutes ago."** with a **Sync now** link — after a prior sync. Older syncs are reported in hours or days.
 - Clicking **Sync now** changes the link to **"Syncing…"** with a spinner while the job is in-flight, then updates to **"Last synced just now."** on completion.
 
 Monitor membership sync
@@ -219,7 +214,7 @@ Monitor membership sync
 
 System Admins can review the results of team sync jobs from the System Console.
 
-1. Go to **System Console > Access Control > Membership sync jobs**.
+1. Go to **System Console > System Attributes > Membership Policies** and scroll to the **Membership Sync Jobs** panel.
 2. Select a job row to open the **Sync Job Details** modal.
 3. Select the **Teams** tab.
 
@@ -231,11 +226,11 @@ The Teams tab shows per-team rows with:
 
 .. note::
 
-   The Teams tab appears only when viewing a team sync job directly, or a channel sync job that was chained from a team sync. The system console section heading was renamed from "Channel access control sync jobs" to **"Membership sync jobs"** to reflect both job types.
+   The Teams tab appears only when viewing a team sync job directly, or a channel sync job that was chained from a team sync. The system console section heading was renamed from "Channel access control sync jobs" to **"Membership Sync Jobs"** to reflect both job types.
 
 .. tip::
 
-   The **Run sync job** button on the Membership Policies list page runs a channel sync only, not a team sync. To trigger a team sync, use the **Sync now** link on the per-team System Console page or in Team Settings > Team Membership tab.
+   The **Run Channel Sync** button on the Membership Policies page runs a channel sync only, not a team sync. To trigger a team sync, use the **Sync now** link on the per-team System Console page or in Team Settings > Team Membership tab.
 
 Team Admin configuration
 -------------------------
@@ -254,7 +249,7 @@ The **Team Membership** tab lets Team Admins view the system policy applied to t
 The tab is visible only when:
 
 - **Enable Attribute-Based Access Control** is on.
-- The ``TeamMembershipAccessControl`` feature flag is on.
+- The ``TeamMembershipAccessControl`` feature flag is on (enabled by default).
 - The user has the ``manage_team_access_rules`` permission (Team Admin or System Admin).
 
 To open Team Settings: select the team name in the sidebar → **Team Settings** → **Team Membership** tab.
@@ -269,10 +264,12 @@ Configure custom rules
 
 Team Admins can add attribute rules that apply on top of any system policy. These rules use the same Basic Mode editor as channel rules.
 
-1. Select **Add attribute rule**.
+1. Select **Add attribute**.
 2. Choose the attribute, operator, and value for each condition.
 3. Add additional rules as needed. All rules are AND-combined.
 4. Select **Save** to open the save confirmation modal.
+
+Clearing every rule and saving opens a **"Remove membership rules?"** modal instead. Confirming removes the team's attribute enforcement; current members keep their access.
 
 Available operators: **Is**, **Is not**, **In**, **Starts with**, **Ends with**, **Contains**. For ranked attributes: **Is exactly**, **Is at least**, **Is greater than**, **Is at most**, **Is less than**.
 
@@ -294,30 +291,39 @@ The **Auto-add members based on access rules** checkbox controls whether the syn
 - Subsequent syncs continue to add newly qualifying users.
 - Turning auto-add **off** does not remove any members — it is additive only. Toggling auto-add off also does **not** trigger a sync job.
 
-Test matching users
-~~~~~~~~~~~~~~~~~~~~
+Test access rule
+~~~~~~~~~~~~~~~~~
 
-Select **Test matching users** to open a preview modal listing users who would match the current rules, before saving. This lets you verify your intended scope without applying the rules.
+Select **Test access rule** to open a preview modal listing users who match the current rules, before saving. This lets you verify your intended scope without applying the rules.
 
 .. note::
 
-   If the current rules would exclude the editing Team Admin, the result set is empty. This is intentional — the preview is fail-secure and does not leak information about restricted users.
+   If the current rules would exclude the editing Team Admin, the **Test access rule** button is disabled with an explanatory tooltip rather than returning results.
 
 Save confirmation and safety
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Selecting **Save** opens a confirmation modal before changes are applied. The modal shows:
+Selecting **Save** opens a confirmation modal before changes are applied. What it shows depends on the team's mode:
 
-- The number of workspace users who match the current rules.
-- The number of current team members who do not qualify (and will be removed at the next sync on private teams).
+**Private teams (strict):**
 
-**Empty-team warning**: For private teams, if no current member qualifies under the rules, the modal displays a highlighted warning. Save is not blocked, but the team will be empty until sync runs.
+- The number of users who match the current rules and will have access.
+- The number of current members who do not match the rules and may be affected — shown only when that number is above zero.
 
-**Self-exclusion hard block**: If the rules would exclude the editing Team Admin, a separate error modal appears *before* the confirmation modal and prevents saving. Select **Back to editing** to adjust the rules.
+**Public teams (advisory):**
+
+- A note that the rules are advisory: no one is blocked or removed.
+- The number of users who match the current rules.
+
+The counts are evaluated against the team's rules combined with any parent policy.
+
+**Empty-team warning**: For private teams, if no user matches the rules, the modal displays a highlighted warning. Save is not blocked, but the team will be empty until sync runs.
+
+**Self-exclusion hard block**: On private teams, if the rules would exclude the editing Team Admin, a separate error modal appears *before* the confirmation modal and prevents saving. Select **Back to editing** to adjust the rules. Public teams are exempt — advisory mode never removes anyone.
 
 .. note::
 
-   The self-exclusion block only applies to the editing admin's own custom rules. A system-level parent policy that happens to exclude all Team Admins is not blocked here — this is a known limitation.
+   By design, the self-exclusion block evaluates only the admin's own team rules. A system-level parent policy that excludes the admin is a System Admin decision and is not blocked here.
 
 Sync status footer (Team Settings)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -363,14 +369,15 @@ The Invite People modal adapts to the team's enforcement mode:
 **Private + ABAC team (strict mode):**
 
 - Only users who qualify for the team's membership policy appear in search results. Non-qualifying users are filtered out before any results are shown.
-- A section notice informs admins: *"Only users who meet the membership requirements can be added to this team."*
-- Qualifying users in the results show attribute value tags (for example, "Department: Engineering").
+- A notice titled **"Team access is restricted by user attributes"** informs admins: *"Only users who meet the membership requirements can be added to this team."*
+- The notice lists the policy's attribute value tags (for example, "Department: Engineering").
+- The invite link warns: *"People who use this link must meet the membership requirements to join."*
 
 **Public + ABAC team (advisory mode):**
 
 - All users appear in search results — there is no filtering because advisory mode never blocks access.
-- A section notice is still shown informing admins that the team has membership requirements.
-- A warning is shown when generating an invite link, noting that the link recipients will be subject to membership requirements.
+- A notice titled **"This team has membership requirements"** is still shown, explaining that users who do not meet them can still join but will not be automatically added.
+- The invite link warns: *"People who use this link can join even if they do not meet the membership requirements, but will not be automatically added."*
 
 **Team without a policy:**
 
@@ -379,22 +386,21 @@ The Invite People modal adapts to the team's enforcement mode:
 Add Members flow (admin)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a System Admin or Team Admin uses the **Add Members** admin flow on a private + ABAC team and selects multiple users, ABAC denials are reported per user without aborting the batch:
+When a System Admin or Team Admin uses the **Add Members** admin flow on a private + ABAC team, non-qualifying users are blocked at selection time rather than at submission:
 
-- Qualifying users in the selection are added successfully.
-- Non-qualifying users show an inline **"Does not meet membership requirements"** indicator on their row.
-- The batch continues — qualifying users are not affected by a co-selected user's denial.
+- Non-qualifying candidates show an inline **"Does not meet membership requirements"** indicator on their row and cannot be selected, including by keyboard.
+- Only qualifying users can be added to the selection, so the add never fails partway through.
 
 On a public + ABAC team (advisory mode), all users can be added without restriction.
 
 Team Members modal
 ~~~~~~~~~~~~~~~~~~~
 
-When a team has an active membership policy:
+When a team has an active membership policy, a notice banner appears at the top of the Team Members modal:
 
-- A requirements notice banner appears at the top of the Team Members modal explaining that membership is controlled by access rules.
-- Qualifying members see attribute value tags on their own user entry (for example, "Department: Engineering").
-- Members without the matching attributes see only the generic notice — attribute values are never shown to non-holders.
+- On private teams: **"Team access is restricted by user attributes"** — only people who meet the membership requirements can be members.
+- On public teams: **"This team has membership requirements"** — people who do not meet them can still join, but will not be automatically added.
+- The banner lists the policy's attribute value tags (for example, "Department: Engineering"). Values the viewer is not permitted to see are stripped server-side, so a non-holder sees only the notice.
 
 Membership notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -411,7 +417,7 @@ When a parent (system-level) policy and custom team rules both apply:
 - The parent policy is shown in a non-dismissible info banner at the top of the Team Membership tab (read-only).
 - The user must satisfy **both** the parent policy and the custom team rules to be admitted.
 - Custom rules can only add restrictions — they cannot weaken or bypass the parent policy.
-- If a parent policy is deleted, the deletion cascades to unlink it from the team. Child (team-scoped) policies are not cascade-deleted.
+- Deleting a parent policy does not unlink it from the team or delete the team's own rules. Unlink the policy from each team before deleting it.
 
 Sync behavior
 --------------
@@ -425,7 +431,7 @@ A team sync batch runs in the following order:
 
 **Mass-removal guardrail**: If a sync pass would remove more than 50% of a team's current members, the job sets a warning flag visible in the Sync Job Details > Teams tab. The job is not blocked — all removals proceed — but the warning is surfaced for admin review.
 
-Team sync also runs automatically every 30 minutes to handle attribute changes propagated from LDAP or SAML.
+Team sync also runs automatically on a schedule to handle attribute changes propagated from LDAP or SAML. The interval is set by ``AccessControlSettings.SyncJobIntervalSeconds`` and defaults to 3600 seconds (60 minutes). The minimum accepted value is 60 seconds, and a change requires a server restart to take effect. The same interval governs channel membership sync.
 
 Mutual exclusivity with group sync
 ------------------------------------
@@ -448,10 +454,10 @@ Why is the Team Membership tab not visible in Team Settings?
 The tab requires all of the following:
 
 - **Enable Attribute-Based Access Control** is ON in System Console > System Attributes > Attribute-Based Access.
-- The ``TeamMembershipAccessControl`` feature flag is ON.
+- The ``TeamMembershipAccessControl`` feature flag is ON (enabled by default).
 - The user has the ``manage_team_access_rules`` permission (Team Admin or System Admin).
 
-If all three conditions are met but the tab is still missing, confirm the feature flag is actually enabled by checking **System Console > Environment > Feature Flags** or the server configuration.
+If all three conditions are met but the tab is still missing, confirm the feature flag has not been disabled by checking **System Console > Experimental > Feature Flags** or the server configuration.
 
 Why are private ABAC teams not appearing in Browse Teams for some users?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -471,7 +477,7 @@ No. Group sync and ABAC are mutually exclusive on a per-team basis. If a team is
 How quickly are membership changes applied?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Saving rules in Team Settings or the System Console triggers an immediate team sync — **including when auto-add is off**, because enforcement (removal on private teams) runs regardless of the auto-add setting. Changes are applied as soon as the sync completes. An automatic sync also runs every 30 minutes to process attribute changes from LDAP or SAML.
+Saving rules in Team Settings or the System Console triggers an immediate team sync — **including when auto-add is off**, because enforcement (removal on private teams) runs regardless of the auto-add setting. Changes are applied as soon as the sync completes. A scheduled sync also runs on the interval set by ``AccessControlSettings.SyncJobIntervalSeconds`` (60 minutes by default) to process attribute changes from LDAP or SAML.
 
 Does System Admin role bypass team ABAC enforcement?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -481,7 +487,9 @@ No. All roles — including System Admin — are subject to team ABAC policy eva
 What happens when I switch a team from public to private while a policy is assigned?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If team ABAC is enabled (both flags on) and a policy is assigned to the team, clicking **Private Team** opens a confirmation modal — **"Switch to Private Team?"** — showing how many current members do not meet the policy criteria. Confirming the switch saves the change and triggers an immediate sync to enforce strict mode. Members who don't qualify are removed at that sync.
+If team ABAC is enabled (Enterprise Advanced license and **Enable Attribute-Based Access Control**) and a policy is assigned to the team, clicking **Private Team** opens a confirmation modal — **"Switch to Private Team?"** — showing how many current members do not meet the policy criteria. Confirming the switch saves the change and triggers an immediate sync to enforce strict mode. Members who don't qualify are removed at that sync.
+
+If the admin making the switch does not meet the criteria themselves, the switch is blocked with a **"Cannot switch to Private Team"** modal.
 
 If no policy is assigned, the switch saves directly with no confirmation.
 
@@ -493,12 +501,12 @@ Switching from Private to Public always saves directly with no confirmation moda
 Can I add a non-qualifying user to a private ABAC team?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-No. The enforcement gate applies to all add paths: the Invite People modal (non-qualifying users are filtered from search results entirely), the Add Members admin flow (inline denial per user), and direct API calls. The error message is generic and does not expose policy names or attribute details. Qualifying users in the same batch request are still added — a denial for one user does not abort the rest.
+No. The enforcement gate applies to all add paths: the Invite People modal (non-qualifying users are filtered from search results entirely), the Add Members admin flow (non-qualifying users cannot be selected), and direct API calls. The error message is generic and does not expose policy names or attribute details.
 
 How does ABAC interact with email-domain restrictions?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Email-domain restrictions (configured on the Access tab) and ABAC rules (Team Membership tab) apply independently. A user must satisfy both to join the team. If both are configured and they conflict — for example, an email-domain rule and an attribute rule that together make the team unreachable — no warning is shown at configuration time. Review both settings together when debugging unexpected access denials.
+Email-domain restrictions (configured on the Access tab) and ABAC rules (Team Membership tab) apply independently, and a user must satisfy both to join the team. The domain check runs first, so a user rejected on domain grounds never reaches policy evaluation. The two settings are not cross-validated at configuration time, so review them together when debugging unexpected access denials.
 
 Why does saving rules trigger a sync even when auto-add is off?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/administration-guide/manage/admin/abac-team-membership.rst
+++ b/source/administration-guide/manage/admin/abac-team-membership.rst
@@ -24,7 +24,7 @@ Access tab: Public/Private team cards
 
 .. important::
 
-   This change affects **all Mattermost teams on all deployments**, regardless of whether ABAC is enabled or whether your organization has an Enterprise Advanced license. Any team admin who opens **Team Settings > Access** after upgrading will see the new UI.
+   This change affects **all Mattermost teams on all deployments**, regardless of whether ABAC is enabled or whether your organization has an Enterprise Advanced license. Any team admin who opens **Team Settings > Access** after upgrading will see the new UI. The exception is teams managed by LDAP/AD group sync, which show a static message in place of the cards — see `Switching modes`_.
 
 **What changed:** The "Allow any user to join" checkbox has been permanently replaced by two selection cards:
 
@@ -123,10 +123,10 @@ Team membership ABAC is also gated by the ``TeamMembershipAccessControl`` featur
      - Team membership ABAC OFF
    * - Join gate (private teams)
      - Enforced — non-qualifying users denied
-     - Off — anyone can join as before
+     - Not evaluated — private teams stay invite-only, as before
    * - Browse Teams filter
      - Private+ABAC teams hidden from non-qualifying users
-     - All teams visible
+     - No attribute filtering — standard privacy rules apply
    * - Team Membership tab (Team Settings)
      - Visible to Team Admins and System Admins
      - Hidden — tab does not appear
@@ -143,8 +143,8 @@ Team membership ABAC is also gated by the ``TeamMembershipAccessControl`` featur
      - Filters on private+ABAC teams
      - All users shown, as before
    * - Public/Private cards (Access tab)
-     - **Always visible** — not gated
-     - **Still visible** — always rendered (see note above)
+     - **Visible** — not gated
+     - **Still visible** — rendered on every team except group-synced ones
    * - Channel ABAC
      - Unaffected
      - Unaffected
@@ -511,4 +511,4 @@ Email-domain restrictions (configured on the Access tab) and ABAC rules (Team Me
 Why does saving rules trigger a sync even when auto-add is off?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Auto-add controls only the **add pass** (whether sync adds qualifying non-members). The **enforcement pass** (removing non-qualifying members from private teams) runs whenever rules exist, regardless of auto-add. This ensures that newly saved or changed rules take effect immediately rather than waiting up to 30 minutes for the next scheduled sync.
+Auto-add controls only the **add pass** (whether sync adds qualifying non-members). The **enforcement pass** (removing non-qualifying members from private teams) runs whenever rules exist, regardless of auto-add. This ensures that newly saved or changed rules take effect immediately rather than waiting up to 60 minutes for the next scheduled sync.

--- a/source/administration-guide/manage/admin/attribute-based-access-control.rst
+++ b/source/administration-guide/manage/admin/attribute-based-access-control.rst
@@ -10,18 +10,20 @@ Attribute-Based Access Control
   :titlesonly:
 
   /administration-guide/manage/admin/abac-system-wide-policies
+  /administration-guide/manage/admin/abac-team-membership
   /administration-guide/manage/admin/abac-team-channel-policies
   /administration-guide/manage/admin/abac-channel-access-rules
 
 From Mattermost v10.9, system admins in large or complex organizations who require Zero Trust Security when handling with sensitive information can prevent unauthorized access through attribute-based access controls.
 
-Enforcing strict access controls based on user attributes eliminates manual role adjustment processes that can lead to security risks, inefficiencies, or inappropriate access, while maintaining security and compliance by ensuring that only authorized users can access specific Mattermost channels.
+Enforcing strict access controls based on user attributes eliminates manual role adjustment processes that can lead to security risks, inefficiencies, or inappropriate access, while maintaining security and compliance by ensuring that only authorized users can access specific Mattermost channels and teams.
 
 Attribute-based access control (ABAC) can be used with the following policy types:
 
-- **System-wide access policies** (managed by System Admins): Centralized policies created in the System Console that can be applied across multiple channels. See :doc:`System-wide attribute-based access policies </administration-guide/manage/admin/abac-system-wide-policies>`.
+- **System-wide access policies** (managed by System Admins): Centralized policies created in the System Console that can be applied across multiple channels and teams. See :doc:`System-wide attribute-based access policies </administration-guide/manage/admin/abac-system-wide-policies>`.
 - **Permission policies** (managed by System Admins): Attribute-based restrictions on user actions such as file upload and file download. See :ref:`Permission policies <administration-guide/manage/admin/abac-system-wide-policies:permission policies>`.
-- **Team-scoped membership policies** (managed by Team Admins): Channel membership policies that Team Admins can create, edit, and delete directly from Team Settings for channels in their team. See :ref:`Manage team-scoped membership policies in Team Settings <administration-guide/manage/admin/abac-channel-access-rules:manage team-scoped membership policies in team settings>`.
+- **Team membership policies** (managed by System Admins and Team Admins): Attribute-based rules that control who can join a team. On private teams, rules gate directory visibility, join evaluation, and removal at sync (strict mode). On public teams, rules drive a "Recommended" tag and optional auto-add without restricting access (advisory mode). See :doc:`Team membership access policies </administration-guide/manage/admin/abac-team-membership>`.
+- **Team-scoped channel membership policies** (managed by Team Admins): Channel membership policies that Team Admins can create, edit, and delete directly from the Channel Membership tab in Team Settings for channels in their team. See :doc:`Team-level channel membership policies </administration-guide/manage/admin/abac-team-channel-policies>`.
 - **Channel-specific access rules** (managed by Channel Admins): Self-service access rules that Channel Admins can configure directly in Channel Settings for individual channels. See :doc:`Channel-specific access rules </administration-guide/manage/admin/abac-channel-access-rules>`.
 
 From Mattermost v11.8, ABAC policies can be applied to **both private and public channels**, with deliberately different semantics for each:
@@ -30,6 +32,8 @@ From Mattermost v11.8, ABAC policies can be applied to **both private and public
 - **Public channels** are advisory. Anyone can still join freely, no member is ever removed by ABAC, and the policy is used either to **auto-add** matching users (when enabled) or to **recommend** the channel under **Browse Channels > Recommended channels** (when auto-add is disabled).
 
 Default channels (Town Square, Off-Topic), shared channels, and group-synced channels remain ineligible.
+
+From Mattermost v11.10, ABAC policies can also be applied to **teams**, with the same advisory/strict model keyed on whether the team is public or private. See :doc:`Team membership access policies </administration-guide/manage/admin/abac-team-membership>` for details.
 
 Before you begin
 ------------------
@@ -51,18 +55,16 @@ From Mattermost v11.8.0, admins can configure membership policies for both publi
 
 **System Admins can:**
 
-- Create :doc:`system-wide access policies </administration-guide/manage/admin/abac-system-wide-policies>` that can be assigned across multiple channels in the System Console. Membership policies can be applied to both public and private channels, with :ref:`advisory behavior on public channels <administration-guide/manage/admin/abac-channel-access-rules:public and private channel behavior>`.
+- Create :doc:`system-wide access policies </administration-guide/manage/admin/abac-system-wide-policies>` that can be assigned across multiple channels and teams in the System Console. Membership policies can be applied to both public and private channels, with :ref:`advisory behavior on public channels <administration-guide/manage/admin/abac-channel-access-rules:public and private channel behavior>`.
 - Assign :ref:`individual channel policies <administration-guide/manage/admin/abac-system-wide-policies:define access controls per channel>` to specific channels in the System Console.
+- :ref:`Assign membership policies to teams <administration-guide/manage/admin/abac-team-membership:assign a membership policy to a team>` via the per-team System Console page, with advisory enforcement on public teams and strict enforcement on private teams.
 - Define :ref:`permission policies <administration-guide/manage/admin/abac-system-wide-policies:permission policies>` that restrict actions such as file upload and file download based on user attributes.
 - :ref:`Simulate policy outcomes <administration-guide/manage/admin/abac-system-wide-policies:simulate access>` to preview whether selected users can perform actions such as joining a channel or uploading and downloading files before saving policy changes.
 
 **Team Admins can:**
 
-- Create, edit, and delete :ref:`team-scoped channel membership policies <administration-guide/manage/admin/abac-channel-access-rules:manage team-scoped membership policies in team settings>` for channels in their team directly from Team Settings, when granted the ``manage_team_access_rules`` permission.
-
-**Team Admins can:**
-
-- Create and manage :doc:`team-level channel membership policies </administration-guide/manage/admin/abac-team-channel-policies>` in Team Settings, scoping attribute-based rules to one or more private channels within their team.
+- View the system policy applied to their team and :ref:`configure custom team membership rules <administration-guide/manage/admin/abac-team-membership:configure custom rules>` directly from the **Team Membership** tab in Team Settings, when granted the ``manage_team_access_rules`` permission.
+- Create and manage :doc:`team-level channel membership policies </administration-guide/manage/admin/abac-team-channel-policies>` from the **Channel Membership** tab in Team Settings, scoping attribute-based rules to one or more channels within their team.
 
 **Channel Admins can:**
 

--- a/source/administration-guide/manage/admin/attribute-based-access-control.rst
+++ b/source/administration-guide/manage/admin/attribute-based-access-control.rst
@@ -16,7 +16,7 @@ Attribute-Based Access Control
 
 From Mattermost v10.9, system admins in large or complex organizations who require Zero Trust Security when handling with sensitive information can prevent unauthorized access through attribute-based access controls.
 
-Enforcing strict access controls based on user attributes eliminates manual role adjustment processes that can lead to security risks, inefficiencies, or inappropriate access, while maintaining security and compliance by ensuring that only authorized users can access specific Mattermost channels and teams.
+Enforcing strict access controls based on user attributes eliminates manual role adjustment processes that can lead to security risks, inefficiencies, or inappropriate access, while maintaining security and compliance by ensuring that only authorized users can access specific private Mattermost channels and teams. On public channels and teams, policies are advisory rather than a gate — see the advisory and strict behaviour described below.
 
 Attribute-based access control (ABAC) can be used with the following policy types:
 


### PR DESCRIPTION
…

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Documents the Team Membership ABAC feature (PR #37054 / MM-69100) and updates the existing ABAC docs to reflect that policies can now be assigned to teams, not just channels.

  ## What's included

  **New page** — `abac-team-membership.rst`:
  - Advisory (public) vs strict (private) enforcement model, keyed on `allow_open_invite`
  - Prerequisites + feature-flag behavior matrix (what changes when
  `EnableAttributeBasedAccessControl` / `TeamMembershipAccessControl` are off)
  - System Admin config: policy assignment, custom rules, both auto-add checkboxes, sync
  footer, Membership sync jobs Teams tab
  - Team Admin config: Team Membership tab, system-policy banner, custom rules, auto-add,
  test matching users, save confirmation, self-exclusion block, sync footer
  - End-user surfaces: Browse Teams (hidden / Recommended chip), Invite modal, Add Members
  admin flow, Team Members modal, removal/auto-add DMs
  - Policy inheritance, sync execution order, mass-removal guardrail, group-sync mutual
  exclusivity
  - Troubleshooting FAQ

  **Access tab UI change (all deployments):** Prominently documents that the "Allow any
  user to join" checkbox is permanently replaced by Public/Private selection cards on
  **every team, regardless of ABAC or license**. The cards control the single
  `allow_open_invite` field (same field the checkbox did); `type` is intentionally left
  untouched.

  **Updated pages:**
  - `attribute-based-access-control.rst` — toctree entry, team policy type, deduped roles
  lists
  - `abac-system-wide-policies.rst` — "Assign policies to teams" section; delete now
  requires 0 channels **and** 0 teams
  - `abac-team-channel-policies.rst` — "Membership Policies" tab renamed to "Channel
  Membership"; disambiguation note vs. the new Team Membership tab

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69100

