### PR TITLE
Make analysis-icu plugin requirement a mandatory callout in Elasticsearch/Opensearch setup

### DIFF
--- a/source/administration-guide/scale/elasticsearch-setup.rst
+++ b/source/administration-guide/scale/elasticsearch-setup.rst
@@ -64,9 +64,20 @@ We highly recommend that you set up Elasticsearch server on a dedicated machine 
 
 11. Install the `icu-analyzer plugin <https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html>`__ to the ``/usr/share/elasticsearch/plugins`` directory by running the following command:
 
+  .. important::
+     The ``analysis-icu`` plugin is **required on every node in the cluster**, not optional. Mattermost's post and file index templates depend on it. Without the plugin, Mattermost cannot create these templates.
+
   .. code-block:: sh
 
     sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+
+  Restart Elasticsearch on each node to load the newly installed plugin before verifying it; ``_cat/plugins`` only reports active plugins, so a restart is required first. For production clusters, restart nodes one at a time (rolling restart) rather than all at once. Confirm the plugin is installed and active on every node before continuing, replacing ``<your-elasticsearch-host>`` with your cluster endpoint:
+
+  .. code-block:: sh
+
+    curl --silent --show-error --fail-with-body --user elastic 'http://<your-elasticsearch-host>:9200/_cat/plugins?v&h=name,component,version&s=name,component'
+
+  Running this command should show ``analysis-icu`` once per node in the cluster. If the ``analysis-icu`` line is missing for any node, the plugin is not installed there.
 
   **(Optional) CJK language analyzer plugins**: To improve search for Korean, Japanese, or Chinese content, install one or more of the following language-specific analyzer plugins: ``analysis-nori`` (Korean), ``analysis-kuromoji`` (Japanese), and ``analysis-smartcn`` (Chinese).
 

--- a/source/administration-guide/scale/opensearch-setup.rst
+++ b/source/administration-guide/scale/opensearch-setup.rst
@@ -98,9 +98,20 @@ We highly recommend that you set up an AWS OpenSearch server on a separate machi
 
   8. Install the `icu-analyzer plugin <https://docs.opensearch.org/latest/install-and-configure/additional-plugins/index/>`__ to the ``/usr/share/opensearch/plugins`` directory by running the following command:
 
+    .. important::
+       The ``analysis-icu`` plugin is **required on every node in the cluster**, not optional. Mattermost's post and file index templates depend on it. Without the plugin, Mattermost cannot create these templates.
+
     .. code-block:: sh
 
       sudo /usr/share/opensearch/bin/opensearch-plugin install analysis-icu
+
+    Restart OpenSearch on each node to load the newly installed plugin before verifying it; ``_cat/plugins`` only reports active plugins, so a restart is required first. For production clusters, restart nodes one at a time (rolling restart) rather than all at once. Confirm the plugin is installed and active on every node before continuing, replacing ``<your-opensearch-host>`` with your cluster endpoint:
+
+    .. code-block:: sh
+
+      curl --silent --show-error --fail-with-body 'http://<your-opensearch-host>:9200/_cat/plugins?v&h=name,component,version&s=name,component'
+
+    Running this command should show ``analysis-icu`` once per node in the cluster. If the ``analysis-icu`` line is missing for any node, the plugin is not installed there.
 
   **(Optional) CJK language analyzer plugins**: To improve search for Korean, Japanese, or Chinese content, install one or more of the following language-specific analyzer plugins: ``analysis-nori`` (Korean), ``analysis-kuromoji`` (Japanese), and ``analysis-smartcn`` (Chinese).
 

--- a/source/administration-guide/scale/opensearch-setup.rst
+++ b/source/administration-guide/scale/opensearch-setup.rst
@@ -105,7 +105,7 @@ We highly recommend that you set up an AWS OpenSearch server on a separate machi
 
       sudo /usr/share/opensearch/bin/opensearch-plugin install analysis-icu
 
-    Restart OpenSearch on each node to load the newly installed plugin before verifying it; ``_cat/plugins`` only reports active plugins, so a restart is required first. For production clusters, restart nodes one at a time (rolling restart) rather than all at once. Confirm the plugin is installed and active on every node before continuing, replacing ``<your-opensearch-host>`` with your cluster endpoint:
+    Restart OpenSearch on each node to load the newly installed plugin before verifying it; ``_cat/plugins`` only reports active plugins, so a restart is required first. For production clusters, restart nodes one at a time (rolling restart) rather than all at once. The OpenSearch Security plugin might need to be set to ``plugins.security.disabled: true`` in ``opensearch.yml`` (disables the auth plugin, for testing) for the following check to run over plain HTTP. Confirm the plugin is installed and active on every node before continuing, replacing ``<your-opensearch-host>`` with your cluster endpoint:
 
     .. code-block:: sh
 


### PR DESCRIPTION
Elasticsearch/Opensearch rejects Mattermost's index template creation without this plugin, so it's a hard requirement rather than a plain setup step. Add a verification command so admins can confirm it's installed on every node before enabling indexing.
