### PR TITLE
Move Mattermost systemd unit file from /lib/systemd/system to /etc/systemd/system

### DIFF
--- a/source/administration-guide/configure/configuration-in-your-database.rst
+++ b/source/administration-guide/configure/configuration-in-your-database.rst
@@ -100,7 +100,7 @@ The second line of output will have the location of the running ``mattermost.ser
 
 .. code-block:: text
 
-      Loaded: loaded (/lib/systemd/system/mattermost.service; enabled; vendor preset: enabled)
+      Loaded: loaded (/etc/systemd/system/mattermost.service; enabled; vendor preset: enabled)
 
 Edit this file as *root* to add the below text just above the line that begins with ``ExecStart``\ :
 

--- a/source/deployment-guide/server/linux/deploy-rhel.rst
+++ b/source/deployment-guide/server/linux/deploy-rhel.rst
@@ -118,9 +118,13 @@ Step 4: Install Mattermost server
 
   .. code-block:: sh
 
-    sudo touch /lib/systemd/system/mattermost.service
+    sudo touch /etc/systemd/system/mattermost.service
 
-7. As root, edit the systemd unit file at ``/lib/systemd/system/mattermost.service`` to add the following lines:
+  .. note::
+
+     Earlier versions of this guide had you create the unit file under ``/lib/systemd/system/``, which is reserved for unit files installed and owned by a package manager.
+
+7. As root, edit the systemd unit file at ``/etc/systemd/system/mattermost.service`` to add the following lines:
 
   .. code-block:: text
 

--- a/source/deployment-guide/server/linux/deploy-tar.rst
+++ b/source/deployment-guide/server/linux/deploy-tar.rst
@@ -112,9 +112,13 @@ Install the Mattermost Server by extracting the tarball, creating users and grou
 
   .. code-block:: sh
 
-    sudo touch /lib/systemd/system/mattermost.service
+    sudo touch /etc/systemd/system/mattermost.service
 
-8. As root, edit the systemd unit file at ``/lib/systemd/system/mattermost.service`` to add the following lines:
+  .. note::
+
+     Earlier versions of this guide had you create the unit file under ``/lib/systemd/system/``, which is reserved for unit files installed and owned by a package manager.
+
+8. As root, edit the systemd unit file at ``/etc/systemd/system/mattermost.service`` to add the following lines:
 
   .. code-block:: text
 

--- a/source/deployment-guide/server/prepare-mattermost-mysql-database.rst
+++ b/source/deployment-guide/server/prepare-mattermost-mysql-database.rst
@@ -201,7 +201,7 @@ The second line of output will have the location of the running ``mattermost.ser
 
 .. code-block:: text
 
-    Loaded: loaded (/lib/systemd/system/mattermost.service; enabled; vendor preset: enabled)
+    Loaded: loaded (/etc/systemd/system/mattermost.service; enabled; vendor preset: enabled)
 
 Edit this file as *root* to add the below text just above the line that begins with ``ExecStart``\ :
 

--- a/source/deployment-guide/server/troubleshooting.rst
+++ b/source/deployment-guide/server/troubleshooting.rst
@@ -12,7 +12,7 @@ To have the Mattermost Server start at system boot, the systemd unit file needs 
 
   sudo systemctl enable mattermost.service
 
-If your database is on the same system as your Mattermost Server, we recommend editing the default ``/lib/systemd/system/mattermost.service`` systemd unit file to add ``After=postgresql.service`` and ``BindsTo=postgresql.service`` to the ``[Unit]`` section.
+If your database is on the same system as your Mattermost Server, we recommend editing the default ``/etc/systemd/system/mattermost.service`` systemd unit file to add ``After=postgresql.service`` and ``BindsTo=postgresql.service`` to the ``[Unit]`` section.
 
 Run Mattermost without a proxy
 ------------------------------

--- a/source/deployment-guide/transport-encryption.rst
+++ b/source/deployment-guide/transport-encryption.rst
@@ -114,7 +114,7 @@ Restart the Mattermost server and ensure it's up and running:
 .. code-block:: text
 
   ● mattermost.service - Mattermost
-     Loaded: loaded (/lib/systemd/system/mattermost.service; static; vendor preset: enabled)
+     Loaded: loaded (/etc/systemd/system/mattermost.service; static; vendor preset: enabled)
      Active: active (running) since Mon 2019-10-28 16:45:29 UTC; 1h 15min ago
      [...]
 
@@ -223,7 +223,7 @@ Once complete, restart the Mattermost server and ensure the system is operationa
 .. code-block:: text
 
   ● mattermost.service - Mattermost
-     Loaded: loaded (/lib/systemd/system/mattermost.service; static; vendor preset: enabled)
+     Loaded: loaded (/etc/systemd/system/mattermost.service; static; vendor preset: enabled)
      Active: active (running) since Fri 2019-10-18 16:47:08 UTC; 3s ago
     Process: 3424 ExecStartPre=/opt/mattermost/bin/pre_start.sh (code=exited, status=0/SUCCESS)
    Main PID: 3443 (mattermost)
@@ -458,7 +458,7 @@ Once each node is configured, restart the service on each cluster and confirm th
 .. code-block:: text
 
   ● mattermost.service - Mattermost
-     Loaded: loaded (/lib/systemd/system/mattermost.service; static; vendor preset: enabled)
+     Loaded: loaded (/etc/systemd/system/mattermost.service; static; vendor preset: enabled)
      Active: active (running) since Fri 2019-10-04 19:44:20 UTC; 5min ago
     Process: 16734 ExecStartPre=/opt/mattermost/bin/pre_start.sh (code=exited, status=0/SUCCESS)
 


### PR DESCRIPTION
## Summary
- `/lib/systemd/system` (aliased to `/usr/lib/systemd/system` on merged-usr systems) is reserved for unit files installed and owned by a package manager. Our tarball and RHEL install guides have the admin create the Mattermost unit file by hand, so `/etc/systemd/system` is the correct location.
- Updates the unit file creation step in the tarball and RHEL install guides, with a note that earlier versions of the guide used `/lib/systemd/system`.
- Updates every downstream reference to the unit file path (troubleshooting guide, transport encryption guide, MySQL/database prep guides) for consistency. Two other pages already referenced `/etc/systemd/system` for this file, so this also removes an existing inconsistency rather than introducing one.