### PR TITLE
Fix incorrect GPO policy name for desktop auto-updater

### DIFF
--- a/source/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.rst
+++ b/source/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.rst
@@ -67,7 +67,7 @@ The following group policies are available supporting a state option of Not Conf
   +--------------------------+------------------------------------------------------------+----------------------+----------------------------+
   | Default Server List      | Define one or more default, permanent servers.             | v4.3 or later        | ``DefaultServerList``      |
   +--------------------------+------------------------------------------------------------+----------------------+----------------------------+
-  | Update Notifications     | If disabled, in-app update notifications are not shown.    | v5.1 or later        | ``EnableAutoUpdates``      |
+  | Update Notifications     | If disabled, in-app update notifications are not shown.    | v5.1 or later        | ``EnableAutoUpdater``      |
   +--------------------------+------------------------------------------------------------+----------------------+----------------------------+
 
 1. Browse to the folder the above files were downloaded to and unzip the ``desktop-6.3.0.zip`` file in place.
@@ -144,7 +144,7 @@ From desktop v6.0, users can run multiple Mattermost workspaces at the same time
 - On Windows, seed the approved list using the ``DefaultServerList`` Group Policy.
 - For scripted installs, seed ``config.json`` on first run to include multiple entries in the ``teams`` array. See the :doc:`Silent Windows desktop distribution </deployment-guide/desktop/silent-windows-desktop-distribution>` documentation for details.
 - To prevent users from adding or removing workspaces, use the existing ``EnableServerManagement`` Group Policy.
-- Disable ``EnableAutoUpdates`` to turn off update notifications.
+- Disable ``EnableAutoUpdater`` to turn off update notifications.
 
 Verify group policy settings have been applied
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/deployment-guide/desktop/desktop-troubleshooting.rst
+++ b/source/deployment-guide/desktop/desktop-troubleshooting.rst
@@ -48,7 +48,7 @@ If you're not seeing in-app update notifications when new versions are available
    - On Windows: Go to **… > File > Settings** and ensure **Automatically check for updates** is enabled.
    - On macOS: Go to **Mattermost > Settings** and ensure **Automatically check for updates** is enabled.
 
-4. **Check Group Policy settings** (Enterprise deployments): Your system administrator may have disabled update notifications via the ``EnableAutoUpdates`` Group Policy. Contact your IT department for clarification.
+4. **Check Group Policy settings** (Enterprise deployments): Your system administrator may have disabled update notifications via the ``EnableAutoUpdater`` Group Policy. Contact your IT department for clarification.
 
 5. **Version previously skipped**: If you selected **Skip This Version** for the current release, manually check for updates to see it again.
 


### PR DESCRIPTION
## Summary
- The Windows GPO/registry value that controls the desktop app's auto-updater is `EnableAutoUpdater` (see `resources/windows/gpo/mattermost.admx` and `policyConfigLoader.ts` in mattermost/desktop), not `EnableAutoUpdates`.
- Fixes the incorrect name in the group policy table and related references.

## Test plan
- [x] Docs-only change; verified no other occurrences of `EnableAutoUpdates` remain in the repo