### PR TITLE
fix(docs): update broken message attachments links to current developer docs URL

### DIFF
--- a/source/administration-guide/manage/bulk-export-tool.rst
+++ b/source/administration-guide/manage/bulk-export-tool.rst
@@ -615,7 +615,7 @@ Post object
     <tr class="row-odd">
       <td valign="middle">props</td>
       <td valign="middle">object</td>
-      <td>The props for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://docs.mattermost.com/developer/message-attachments.html">message attachments documentation</a>.</td>
+      <td>The props for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://developers.mattermost.com/integrate/reference/message-attachments/">message attachments documentation</a>.</td>
     </tr>
     <tr class="row-odd">
       <td valign="middle">create_at</td>

--- a/source/administration-guide/onboard/bulk-loading-data.rst
+++ b/source/administration-guide/onboard/bulk-loading-data.rst
@@ -1229,7 +1229,7 @@ Fields of the Post object
     <tr class="row-odd">
       <td valign="middle">props</td>
       <td valign="middle">object</td>
-      <td>The props for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://docs.mattermost.com/developer/message-attachments.html">message attachments documentation</a>.</td>
+      <td>The props for a post. Contains additional formatting information used by integrations and bot posts. For a more detailed explanation see the <a href="https://developers.mattermost.com/integrate/reference/message-attachments/">message attachments documentation</a>.</td>
       <td align="center" valign="middle">Yes</td>
       <td align="center" valign="middle">Yes</td>
     </tr>


### PR DESCRIPTION
## Summary

Two documentation pages linked to `https://docs.mattermost.com/developer/message-attachments.html`, which returns **404** — the message attachments reference now lives on the developer portal at `https://developers.mattermost.com/integrate/reference/message-attachments/` (the URL already used elsewhere in these docs, e.g. `source/end-user-guide/access/client-availability.rst` and `source/integrations-guide/faq.rst`).

## Changes

- `source/administration-guide/manage/bulk-export-tool.rst`: update the message attachments link in the Post object `props` field description.
- `source/administration-guide/onboard/bulk-loading-data.rst`: same fix for the bulk-loading Post object table.

## Verification

- Confirmed `https://docs.mattermost.com/developer/message-attachments.html` returns HTTP 404.
- Confirmed the replacement URL returns HTTP 200.
- Scanned all outbound links in the docs source; these were the only two occurrences of this broken link.